### PR TITLE
Hotfix - Flujos de trabajo - Evaluar valores vacíos en campos numéricos

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -919,7 +919,7 @@ class AOW_WorkFlow extends Basic
                         break;
                 }
 
-                if (!($this->compare_condition($field, $value, $condition->operator))) {
+                if (!($this->compare_condition($field, $value, $condition->operator, $type))) {
                     return false;
                 }
             }
@@ -950,8 +950,16 @@ class AOW_WorkFlow extends Basic
         return true;
     }
 
-    public function compare_condition($var1, $var2, $operator = 'Equal_To')
+    // STIC Custom 20231228 EPS - numeric null condition does not work properly
+    // STIC#1363
+    // public function compare_condition($var1, $var2, $operator = 'Equal_To')
+    // {
+    public function compare_condition($var1, $var2, $operator = 'Equal_To', $type= '')
     {
+        
+        $numericTypes = array('double','decimal','currency','float','uint','ulong','long','short','tinyint','int');
+    // STIC Custom End
+
         switch ($operator) {
             case "Not_Equal_To": return $var1 != $var2;
             case "Greater_Than":  return $var1 >  $var2;
@@ -961,7 +969,15 @@ class AOW_WorkFlow extends Basic
             case "Contains": return strpos(strtolower($var1), strtolower($var2)) !== false;
             case "Starts_With": return substr(strtolower($var1), 0, strlen($var2) ) === strtolower($var2);
             case "Ends_With": return substr(strtolower($var1), -strlen($var2) ) === strtolower($var2);
-            case "is_null": return $var1 == '';
+            // STIC Custom 20231228 EPS - numeric null condition does not work properly
+            // STIC#1363
+            // case "is_null": return $var1 == '';
+            case "is_null": 
+                if (in_array($type, $numericTypes) && $var1 == 'NULL') {
+                    $var1 = "";
+                }
+                return $var1 == '';
+            // STIC Custom End
             case "One_of":
                 if (is_array($var1)) {
                     foreach ($var1 as $var) {


### PR DESCRIPTION
- Closes #1 

### Descripción
A la hora de evaluar el valor nulo en lasd condiciones de los flujos de trabajo, se ha visto que los campos de tipo texto o fecha se recuperan como "", sin embargo los campos numéricos se estaban seteando a NULL. A la hora de comprobar si un campo era NULL, la condición miraba si el campo estaba como "". Se ha cambiado esta condición para que si el tipo es numérico y tiene valor NULL se altere el valor previo a la condición a "", sin afectar el valor en el resto del código (sólo para la evaluación de la condición), de manera que no haya efectos colaterales.

### Pruebas
1. Crear flujo de trabajo, añadiendo una condición donde se requiera que un importe sea nulo
2. Comprobar que tanto en ejecucion "on save" como en el planificador, se ejecuta el flujo cuando y sólo cuando el campo numérico es NULL.