### PR TITLE
Hotfix - General - Comprobar si las variables están seteadas para evitar aviso de error

### DIFF
--- a/SticInclude/Views.php
+++ b/SticInclude/Views.php
@@ -25,7 +25,7 @@ class SticViews {
         foreach ($view->bean as $key => $value) {
             if (is_string($value)) {
                 // We separate the TextArea fields because they can contain line breaks. These produce an error when encoding them to JSON from PHP and decoding them from javascript. 
-                if ($view->bean->field_name_map[$key]["type"] == 'text') {
+                if (isset($view->bean->field_name_map[$key]["type"]) && $view->bean->field_name_map[$key]["type"] == 'text') {
                     $parsedValuesTextToJS[$key] = $value;
                 } else {
                     $parsedValuesToJS[$key] = $value;

--- a/custom/modules/Accounts/SticLogicHooksCode.php
+++ b/custom/modules/Accounts/SticLogicHooksCode.php
@@ -31,14 +31,14 @@ class AccountsLogicHooks
         // When a new Contact Relationship is added, the Contact is saved and the stic_relationship_type_c field overwritten with the values 
         // added with the SQL
         // Please, delete these lines when the issue is resolved
-        if ($_REQUEST['child_field'] == 'stic_accounts_relationships_accounts') {
+        if (isset($_REQUEST['child_field']) && $_REQUEST['child_field'] == 'stic_accounts_relationships_accounts') {
             include_once 'modules/stic_Accounts_Relationships/Utils.php';
             stic_Accounts_RelationshipsUtils::setRelationshipType($bean->id);
         }
         // End of Patch issue
 
         // Generate automatic Call
-        if ($bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c']) {
+        if (isset($bean->stic_postal_mail_return_reason_c) && ($bean->fetched_row['stic_postal_mail_return_reason_c'] == null || $bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c'])) {
             include_once 'custom/modules/Accounts/SticUtils.php';
             AccountsUtils::generateCallFromReturnMailReason($bean);
         }
@@ -47,7 +47,8 @@ class AccountsLogicHooks
     public function before_save(&$bean, $event, $arguments)
     {
         // Bring Incorpora location data, if there is any
-        if ($bean->fetched_row['stic_incorpora_locations_id_c'] != $bean->stic_incorpora_locations_id_c) {
+        if (isset($bean->fetched_row['stic_incorpora_locations_id_c']) && isset($bean->stic_incorpora_locations_id_c) && 
+            $bean->fetched_row['stic_incorpora_locations_id_c'] != $bean->stic_incorpora_locations_id_c) {
             include_once 'modules/stic_Incorpora_Locations/Utils.php';
             stic_Incorpora_LocationsUtils::transferLocationData($bean);
         }

--- a/custom/modules/Accounts/SticLogicHooksCode.php
+++ b/custom/modules/Accounts/SticLogicHooksCode.php
@@ -38,7 +38,7 @@ class AccountsLogicHooks
         // End of Patch issue
 
         // Generate automatic Call
-        if (isset($bean->stic_postal_mail_return_reason_c) && !empty($bean->stic_postal_mail_return_reason_c) && (is_null($bean->fetched_row['stic_postal_mail_return_reason_c']) || $bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c'])) {
+        if (isset($bean->stic_postal_mail_return_reason_c) && !empty($bean->stic_postal_mail_return_reason_c) && $bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c']) {   
             include_once 'custom/modules/Accounts/SticUtils.php';
             AccountsUtils::generateCallFromReturnMailReason($bean);
         }
@@ -48,8 +48,9 @@ class AccountsLogicHooks
     {
         // Bring Incorpora location data, if there is any
         if (isset($bean->stic_incorpora_locations_id_c) && 
-            (!empty($bean->stic_incorpora_locations_id_c) && is_null($bean->fetched_row['stic_incorpora_locations_id_c']) || 
-             $bean->fetched_row['stic_incorpora_locations_id_c'] != $bean->stic_incorpora_locations_id_c)
+            ( empty($bean->stic_incorpora_locations_id_c) && !is_null($bean->fetched_row['stic_incorpora_locations_id_c']) || 
+              (!empty($bean->stic_incorpora_locations_id_c) && $bean->fetched_row['stic_incorpora_locations_id_c'] != $bean->stic_incorpora_locations_id_c)
+            )
            ) {
             include_once 'modules/stic_Incorpora_Locations/Utils.php';
             stic_Incorpora_LocationsUtils::transferLocationData($bean);

--- a/custom/modules/Accounts/SticLogicHooksCode.php
+++ b/custom/modules/Accounts/SticLogicHooksCode.php
@@ -38,7 +38,7 @@ class AccountsLogicHooks
         // End of Patch issue
 
         // Generate automatic Call
-        if (isset($bean->stic_postal_mail_return_reason_c) && ($bean->fetched_row['stic_postal_mail_return_reason_c'] == null || $bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c'])) {
+        if (isset($bean->stic_postal_mail_return_reason_c) && !empty($bean->stic_postal_mail_return_reason_c) && (is_null($bean->fetched_row['stic_postal_mail_return_reason_c']) || $bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c'])) {
             include_once 'custom/modules/Accounts/SticUtils.php';
             AccountsUtils::generateCallFromReturnMailReason($bean);
         }
@@ -47,8 +47,10 @@ class AccountsLogicHooks
     public function before_save(&$bean, $event, $arguments)
     {
         // Bring Incorpora location data, if there is any
-        if (isset($bean->fetched_row['stic_incorpora_locations_id_c']) && isset($bean->stic_incorpora_locations_id_c) && 
-            $bean->fetched_row['stic_incorpora_locations_id_c'] != $bean->stic_incorpora_locations_id_c) {
+        if (isset($bean->stic_incorpora_locations_id_c) && 
+            (!empty($bean->stic_incorpora_locations_id_c) && is_null($bean->fetched_row['stic_incorpora_locations_id_c']) || 
+             $bean->fetched_row['stic_incorpora_locations_id_c'] != $bean->stic_incorpora_locations_id_c)
+           ) {
             include_once 'modules/stic_Incorpora_Locations/Utils.php';
             stic_Incorpora_LocationsUtils::transferLocationData($bean);
         }

--- a/custom/modules/Contacts/SticLogicHooksCode.php
+++ b/custom/modules/Contacts/SticLogicHooksCode.php
@@ -24,13 +24,13 @@
 class ContactsLogicHooks {
     public function before_save(&$bean, $event, $arguments) {
         // Calculate age
-        if ($bean->birthdate != $bean->fetched_row['birthdate']) {
+        if (isset($bean->birthdate) && isset($bean->fetched_row['birthdate']) && $bean->birthdate != $bean->fetched_row['birthdate']) {
             include_once 'custom/modules/Contacts/SticUtils.php';
             $bean->stic_age_c = ContactsUtils::getAge($bean->birthdate);
         }
 
         // Bring Incorpora location data, if there is any
-        if ($bean->fetched_row['stic_incorpora_locations_id_c'] != $bean->stic_incorpora_locations_id_c) {
+        if (isset($bean->stic_incorpora_locations_id_c) && isset($bean->fetched_row['stic_incorpora_locations_id_c']) && $bean->fetched_row['stic_incorpora_locations_id_c'] != $bean->stic_incorpora_locations_id_c) {
             include_once 'modules/stic_Incorpora_Locations/Utils.php';
             stic_Incorpora_LocationsUtils::transferLocationData($bean);
         }
@@ -49,7 +49,7 @@ class ContactsLogicHooks {
         // End of Patch issue
 
         // Generate automatic Call
-        if ($bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c']) {
+        if (isset($bean->stic_postal_mail_return_reason_c) && ($bean->fetched_row['stic_postal_mail_return_reason_c'] == null || $bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c'])) {        
             include_once 'custom/modules/Contacts/SticUtils.php';
             ContactsUtils::generateCallFromReturnMailReason($bean);
         }

--- a/custom/modules/Contacts/SticLogicHooksCode.php
+++ b/custom/modules/Contacts/SticLogicHooksCode.php
@@ -49,7 +49,7 @@ class ContactsLogicHooks {
         // End of Patch issue
 
         // Generate automatic Call
-        if (isset($bean->stic_postal_mail_return_reason_c) && ($bean->fetched_row['stic_postal_mail_return_reason_c'] == null || $bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c'])) {        
+        if (isset($bean->stic_postal_mail_return_reason_c) && !empty($bean->stic_postal_mail_return_reason_c) && (is_null($bean->fetched_row['stic_postal_mail_return_reason_c']) || $bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c'])) {
             include_once 'custom/modules/Contacts/SticUtils.php';
             ContactsUtils::generateCallFromReturnMailReason($bean);
         }

--- a/custom/modules/Contacts/SticLogicHooksCode.php
+++ b/custom/modules/Contacts/SticLogicHooksCode.php
@@ -30,7 +30,11 @@ class ContactsLogicHooks {
         }
 
         // Bring Incorpora location data, if there is any
-        if (isset($bean->stic_incorpora_locations_id_c) && isset($bean->fetched_row['stic_incorpora_locations_id_c']) && $bean->fetched_row['stic_incorpora_locations_id_c'] != $bean->stic_incorpora_locations_id_c) {
+        if (isset($bean->stic_incorpora_locations_id_c) && 
+            ( empty($bean->stic_incorpora_locations_id_c) && !is_null($bean->fetched_row['stic_incorpora_locations_id_c']) || 
+              (!empty($bean->stic_incorpora_locations_id_c) && $bean->fetched_row['stic_incorpora_locations_id_c'] != $bean->stic_incorpora_locations_id_c)
+            )
+           ) {
             include_once 'modules/stic_Incorpora_Locations/Utils.php';
             stic_Incorpora_LocationsUtils::transferLocationData($bean);
         }
@@ -49,7 +53,7 @@ class ContactsLogicHooks {
         // End of Patch issue
 
         // Generate automatic Call
-        if (isset($bean->stic_postal_mail_return_reason_c) && !empty($bean->stic_postal_mail_return_reason_c) && (is_null($bean->fetched_row['stic_postal_mail_return_reason_c']) || $bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c'])) {
+        if (isset($bean->stic_postal_mail_return_reason_c) && !empty($bean->stic_postal_mail_return_reason_c) && $bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c']) {   
             include_once 'custom/modules/Contacts/SticUtils.php';
             ContactsUtils::generateCallFromReturnMailReason($bean);
         }

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2522,7 +2522,8 @@ class SugarBean
                 // STIC Custom - 20221213 - JCH - Trim name & varchar type values on save when the value is not null
                 // STIC#902
                 // STIC#982
-                if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && !is_null($this->$key)) {
+                // STIC#1289
+                if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && isset($this->$key) && !is_null($this->$key)) {                
                     $this->$key = trim($this->$key);
                 }
                 // END STIC

--- a/include/entryPoint.php
+++ b/include/entryPoint.php
@@ -108,7 +108,7 @@ $skipAntiXSS = false;
 // See if the current module is set as an exception 
 if (isset($GLOBALS['sugar_config']['anti_xss_data_exceptions'])){
     foreach ($GLOBALS['sugar_config']['anti_xss_data_exceptions'] as $key => $xssException) {
-        if (isset($_REQUEST['module']) && isset($xssException['module']) && $xssException['module'] == $_REQUEST['module'] && isset($skipAntiXSS) && $skipAntiXSS !== true ) {
+        if (isset($_REQUEST['module']) && isset($xssException['module']) && $xssException['module'] == $_REQUEST['module'] && $skipAntiXSS !== true ) {
             // Sort config exception array (further than module, may contain other params like action or step)
             ksort($xssException);
             // Create a subarray from $_REQUEST containing the elements with keys defined in the prior exception

--- a/include/entryPoint.php
+++ b/include/entryPoint.php
@@ -102,23 +102,26 @@ clean_special_arguments();
 // While looking for a better way of ensuring both security and functionality, let's manage some exceptions.
 // STIC#633
 // STIC#699
+// STIC#1289
 // clean_incoming_data();
 $skipAntiXSS = false;
 // See if the current module is set as an exception 
-foreach ($GLOBALS['sugar_config']['anti_xss_data_exceptions'] as $key => $xssException) {
-    if ($xssException['module'] == $_REQUEST['module'] && $skipAntiXSS !== true ) {
-        // Sort config exception array (further than module, may contain other params like action or step)
-        ksort($xssException);
-        // Create a subarray from $_REQUEST containing the elements with keys defined in the prior exception
-        $requestFiltered = array_intersect_key($_REQUEST, $xssException);
-        // Sort the new array in order to have its elements in the same order of the config exception array 
-        ksort($requestFiltered);
-        // If both arrays are equal (ie, there is a match not only in module param but in all of them: action, step, etc.)
-        // clean_incoming_data() should be avoided
-        if (join($xssException) == join($requestFiltered)) {
-            $skipAntiXSS = true;
-            break;
-        } 
+if (isset($GLOBALS['sugar_config']['anti_xss_data_exceptions'])){
+    foreach ($GLOBALS['sugar_config']['anti_xss_data_exceptions'] as $key => $xssException) {
+        if (isset($_REQUEST['module']) && isset($xssException['module']) && $xssException['module'] == $_REQUEST['module'] && isset($skipAntiXSS) && $skipAntiXSS !== true ) {
+            // Sort config exception array (further than module, may contain other params like action or step)
+            ksort($xssException);
+            // Create a subarray from $_REQUEST containing the elements with keys defined in the prior exception
+            $requestFiltered = array_intersect_key($_REQUEST, $xssException);
+            // Sort the new array in order to have its elements in the same order of the config exception array 
+            ksort($requestFiltered);
+            // If both arrays are equal (ie, there is a match not only in module param but in all of them: action, step, etc.)
+            // clean_incoming_data() should be avoided
+            if (join($xssException) == join($requestFiltered)) {
+                $skipAntiXSS = true;
+                break;
+            } 
+        }
     }
 }
 

--- a/modules/stic_Incorpora_Locations/Utils.php
+++ b/modules/stic_Incorpora_Locations/Utils.php
@@ -42,11 +42,11 @@ class stic_Incorpora_LocationsUtils {
         $stic_incorpora_locations_id = 'stic_incorpora_locations_id' .$sufix;
 
         $location_bean = BeanFactory::getBean('stic_Incorpora_Locations', $recordBean->$stic_incorpora_locations_id);
-        $recordBean->$inc_town_code = $location_bean->town_code;
-        $recordBean->$inc_town = $location_bean->town;
-        $recordBean->$inc_municipality_code = $location_bean->municipality_code;
-        $recordBean->$inc_municipality = $location_bean->municipality;
-        $recordBean->$inc_state_code = $location_bean->state_code;
-        $recordBean->$inc_state = $location_bean->state;
+        $recordBean->$inc_town_code = $location_bean->town_code ?? '';
+        $recordBean->$inc_town = $location_bean->town ?? '';
+        $recordBean->$inc_municipality_code = $location_bean->municipality_code ?? '';
+        $recordBean->$inc_municipality = $location_bean->municipality ?? '';
+        $recordBean->$inc_state_code = $location_bean->state_code ?? '';
+        $recordBean->$inc_state = $location_bean->state ?? '';
     }
 }

--- a/modules/stic_Payment_Commitments/stic_Payment_Commitments.php
+++ b/modules/stic_Payment_Commitments/stic_Payment_Commitments.php
@@ -87,7 +87,7 @@ class stic_Payment_Commitments extends Basic
         parent::save($check_notify);
         
         // If things are happening in Payments subpanel...
-        if ($_REQUEST['child_field'] == 'stic_payments_stic_payment_commitments') {
+        if (isset($_REQUEST['child_field']) && $_REQUEST['child_field'] == 'stic_payments_stic_payment_commitments') {
             // For multiple payments selection from popup
             if (is_array($_REQUEST['subpanel_id'])) {
                 foreach($_REQUEST['subpanel_id'] as $paymentId) {

--- a/modules/stic_Payments/stic_Payments.php
+++ b/modules/stic_Payments/stic_Payments.php
@@ -138,7 +138,7 @@ class stic_Payments extends Basic
         include_once 'SticInclude/Utils.php';
 
         // If parent payment commitment has changed...
-        if (!empty($this->stic_paymebfe2itments_ida) && (trim($this->stic_paymebfe2itments_ida) != trim($this->rel_fields_before_value['stic_paymebfe2itments_ida']))) {
+        if (!empty($this->stic_paymebfe2itments_ida) && isset($this->rel_fields_before_value['stic_paymebfe2itments_ida']) && (trim($this->stic_paymebfe2itments_ida) != trim($this->rel_fields_before_value['stic_paymebfe2itments_ida']))) {
             // Get new parent payment commitment bean
             $PCBean = BeanFactory::getBean('stic_Payment_Commitments', $this->stic_paymebfe2itments_ida);
             // Get payment commmitment related contact (usual case)


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/12

Tal y como se indica en el issue, este PR mejora las condiciones de varios IF para compruebar si está seteada la variable que ha generado un aviso de error de tipo NOTICE

Además, se detecta que al deseleccionar el registro de localización de incorpora no se anulan los valores relacionados. Aprovechamos el issue para corregir dicha funcionalidad del fichero `modules/stic_Incorpora_Locations/Utils.php`


**Pruebas**

1. Configurar un nivel de error **E_NOTICE**. Para ello accedemos al fichero phpdocker/php-fpm/php-ini-overrides.ini del workkit y configuramos **error_reporting = 22527** en la línea 5.
2. Comprobar que en la página de inicio NO se muestra el error 2 indicado en el issue
3. Comprobar que al acceder al módulo de personas NO aparece el error 3 indicado en el issue
12. Importar un registro en cada uno de los módulos y comprobar que NO aparece ni el error 1 indicado en el issue ni los errores relacionados con el módulo.