### PR TITLE
Hotfix - Validación de datos - Eliminar registros obsoletos de relaciones/campos relacionados

### DIFF
--- a/SticInstall/sql/ca/Schedulers.sql
+++ b/SticInstall/sql/ca/Schedulers.sql
@@ -12,7 +12,8 @@ INSERT INTO schedulers (id, deleted, date_entered, date_modified, created_by, mo
 ('98eb0c26-99dd-d656-ee73-611cc6994570', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Purga de la base de dades', 'function::sticPurgeDatabase', NOW(), NULL, '*::2::*::*::0', NULL, NULL, NULL, 'Active', 0),
 ('4d0ac999-2bcb-cc4f-f65d-6192a21c4aff', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Validació i actualització mensual de dades', 'function::validationActions', NOW(), NULL, '*::3::1::*::*', NULL, NULL, NULL, 'Inactive', 0),
 ('ca564b47-9a06-987d-a115-6442356ca768', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Creació de registres de medicació', 'function::createMedicationLogs', NOW(), NULL, '*::1::*::*::*', NULL, NULL, NULL, 'Active', 0),
-('c5f7d492-5a02-6fe1-1d6e-6540b28a4b21', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Reconstrucció de les fonts de dades de SinergiaDA', 'function::rebuildSDASources', NOW(), NULL, '*::2::*::*::*', NULL, NULL, NULL, 'Active', 0);
+('c5f7d492-5a02-6fe1-1d6e-6540b28a4b21', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Reconstrucció de les fonts de dades de SinergiaDA', 'function::rebuildSDASources', NOW(), NULL, '*::2::*::*::*', NULL, NULL, NULL, 'Active', 0),
+('4d0ac999-2bcb-cc4f-f65d-6192a21c4aff', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Validació i actualització mensual de dades', 'function::validationActions', NOW(), NULL, '*::3::1::*::*', NULL, NULL, NULL, 'Active', 0);
 
 INSERT INTO stic_validation_actions (id, name, date_entered, date_modified, modified_user_id, created_by, description, deleted, assigned_user_id, last_execution, `function`, report_always, priority) VALUES
 ('0b5b5d41-ae84-11eb-9b56-0242ac180004', 'Compromisos de pagament - Càlcul de registre actiu/inactiu', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '0b5b5d41-ae84-11eb-9b56-0242ac180004', 0, 30),
@@ -38,8 +39,9 @@ INSERT INTO stic_validation_actions (id, name, date_entered, date_modified, modi
 ('430a2764-5e4d-4a54-835c-0a1896ad2fc0', 'Relacions amb Persones - Revisió de les relacions', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '430a2764-5e4d-4a54-835c-0a1896ad2fc0', 0, 70),
 ('375431dc-a6bb-4c0b-ab4c-af1a06229ee4', 'Remeses - Revisió de les dades principals',NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '375431dc-a6bb-4c0b-ab4c-af1a06229ee4', 0, 25),
 ('b07eefb3-20fb-4993-abea-66ce0aa71649', 'Remeses - Revisió de les relacions', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'b07eefb3-20fb-4993-abea-66ce0aa71649', 0, 20),
-('10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'Unitats familiars - Càlcul de registre actiu/inactiu', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 0, 30);
-('b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'Ajuts - Càlcul de registre actiu/inactiu', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 0, 30);
+('10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'Unitats familiars - Càlcul de registre actiu/inactiu', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 0, 30),
+('b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'Ajuts - Càlcul de registre actiu/inactiu', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 0, 30),
+('ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 'General - Eliminació de les relacions obsoletes', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 0, 50);
 
 INSERT INTO stic_validation_actions_schedulers_c (id, date_modified, deleted, stic_validation_actions_schedulersstic_validation_actions_ida, stic_validation_actions_schedulersschedulers_idb) VALUES
 ('16085edd-15a4-e6df-c869-5b406a4611ed', NOW(), 0, 'f512af92-7518-4bbe-b583-5b43bc6223da', '7386c4b1-bcc2-4f6f-be88-7e2a2e5778b5'),
@@ -65,5 +67,6 @@ INSERT INTO stic_validation_actions_schedulers_c (id, date_modified, deleted, st
 ('529f2cd9-b277-11eb-b5ab-0242ac1e0002', NOW(), 0, '8cd4b3ba-b273-11eb-b5ab-0242ac1e0002', 'b05bde8a-1309-4789-993b-bf85be389f07'),
 ('583981c3-b277-11eb-b5ab-0242ac1e0002', NOW(), 0, '23d660da-b276-11eb-b5ab-0242ac1e0002', 'b05bde8a-1309-4789-993b-bf85be389f07'),
 ('6f82c1d8-d481-09b5-9bfb-618955029780', NOW(), 0, 'ac28533e-40ad-11ec-b2f2-0242ac150002', 'b05bde8a-1309-4789-993b-bf85be389f07'),
-('d0d59fed-6419-a8eb-a7e2-636b906e5f36', NOW(), 0, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'b05bde8a-1309-4789-993b-bf85be389f07');
-('d0d59ped-6cd9-areb-a77a-6361606e5f36', NOW(), 0, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'b05bde8a-1309-4789-993b-bf85be389f07');
+('d0d59fed-6419-a8eb-a7e2-636b906e5f36', NOW(), 0, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'b05bde8a-1309-4789-993b-bf85be389f07'),
+('d0d59ped-6cd9-areb-a77a-6361606e5f36', NOW(), 0, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'b05bde8a-1309-4789-993b-bf85be389f07'),
+('73031c41-d137-fd92-e776-6193c94ffaa8', NOW(), 0, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', '4d0ac999-2bcb-cc4f-f65d-6192a21c4aff');

--- a/SticInstall/sql/en/Schedulers.sql
+++ b/SticInstall/sql/en/Schedulers.sql
@@ -12,7 +12,8 @@ INSERT INTO schedulers (id, deleted, date_entered, date_modified, created_by, mo
 ('98eb0c26-99dd-d656-ee73-611cc6994570', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Purge database', 'function::sticPurgeDatabase', NOW(), NULL, '*::2::*::*::0', NULL, NULL, NULL, 'Active', 0),
 ('4d0ac999-2bcb-cc4f-f65d-6192a21c4aff', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Monthly data validation and updating', 'function::validationActions', NOW(), NULL, '*::3::1::*::*', NULL, NULL, NULL, 'Inactive', 0),
 ('ca564b47-9a06-987d-a115-6442356ca768', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Create medication logs', 'function::createMedicationLogs', NOW(), NULL, '*::1::*::*::*', NULL, NULL, NULL, 'Active', 0),
-('c5f7d492-5a02-6fe1-1d6e-6540b28a4b21', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Rebuild SinergiaDA data sources', 'function::rebuildSDASources', NOW(), NULL, '*::2::*::*::*', NULL, NULL, NULL, 'Active', 0);
+('c5f7d492-5a02-6fe1-1d6e-6540b28a4b21', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Rebuild SinergiaDA data sources', 'function::rebuildSDASources', NOW(), NULL, '*::2::*::*::*', NULL, NULL, NULL, 'Active', 0),
+('4d0ac999-2bcb-cc4f-f65d-6192a21c4aff', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Monthly data validation and updating', 'function::validationActions', NOW(), NULL, '*::3::1::*::*', NULL, NULL, NULL, 'Active', 0);
 
 INSERT INTO stic_validation_actions (id, name, date_entered, date_modified, modified_user_id, created_by, description, deleted, assigned_user_id, last_execution, `function`, report_always, priority) VALUES
 ('d1d60459-3713-488d-94ce-ff38bf3e1f98', 'Accounts - Main data validation', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'd1d60459-3713-488d-94ce-ff38bf3e1f98', 0, 65),
@@ -38,8 +39,9 @@ INSERT INTO stic_validation_actions (id, name, date_entered, date_modified, modi
 ('88aa01ca-94a1-4313-a24e-a0a637dcf029', 'Registrations - Relationships validation', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '88aa01ca-94a1-4313-a24e-a0a637dcf029', 0, 10),
 ('375431dc-a6bb-4c0b-ab4c-af1a06229ee4', 'Remittances - Main data validation', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '375431dc-a6bb-4c0b-ab4c-af1a06229ee4', 0, 25),
 ('b07eefb3-20fb-4993-abea-66ce0aa71649', 'Remittances - Relationships validation', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'b07eefb3-20fb-4993-abea-66ce0aa71649', 0, 20),
-('10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'Families - Set active/inactive records', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 0, 30);
-('b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'Grants - Set active/inactive records', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 0, 30);
+('10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'Families - Set active/inactive records', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 0, 30),
+('b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'Grants - Set active/inactive records', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 0, 30),
+('ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 'General - Delete outdated relationships', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 0, 50);
 
 INSERT INTO stic_validation_actions_schedulers_c (id, date_modified, deleted, stic_validation_actions_schedulersstic_validation_actions_ida, stic_validation_actions_schedulersschedulers_idb) VALUES
 ('16085edd-15a4-e6df-c869-5b406a4611ed', NOW(), 0, 'f512af92-7518-4bbe-b583-5b43bc6223da', '7386c4b1-bcc2-4f6f-be88-7e2a2e5778b5'),
@@ -65,6 +67,7 @@ INSERT INTO stic_validation_actions_schedulers_c (id, date_modified, deleted, st
 ('529f2cd9-b277-11eb-b5ab-0242ac1e0002', NOW(), 0, '8cd4b3ba-b273-11eb-b5ab-0242ac1e0002', 'b05bde8a-1309-4789-993b-bf85be389f07'),
 ('583981c3-b277-11eb-b5ab-0242ac1e0002', NOW(), 0, '23d660da-b276-11eb-b5ab-0242ac1e0002', 'b05bde8a-1309-4789-993b-bf85be389f07'),
 ('6f82c1d8-d481-09b5-9bfb-618955029780', NOW(), 0, 'ac28533e-40ad-11ec-b2f2-0242ac150002', 'b05bde8a-1309-4789-993b-bf85be389f07'),
-('d0d59fed-6419-a8eb-a7e2-636b906e5f36', NOW(), 0, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'b05bde8a-1309-4789-993b-bf85be389f07');
-('d0d59ped-6cd9-areb-a77a-6361606e5f36', NOW(), 0, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'b05bde8a-1309-4789-993b-bf85be389f07');
+('d0d59fed-6419-a8eb-a7e2-636b906e5f36', NOW(), 0, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'b05bde8a-1309-4789-993b-bf85be389f07'),
+('d0d59ped-6cd9-areb-a77a-6361606e5f36', NOW(), 0, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'b05bde8a-1309-4789-993b-bf85be389f07'),
+('73031c41-d137-fd92-e776-6193c94ffaa8', NOW(), 0, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', '4d0ac999-2bcb-cc4f-f65d-6192a21c4aff');
 

--- a/SticInstall/sql/es/Schedulers.sql
+++ b/SticInstall/sql/es/Schedulers.sql
@@ -12,7 +12,8 @@ INSERT INTO schedulers (id, deleted, date_entered, date_modified, created_by, mo
 ('98eb0c26-99dd-d656-ee73-611cc6994570', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Purga de la base de datos', 'function::sticPurgeDatabase', NOW(), NULL, '*::2::*::*::0', NULL, NULL, NULL, 'Active', 0),
 ('4d0ac999-2bcb-cc4f-f65d-6192a21c4aff', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Validación y actualización mensual de datos', 'function::validationActions', NOW(), NULL, '*::3::1::*::*', NULL, NULL, NULL, 'Inactive', 0),
 ('ca564b47-9a06-987d-a115-6442356ca768', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Creación de registros de medicación', 'function::createMedicationLogs', NOW(), NULL, '*::1::*::*::*', NULL, NULL, NULL, 'Active', 0),
-('c5f7d492-5a02-6fe1-1d6e-6540b28a4b21', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Reconstrucción de los orígenes de datos de SinergiaDA', 'function::rebuildSDASources', NOW(), NULL, '*::2::*::*::*', NULL, NULL, NULL, 'Active', 0);
+('c5f7d492-5a02-6fe1-1d6e-6540b28a4b21', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Reconstrucción de los orígenes de datos de SinergiaDA', 'function::rebuildSDASources', NOW(), NULL, '*::2::*::*::*', NULL, NULL, NULL, 'Active', 0),
+('4d0ac999-2bcb-cc4f-f65d-6192a21c4aff', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Validación y actualización mensual de datos', 'function::validationActions', NOW(), NULL, '*::3::1::*::*', NULL, NULL, NULL, 'Active', 0);
 
 INSERT INTO stic_validation_actions (id, name, date_entered, date_modified, modified_user_id, created_by, description, deleted, assigned_user_id, last_execution, `function`, report_always, priority) VALUES
 ('0b5b5d41-ae84-11eb-9b56-0242ac180004', 'Compromisos de pago - Cálculo de registro activo/inactivo', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '0b5b5d41-ae84-11eb-9b56-0242ac180004', 0, 30),
@@ -38,8 +39,9 @@ INSERT INTO stic_validation_actions (id, name, date_entered, date_modified, modi
 ('d49627f2-3623-44e3-bdb2-d5af0f8c5165', 'Relaciones con Personas - Revisión de los datos principales', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'd49627f2-3623-44e3-bdb2-d5af0f8c5165', 0, 75),
 ('b07eefb3-20fb-4993-abea-66ce0aa71649', 'Remesas - Revisión de las relaciones', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'b07eefb3-20fb-4993-abea-66ce0aa71649', 0, 20),
 ('375431dc-a6bb-4c0b-ab4c-af1a06229ee4', 'Remesas - Revisión de los datos principales', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '375431dc-a6bb-4c0b-ab4c-af1a06229ee4', 0, 25),
-('10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'Unidades familiares - Cálculo de registro activo/inactivo', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 0, 30);
-('b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'Ayudas - Cálculo de registro activo/inactivo', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 0, 30);
+('10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'Unidades familiares - Cálculo de registro activo/inactivo', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 0, 30),
+('b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'Ayudas - Cálculo de registro activo/inactivo', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 0, 30),
+('ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 'General - Eliminación de relaciones obsoletas', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 0, 50);
 
 INSERT INTO stic_validation_actions_schedulers_c (id, date_modified, deleted, stic_validation_actions_schedulersstic_validation_actions_ida, stic_validation_actions_schedulersschedulers_idb) VALUES
 ('16085edd-15a4-e6df-c869-5b406a4611ed', NOW(), 0, 'f512af92-7518-4bbe-b583-5b43bc6223da', '7386c4b1-bcc2-4f6f-be88-7e2a2e5778b5'),
@@ -65,5 +67,6 @@ INSERT INTO stic_validation_actions_schedulers_c (id, date_modified, deleted, st
 ('529f2cd9-b277-11eb-b5ab-0242ac1e0002', NOW(), 0, '8cd4b3ba-b273-11eb-b5ab-0242ac1e0002', 'b05bde8a-1309-4789-993b-bf85be389f07'),
 ('583981c3-b277-11eb-b5ab-0242ac1e0002', NOW(), 0, '23d660da-b276-11eb-b5ab-0242ac1e0002', 'b05bde8a-1309-4789-993b-bf85be389f07'),
 ('6f82c1d8-d481-09b5-9bfb-618955029780', NOW(), 0, 'ac28533e-40ad-11ec-b2f2-0242ac150002', 'b05bde8a-1309-4789-993b-bf85be389f07'),
-('d0d59fed-6419-a8eb-a7e2-636b906e5f36', NOW(), 0, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'b05bde8a-1309-4789-993b-bf85be389f07');
-('d0d59ped-6cd9-areb-a77a-6361606e5f36', NOW(), 0, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'b05bde8a-1309-4789-993b-bf85be389f07');
+('d0d59fed-6419-a8eb-a7e2-636b906e5f36', NOW(), 0, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'b05bde8a-1309-4789-993b-bf85be389f07'),
+('d0d59ped-6cd9-areb-a77a-6361606e5f36', NOW(), 0, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'b05bde8a-1309-4789-993b-bf85be389f07'),
+('73031c41-d137-fd92-e776-6193c94ffaa8', NOW(), 0, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', '4d0ac999-2bcb-cc4f-f65d-6192a21c4aff');

--- a/SticInstall/sql/gl/Schedulers.sql
+++ b/SticInstall/sql/gl/Schedulers.sql
@@ -12,7 +12,8 @@ INSERT INTO schedulers (id, deleted, date_entered, date_modified, created_by, mo
 ('98eb0c26-99dd-d656-ee73-611cc6994570', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Purga da base de datos', 'function::sticPurgeDatabase', NOW(), NULL, '*::2::*::*::0', NULL, NULL, NULL, 'Active', 0),
 ('4d0ac999-2bcb-cc4f-f65d-6192a21c4aff', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Validación e actualización mensual de datos', 'function::validationActions', NOW(), NULL, '*::3::1::*::*', NULL, NULL, NULL, 'Inactive', 0),
 ('ca564b47-9a06-987d-a115-6442356ca768', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Xeración de rexistros de medicamentos', 'function::createMedicationLogs', NOW(), NULL, '*::1::*::*::*', NULL, NULL, NULL, 'Active', 0),
-('c5f7d492-5a02-6fe1-1d6e-6540b28a4b21', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Reconstrución das fontes de datos de SinergiaDA', 'function::rebuildSDASources', NOW(), NULL, '*::2::*::*::*', NULL, NULL, NULL, 'Active', 0);
+('c5f7d492-5a02-6fe1-1d6e-6540b28a4b21', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Reconstrución das fontes de datos de SinergiaDA', 'function::rebuildSDASources', NOW(), NULL, '*::2::*::*::*', NULL, NULL, NULL, 'Active', 0),
+('4d0ac999-2bcb-cc4f-f65d-6192a21c4aff', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Validación e actualización mensual de datos', 'function::validationActions', NOW(), NULL, '*::3::1::*::*', NULL, NULL, NULL, 'Active', 0);
 
 INSERT INTO stic_validation_actions (id, name, date_entered, date_modified, modified_user_id, created_by, description, deleted, assigned_user_id, last_execution, `function`, report_always, priority) VALUES
 ('0b5b5d41-ae84-11eb-9b56-0242ac180004', 'Compromisos de pago - Cálculo de rexistro activo/inactivo', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '0b5b5d41-ae84-11eb-9b56-0242ac180004', 0, 30),
@@ -38,8 +39,9 @@ INSERT INTO stic_validation_actions (id, name, date_entered, date_modified, modi
 ('d49627f2-3623-44e3-bdb2-d5af0f8c5165', 'Relacións con Persoas - Revisión dos datos principais', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'd49627f2-3623-44e3-bdb2-d5af0f8c5165', 0, 75),
 ('b07eefb3-20fb-4993-abea-66ce0aa71649', 'Remesas - Revisión das relacións', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'b07eefb3-20fb-4993-abea-66ce0aa71649', 0, 20),
 ('375431dc-a6bb-4c0b-ab4c-af1a06229ee4', 'Remesas - Revisión dos datos principais', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '375431dc-a6bb-4c0b-ab4c-af1a06229ee4', 0, 25),
-('10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'Unidades familiares - Cálculo de rexistro activo/inactivo', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 0, 30);
-('b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'Ayudas - Cálculo de rexistro activo/inactivo', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 0, 30);
+('10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'Unidades familiares - Cálculo de rexistro activo/inactivo', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 0, 30),
+('b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'Ayudas - Cálculo de rexistro activo/inactivo', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 0, 30),
+('ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 'Xeral - Eliminación de las relaciones obsoletas', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 0, 50);
 
 INSERT INTO stic_validation_actions_schedulers_c (id, date_modified, deleted, stic_validation_actions_schedulersstic_validation_actions_ida, stic_validation_actions_schedulersschedulers_idb) VALUES
 ('16085edd-15a4-e6df-c869-5b406a4611ed', NOW(), 0, 'f512af92-7518-4bbe-b583-5b43bc6223da', '7386c4b1-bcc2-4f6f-be88-7e2a2e5778b5'),
@@ -65,5 +67,6 @@ INSERT INTO stic_validation_actions_schedulers_c (id, date_modified, deleted, st
 ('529f2cd9-b277-11eb-b5ab-0242ac1e0002', NOW(), 0, '8cd4b3ba-b273-11eb-b5ab-0242ac1e0002', 'b05bde8a-1309-4789-993b-bf85be389f07'),
 ('583981c3-b277-11eb-b5ab-0242ac1e0002', NOW(), 0, '23d660da-b276-11eb-b5ab-0242ac1e0002', 'b05bde8a-1309-4789-993b-bf85be389f07'),
 ('6f82c1d8-d481-09b5-9bfb-618955029780', NOW(), 0, 'ac28533e-40ad-11ec-b2f2-0242ac150002', 'b05bde8a-1309-4789-993b-bf85be389f07'),
-('d0d59fed-6419-a8eb-a7e2-636b906e5f36', NOW(), 0, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'b05bde8a-1309-4789-993b-bf85be389f07');
-('d0d59ped-6cd9-areb-a77a-6361606e5f36', NOW(), 0, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'b05bde8a-1309-4789-993b-bf85be389f07');
+('d0d59fed-6419-a8eb-a7e2-636b906e5f36', NOW(), 0, '10fff3d4-5dc5-ef7a-3d7f-636bae661c14', 'b05bde8a-1309-4789-993b-bf85be389f07'),
+('d0d59ped-6cd9-areb-a77a-6361606e5f36', NOW(), 0, 'b53a08c5-23dc-96b7-2b31-6582cf7dbebc', 'b05bde8a-1309-4789-993b-bf85be389f07'),
+('73031c41-d137-fd92-e776-6193c94ffaa8', NOW(), 0, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', '4d0ac999-2bcb-cc4f-f65d-6192a21c4aff');

--- a/SticUpdates/Migrations/ca/20221214_CrearAccionEliminarRelacionesInoperativas.sql
+++ b/SticUpdates/Migrations/ca/20221214_CrearAccionEliminarRelacionesInoperativas.sql
@@ -1,0 +1,16 @@
+-- Eliminamos antes de insertar para evitar problemas de IDs duplicados en caso de que haya que relanzar el script de actualización
+DELETE FROM schedulers WHERE id='4d0ac999-2bcb-cc4f-f65d-6192a21c4aff';
+DELETE FROM stic_validation_actions WHERE id='ef33e1ee-1d8e-e054-0d6d-6193c473d5b9';
+DELETE FROM stic_validation_actions_schedulers_c WHERE stic_validation_actions_schedulersstic_validation_actions_ida ='ef33e1ee-1d8e-e054-0d6d-6193c473d5b9';
+
+
+-- Insertamos la tarea planificada SinergiaCRM - Validació i actualització diària de dades
+INSERT INTO `schedulers` (`id`, `deleted`, `date_entered`, `date_modified`, `created_by`, `modified_user_id`, `name`, `job`, `date_time_start`, `date_time_end`, `job_interval`, `time_from`, `time_to`, `last_run`, `status`, `catch_up`) VALUES ('4d0ac999-2bcb-cc4f-f65d-6192a21c4aff', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Validació i actualització mensual de dades', 'function::validationActions', NOW(), NULL, '*::3::1::*::*', NULL, NULL, NULL, 'Active', 0);
+
+-- Insertamos la acción de validación SinergiaCRM - Eliminar relacions inoperatives
+INSERT INTO stic_validation_actions (id, name, date_entered, date_modified, modified_user_id, created_by, description, deleted, assigned_user_id, last_execution, `function`, report_always, priority) VALUES
+('ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 'General - Eliminació de les relacions obsoletes', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 0, 50);
+
+-- Insertamos la relación entre la tarea y la acción de validación
+INSERT INTO stic_validation_actions_schedulers_c (id, date_modified, deleted, stic_validation_actions_schedulersstic_validation_actions_ida, stic_validation_actions_schedulersschedulers_idb) VALUES
+('73031c41-d137-fd92-e776-6193c94ffaa8', NOW(), 0, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', '4d0ac999-2bcb-cc4f-f65d-6192a21c4aff');

--- a/SticUpdates/Migrations/es/20221214_CrearAccionEliminarRelacionesInoperativas.sql
+++ b/SticUpdates/Migrations/es/20221214_CrearAccionEliminarRelacionesInoperativas.sql
@@ -1,0 +1,16 @@
+-- Eliminamos antes de insertar para evitar problemas de IDs duplicados en caso de que haya que relanzar el script de actualización
+DELETE FROM schedulers WHERE id='4d0ac999-2bcb-cc4f-f65d-6192a21c4aff';
+DELETE FROM stic_validation_actions WHERE id='ef33e1ee-1d8e-e054-0d6d-6193c473d5b9';
+DELETE FROM stic_validation_actions_schedulers_c WHERE stic_validation_actions_schedulersstic_validation_actions_ida ='ef33e1ee-1d8e-e054-0d6d-6193c473d5b9';
+
+
+-- Insertamos la tarea planificada SinergiaCRM - Validación y actualización diaria de datos
+INSERT INTO `schedulers` (`id`, `deleted`, `date_entered`, `date_modified`, `created_by`, `modified_user_id`, `name`, `job`, `date_time_start`, `date_time_end`, `job_interval`, `time_from`, `time_to`, `last_run`, `status`, `catch_up`) VALUES ('4d0ac999-2bcb-cc4f-f65d-6192a21c4aff', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Validación y actualización mensual de datos', 'function::validationActions', NOW(), NULL, '*::3::1::*::*', NULL, NULL, NULL, 'Active', 0);
+
+-- Insertamos la acción de validación SinergiaCRM - Eliminar relaciones inoperativas
+INSERT INTO stic_validation_actions (id, name, date_entered, date_modified, modified_user_id, created_by, description, deleted, assigned_user_id, last_execution, `function`, report_always, priority) VALUES
+('ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 'General - Eliminación de las relaciones obsoletas', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 0, 50);
+
+-- Insertamos la relación entre la tarea y la acción de validación
+INSERT INTO stic_validation_actions_schedulers_c (id, date_modified, deleted, stic_validation_actions_schedulersstic_validation_actions_ida, stic_validation_actions_schedulersschedulers_idb) VALUES
+('73031c41-d137-fd92-e776-6193c94ffaa8', NOW(), 0, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', '4d0ac999-2bcb-cc4f-f65d-6192a21c4aff');

--- a/SticUpdates/Migrations/gl/20221214_CrearAccionEliminarRelacionesInoperativas.sql
+++ b/SticUpdates/Migrations/gl/20221214_CrearAccionEliminarRelacionesInoperativas.sql
@@ -1,0 +1,16 @@
+-- Eliminamos antes de insertar para evitar problemas de IDs duplicados en caso de que haya que relanzar el script de actualización
+DELETE FROM schedulers WHERE id='4d0ac999-2bcb-cc4f-f65d-6192a21c4aff';
+DELETE FROM stic_validation_actions WHERE id='ef33e1ee-1d8e-e054-0d6d-6193c473d5b9';
+DELETE FROM stic_validation_actions_schedulers_c WHERE stic_validation_actions_schedulersstic_validation_actions_ida ='ef33e1ee-1d8e-e054-0d6d-6193c473d5b9';
+
+
+-- Insertamos la tarea planificada SinergiaCRM - Validación y actualización diaria de datos
+INSERT INTO `schedulers` (`id`, `deleted`, `date_entered`, `date_modified`, `created_by`, `modified_user_id`, `name`, `job`, `date_time_start`, `date_time_end`, `job_interval`, `time_from`, `time_to`, `last_run`, `status`, `catch_up`) VALUES ('4d0ac999-2bcb-cc4f-f65d-6192a21c4aff', 0, NOW(), NOW(), '1', '1', 'SinergiaCRM - Validación e actualización mensual de datos', 'function::validationActions', NOW(), NULL, '*::3::1::*::*', NULL, NULL, NULL, 'Active', 0);
+
+-- Insertamos la acción de validación SinergiaCRM - Eliminar relaciones inoperativas
+INSERT INTO stic_validation_actions (id, name, date_entered, date_modified, modified_user_id, created_by, description, deleted, assigned_user_id, last_execution, `function`, report_always, priority) VALUES
+('ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 'Xeral - Eliminación de las relaciones obsoletas', NOW(), NOW(), '1', '1', NULL, 0, '1', NULL, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', 0, 50);
+
+-- Insertamos la relación entre la tarea y la acción de validación
+INSERT INTO stic_validation_actions_schedulers_c (id, date_modified, deleted, stic_validation_actions_schedulersstic_validation_actions_ida, stic_validation_actions_schedulersschedulers_idb) VALUES
+('73031c41-d137-fd92-e776-6193c94ffaa8', NOW(), 0, 'ef33e1ee-1d8e-e054-0d6d-6193c473d5b9', '4d0ac999-2bcb-cc4f-f65d-6192a21c4aff');

--- a/modules/stic_Validation_Actions/DataAnalyzer/Functions/General_DeleteInactiveRelations/DeleteInactiveRelations.php
+++ b/modules/stic_Validation_Actions/DataAnalyzer/Functions/General_DeleteInactiveRelations/DeleteInactiveRelations.php
@@ -54,9 +54,11 @@ class DeleteInactiveRelations extends DataCheckFunction {
         - 2nd: deleteInactiveParentIdFields()
         - 3rd: deleteInactiveRelateFields() 
         */
+        $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ": --- START Delete Inactive Relations ---\n");        
         $this->deleteInactiveRelationshipsWithoutParentId();
         $this->deleteInactiveParentIdFields();
         $this->deleteInactiveRelateFields();
+        $GLOBALS['log']->stic('\nLine ' . __LINE__ . ': ' . __METHOD__ . ": --- END Delete Inactive Relations ---");
 
         return true;
     }
@@ -257,16 +259,16 @@ class DeleteInactiveRelations extends DataCheckFunction {
     {
         if($resultUpdate){
             if ($affectedRows > 0) {
-                $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ': Deleted outdated records: ');                                
-                $GLOBALS['log']->error('- Relationship:' . $relationship);                                
-                $GLOBALS['log']->error('- ' . $affectedRows . ' records have been updated in the table ' . $updateTable);                
-                $GLOBALS['log']->error('- Executed query: ' . $queryUpdate); 
+                $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': Deleted outdated records: ');                                
+                $GLOBALS['log']->stic('- Relationship:' . $relationship);                                
+                $GLOBALS['log']->stic('- ' . $affectedRows . ' records have been updated in the table ' . $updateTable);                
+                $GLOBALS['log']->stic('- Executed query: ' . $queryUpdate); 
             }
         } else {
             if($updateField){
-                $GLOBALS['log']->info('Line ' . __LINE__ . ': ' . __METHOD__ . ': Error updating the ' . $updateField . ' field in the table: ' . $updateTable);                
+                $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': Error updating the ' . $updateField . ' field in the table: ' . $updateTable);                
             } else {
-                $GLOBALS['log']->info('Line ' . __LINE__ . ': ' . __METHOD__ . ': Error updating the relationship ' . $relationship);                
+                $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': Error updating the relationship ' . $relationship);                
             }             
         }
     }


### PR DESCRIPTION
- Closes #19

Este PR soluciona la incidencia que tuvimos el pasado 1 de octubre cuando, tras ser desplegada, la acción de validación _General - Eliminación de relaciones obsoletas_ eliminó  información que no tenía que haber sido eliminada. En algunos casos se establecía el valor deleted = 1 en el registro y en otros se eliminaba el contenido de los campos relacionados, según las dos formas de actuar previstas en la tarea. Además, como la tarea no actualizaba la fecha de modificación, algunos de los registros marcados con deleted = 1 fueron eliminados completamente de las BBDD por parte de la tarea de purga de datos (registros con fecha de modificación > 90 días y deleted = 1). 

En esta [carpeta del drive](https://drive.google.com/drive/folders/1RMRjdZm7CvNXVw8hE84Adm72xAGYdaPB) tenemos el análisis y las diferentes acciones que hicimos para recuperar la información. 

Sintetizando, los casos detectados tienen relación con registros que guardan información de: 
- Relaciones flex relate 
- Campos flex relate



Además, con este PR:
- Se actualiza la fecha de modificación y se indicará el usuario de _sinergiacrm_ en modified_by de aquellos registros que se modifiquen. 
- Se procede a eliminar y a crear de nuevo la tarea programada, la acción de validación y su relación ya que la tarea _SinergiaCRM - Validación y actualización mensual de datos_ solo contiene la acción de validación _Eliminar relaciones obsoletas_. 
- Se usará el log de stic.
- Que se ejecute después de la tarea de purgar base de datos. 
   - La tarea que purga la base de datos está configurada para que se ejecute cada domingo a las 2 de la madrugada. 
   - La tarea de validación mensual, que contiene a la acción de validación de _Eliminar relaciones obsoletas_ se ejecuta el día 1 de cada mes a las 3 de la madrugada
   - En la incidencia que tuvimos, la acción de validación de _Eliminar relaciones obsoletas_ se ejecutó el sábado 1 de octubre y la tarea de _Purge database_ el domingo 2 de octubre. Es decir, que se ejecuten en determinado orden por ahora depende de la casuística.. Y la única forma que se me ocurre de  conseguir que se ejecute primero la tarea de purgar la base de datos es que ambas acciones se ejecuten dentro de la misma tarea planificada. 
 


