### PR TITLE
Enhancement - Formularios web - Plantilla personalizada de email para usuario asignado

### DIFF
--- a/modules/stic_Web_Forms/Catcher/Donation/DonationController.php
+++ b/modules/stic_Web_Forms/Catcher/Donation/DonationController.php
@@ -117,10 +117,14 @@ class DonationController extends WebFormDataController
             $payment = $this->fp->getResponseData();
 
             // If the shipment has not gone ok it generates a trace
-            if (!$mailer->sendAdminMail($objWeb, $payment, $this->bo->getFormParams(), $donator, $candidates, $donatorResult)) {
-                $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Unable to send the email to the administrator.");
+            if (!$mailer->sendAdminMail($objWeb, $payment, $this->bo->getFormParams(), $donator, $candidates, $donatorResult)) {    
+                // STIC 20240108 - ART - Enable custom email template for assigned user
+                // STIC#1224
+                if(empty($_REQUEST['custom_assigned_email_template'])) {
+                    // End STIC 20240108
+                    $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Unable to send the email to the administrator.");
+                }
             }
-
             // If we are in an advanced version of the form send the notice to the user
             if ($this->version > 1) {
                 $defParams = $this->bo->getDefParams();

--- a/modules/stic_Web_Forms/Catcher/Donation/DonationController.php
+++ b/modules/stic_Web_Forms/Catcher/Donation/DonationController.php
@@ -118,12 +118,7 @@ class DonationController extends WebFormDataController
 
             // If the shipment has not gone ok it generates a trace
             if (!$mailer->sendAdminMail($objWeb, $payment, $this->bo->getFormParams(), $donator, $candidates, $donatorResult)) {    
-                // STIC 20240108 - ART - Enable custom email template for assigned user
-                // STIC#1224
-                if(empty($_REQUEST['custom_assigned_email_template'])) {
-                    // End STIC 20240108
-                    $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Unable to send the email to the administrator.");
-                }
+                $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Unable to send the email to the administrator.");
             }
             // If we are in an advanced version of the form send the notice to the user
             if ($this->version > 1) {

--- a/modules/stic_Web_Forms/Catcher/Donation/DonationController.php
+++ b/modules/stic_Web_Forms/Catcher/Donation/DonationController.php
@@ -117,9 +117,10 @@ class DonationController extends WebFormDataController
             $payment = $this->fp->getResponseData();
 
             // If the shipment has not gone ok it generates a trace
-            if (!$mailer->sendAdminMail($objWeb, $payment, $this->bo->getFormParams(), $donator, $candidates, $donatorResult)) {    
+            if (!$mailer->sendAdminMail($objWeb, $payment, $this->bo->getFormParams(), $donator, $candidates, $donatorResult)) {
                 $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Unable to send the email to the administrator.");
             }
+
             // If we are in an advanced version of the form send the notice to the user
             if ($this->version > 1) {
                 $defParams = $this->bo->getDefParams();

--- a/modules/stic_Web_Forms/Catcher/Donation/DonationMailer.php
+++ b/modules/stic_Web_Forms/Catcher/Donation/DonationMailer.php
@@ -58,45 +58,38 @@ class DonationMailer extends WebFormMailer
 
                 // Function that verify if the form have the 'custom_assigned_email_template' input
                 if(!empty($_REQUEST['custom_assigned_email_template'])) {
-                    if($this->sendAssignedUserMail($_REQUEST['custom_assigned_email_template'], $objWeb, $payment)) {
-                        return;
-                    }
+                    return $this->sendAssignedUserMail($_REQUEST['custom_assigned_email_template'], $objWeb, $payment);
                 // If the form doesn't have the input send the generic email
                 } else {
                     $html = $this->newDonationMail($objWeb, $payment, $formParams, $donator, $donatorResult == DonationBO::DONATOR_NEW);
                     $html .= $paymentMailer->paymentToHTML($payment);
                 }
-                // End STIC 20230920
+                // End STIC 20240109
                 
                 break;
         }
 
-        // STIC 20231220 - ART - Enable custom email template for assigned user
-        // STIC#1224
-        if(empty($_REQUEST['custom_assigned_email_template'])) {
-            // Link the attached form files to the mail
-            $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Linking the attached documents of the form to the mail to be sent to the administrator ...");
-            $documents = $donator->documents->tempBeans;
+        // Link the attached form files to the mail
+        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Linking the attached documents of the form to the mail to be sent to the administrator ...");
+        $documents = $donator->documents->tempBeans;
 
-            if ($documents) {
-                $html .= '<span style="font-weight: bold;">';
-                $html .= $this->translate('LBL_ATTACHMENTS_WEBFORM');
-                $html .= '</span>';
-                $html .= '<table>';
+        if ($documents) {
+            $html .= '<span style="font-weight: bold;">';
+            $html .= $this->translate('LBL_ATTACHMENTS_WEBFORM');
+            $html .= '</span>';
+            $html .= '<table>';
 
-                foreach ($documents as $key => $value) {
-                    $your_url = $GLOBALS['sugar_config']['site_url'] . "/index.php?module=Documents&action=DetailView&record=" . $value->id;
-                    $html .= '<tr><td><a href="' . $your_url . '">' . $value->document_name . '</a></td></tr>';
-                    $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  File name: " . $value->document_name . " - File URL: " . $your_url);
-                }
-                $html .= '</table><br><br>';
+            foreach ($documents as $key => $value) {
+                $your_url = $GLOBALS['sugar_config']['site_url'] . "/index.php?module=Documents&action=DetailView&record=" . $value->id;
+                $html .= '<tr><td><a href="' . $your_url . '">' . $value->document_name . '</a></td></tr>';
+                $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  File name: " . $value->document_name . " - File URL: " . $your_url);
             }
-
-            $this->body = $html;
-            $this->subject = "{$payment->transaction_code} - {$this->subject}";
-            return $this->send();
+            $html .= '</table><br><br>';
         }
-        // End STIC 20231220
+
+        $this->body = $html;
+        $this->subject = "{$payment->transaction_code} - {$this->subject}";
+        return $this->send();
     }
 
     /**

--- a/modules/stic_Web_Forms/Catcher/Donation/DonationMailer.php
+++ b/modules/stic_Web_Forms/Catcher/Donation/DonationMailer.php
@@ -54,7 +54,6 @@ class DonationMailer extends WebFormMailer
                 // STIC 20230905 - ART - Enable custom email template for assigned user
                 // STIC#1224 
                 // $html = $this->newDonationMail($objWeb, $payment, $formParams, $donator, $donatorResult == DonationBO::DONATOR_NEW);
-                $paymentMailer = new PaymentMailer();
 
                 // Function that verify if the form have the 'custom_assigned_email_template' input
                 if(!empty($_REQUEST['custom_assigned_email_template'])) {
@@ -62,12 +61,14 @@ class DonationMailer extends WebFormMailer
                 // If the form doesn't have the input send the generic email
                 } else {
                     $html = $this->newDonationMail($objWeb, $payment, $formParams, $donator, $donatorResult == DonationBO::DONATOR_NEW);
-                    $html .= $paymentMailer->paymentToHTML($payment);
                 }
                 // End STIC 20240109
                 
                 break;
         }
+
+        $paymentMailer = new PaymentMailer();
+        $html .= $paymentMailer->paymentToHTML($payment);
 
         // Link the attached form files to the mail
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Linking the attached documents of the form to the mail to be sent to the administrator ...");

--- a/modules/stic_Web_Forms/Catcher/Donation/DonationMailer.php
+++ b/modules/stic_Web_Forms/Catcher/Donation/DonationMailer.php
@@ -51,10 +51,6 @@ class DonationMailer extends WebFormMailer
             case DonationBO::DONATOR_NEW:
             case DonationBO::DONATOR_UNIQUE:
                 
-                // STIC 20230905 - ART - Enable custom email template for assigned user
-                // STIC#1224 
-                // $html = $this->newDonationMail($objWeb, $payment, $formParams, $donator, $donatorResult == DonationBO::DONATOR_NEW);
-
                 // Function that verify if the form have the 'custom_assigned_email_template' input
                 if(!empty($_REQUEST['custom_assigned_email_template'])) {
                     return $this->sendAssignedUserMail($_REQUEST['custom_assigned_email_template'], $objWeb, $payment);
@@ -62,7 +58,6 @@ class DonationMailer extends WebFormMailer
                 } else {
                     $html = $this->newDonationMail($objWeb, $payment, $formParams, $donator, $donatorResult == DonationBO::DONATOR_NEW);
                 }
-                // End STIC 20240109
                 
                 break;
         }
@@ -243,8 +238,6 @@ class DonationMailer extends WebFormMailer
         return $html;
     }
 
-    // STIC 20230905 - ART - Enable custom email template for assigned user
-    // STIC#1224
     /**
      * Function to parse the email
      *
@@ -273,7 +266,6 @@ class DonationMailer extends WebFormMailer
             return false;
         }
     }
-    // End STIC 20231205 - ART
 
     /**
      * Send the notification email to the registered user
@@ -297,23 +289,6 @@ class DonationMailer extends WebFormMailer
         $replacementObjects[0] = $objWeb;
         $replacementObjects[1] = $payment;
 
-        // STIC 20230905 - ART - Enable custom email template for assigned user
-        // STIC#1224
-        // if ($payment->load_relationship('stic_payments_stic_payment_commitments')) {
-        //     $relatedBeans = $payment->stic_payments_stic_payment_commitments->getBeans();
-        //     foreach ($relatedBeans as $fpBean) {
-        //         $replacementObjects[] = $fpBean;
-        //     }
-        // }
-
-        // Parse the template
-        // $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Parsing template [{$templateId}]...");
-
-        // if (false === parent::parseEmailTemplateById($templateId, $replacementObjects, $lang)) {
-        //     $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Error parsing the template.");
-        //     return false;
-        // }
-
         // Function to parse the email
         $this->parsingEmail($templateId, $replacementObjects[1], $replacementObjects, $lang);
 
@@ -323,12 +298,9 @@ class DonationMailer extends WebFormMailer
         // If there's a template for the user send the mail
         if(!empty($templateId)) {
             return $this->send();
-        }   
-        // End STIC 20240116 - ART
+        }
     }
     
-    // STIC 20230905 - ART - Enable custom email template for assigned user
-    // STIC#1224
     /**
      * Send the notification email to the assigned user
      *
@@ -377,5 +349,4 @@ class DonationMailer extends WebFormMailer
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Sending mail...");
         return $this->send();
     }
-    // End STIC 20231205 - ART
 }

--- a/modules/stic_Web_Forms/Catcher/Donation/DonationMailer.php
+++ b/modules/stic_Web_Forms/Catcher/Donation/DonationMailer.php
@@ -316,11 +316,15 @@ class DonationMailer extends WebFormMailer
 
         // Function to parse the email
         $this->parsingEmail($templateId, $replacementObjects[1], $replacementObjects, $lang);
-        // End STIC 20231205 - ART
 
         // Send the mail
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Sending mail...");
-        return $this->send();
+
+        // If there's a template for the user send the mail
+        if(!empty($templateId)) {
+            return $this->send();
+        }   
+        // End STIC 20240116 - ART
     }
     
     // STIC 20230905 - ART - Enable custom email template for assigned user

--- a/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionMailer.php
+++ b/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionMailer.php
@@ -287,11 +287,15 @@ class EventInscriptionMailer extends WebFormMailer
 
         // Function to parse the email
         $this->parsingEmail($templateId, $account, $payment, $replacementObjects, $lang);
-        // End STIC 20230921 - ART
-
+        
         // Send the mail
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Sending mail ...");
-        return $this->send();
+
+        // If there's a template for the user send the mail
+        if(!empty($templateId)) {
+            return $this->send();
+        }
+        // End STIC 20240116 - ART
     }
 
 

--- a/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionMailer.php
+++ b/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionMailer.php
@@ -90,8 +90,26 @@ class EventInscriptionMailer extends WebFormMailer
                 break;
             case EventInscriptionBO::CONTACT_NEW:
             case EventInscriptionBO::CONTACT_UNIQUE:
-                $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Generating information for CONTACT_NEW or CONTACT_UNIQUE");
-                $html .= $this->newObjectBodyHTML($objWeb, $formParams, $contactObject, $contactResult == EventInscriptionBO::CONTACT_NEW);
+
+                // STIC 20230905 - ART - Enable custom email template for assigned user
+                // STIC#1224
+                // $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Generating information for CONTACT_NEW or CONTACT_UNIQUE");
+                //     $html .= $this->newObjectBodyHTML($objWeb, $formParams, $contactObject, $contactResult == EventInscriptionBO::CONTACT_NEW);
+                $paymentMailer = new PaymentMailer();
+
+                // Function that verify if the form have the 'custom_assigned_email_template' input
+                if(!empty($_REQUEST['custom_assigned_email_template'])) {
+                    if($this->sendAssignedUserMail($_REQUEST['custom_assigned_email_template'], $objWeb, $this->eventInscriptionBO->getEvent(), $this->eventInscriptionBO->getInscriptionObject(), null, $this->payment)) {
+                        return;
+                    }
+                // If the form doesn't have the input send the generic email
+                } else { 
+                    $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Generating information for CONTACT_NEW or CONTACT_UNIQUE");
+                    $html .= $this->newObjectBodyHTML($objWeb, $formParams, $contactObject, $contactResult == EventInscriptionBO::CONTACT_NEW);
+                    $html .= $paymentMailer->paymentToHTML($this->payment);
+                }
+                // End STIC 20230920
+
                 break;
         }
 
@@ -131,24 +149,47 @@ class EventInscriptionMailer extends WebFormMailer
                 break;
             case EventInscriptionBO::ACCOUNT_NEW:
             case EventInscriptionBO::ACCOUNT_UNIQUE:
-                $html .= $this->newObjectBodyHTML($objWeb, $formParams, $accountObject, $accountResult == EventInscriptionBO::ACCOUNT_NEW);
+
+                // STIC 20230905 - ART - Enable custom email template for assigned user
+                // STIC#1224
+                //$html .= $this->newObjectBodyHTML($objWeb, $formParams, $accountObject, $accountResult == EventInscriptionBO::ACCOUNT_NEW);
+                $paymentMailer = new PaymentMailer();
+
+                // Function that verify if the form have the 'custom_assigned_email_template' input
+                if(!empty($_REQUEST['custom_assigned_email_template'])) {
+                    if($this->sendAssignedUserMail($_REQUEST['custom_assigned_email_template'], $objWeb, $this->eventInscriptionBO->getEvent(), $this->eventInscriptionBO->getInscriptionObject(), $accountObject, $this->payment)) {
+                        return;
+                    }
+                // If the form doesn't have the input send the generic email
+                } else {
+                    $html .= $this->newObjectBodyHTML($objWeb, $formParams, $accountObject, $accountResult == EventInscriptionBO::ACCOUNT_NEW);
+                    $html .= $paymentMailer->paymentToHTML($this->payment);
+                }
+                // End STIC 20230920
+                
                 break;
             case EventInscriptionBO::ACCOUNT_NO_DATA:
                 $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  The form does not include organizational data.");
         }
 
-        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Payment data ...");
-        if ($this->payment == null) {
-            $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Payment data have not been included.");
-        } else {
-            $paymentMailer = new PaymentMailer();
-            $html .= $paymentMailer->paymentToHTML($this->payment);
-            $this->subject = "{$this->payment->transaction_code} - {$this->subject}"; // If there is linked payment, include the payment number in the subject of the mail
-        }
-        $this->body = $html;
 
-        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Sending mail ...");
-        return $this->send();
+        // STIC 20231220 - ART - Enable custom email template for assigned user
+        // STIC#1224
+        if(empty($_REQUEST['custom_assigned_email_template'])) {
+            $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Payment data ...");
+            if ($this->payment == null) {
+                $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Payment data have not been included.");
+            } else {
+                $paymentMailer = new PaymentMailer();
+                $html .= $paymentMailer->paymentToHTML($this->payment);
+                $this->subject = "{$this->payment->transaction_code} - {$this->subject}"; // If there is linked payment, include the payment number in the subject of the mail
+            }
+            $this->body = $html;
+
+            $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Sending mail ...");
+            return $this->send();
+        }
+        // End STIC 20231220
     }
 
     /**
@@ -174,6 +215,44 @@ class EventInscriptionMailer extends WebFormMailer
             $lang);
     }
 
+    // STIC 20230905 - ART - Enable custom email template for assigned user
+    // STIC#1224
+    /**
+     * Function to parse the email
+     *
+     * @param $templateId id of the template
+     * @param $account data of the account
+     * @param $payment data of the payment
+     * @param $replacementObjects array with the object
+     * @param $lang
+     * @return void
+     */
+    public function parsingEmail($templateId, $account, $payment, $replacementObjects, $lang){
+        // Function to get the object
+        if (!empty($account)) {
+            $replacementObjects[] = $account;
+        }
+
+        if (!empty($payment)) {
+            $replacementObjects[] = $payment;
+            if ($payment->load_relationship('stic_payments_stic_payment_commitments')) {
+                $relatedBeans = $payment->stic_payments_stic_payment_commitments->getBeans();
+                foreach ($relatedBeans as $fpBean) {
+                    $replacementObjects[] = $fpBean;
+                }
+            }
+        }
+
+        // Parse the template
+        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Parsing template [{$templateId}]...");
+
+        if (false === parent::parseEmailTemplateById($templateId, $replacementObjects, $lang)) {
+            $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Error parsing the template.");
+            return false;
+        }
+    }
+    // End STIC 20230921 - ART
+
     /**
      * Send the notification email to the registered user
      */
@@ -197,31 +276,101 @@ class EventInscriptionMailer extends WebFormMailer
         $replacementObjects[1] = $event;
         $replacementObjects[2] = $inscription;
 
-        if (!empty($account)) {
-            $replacementObjects[] = $account;
-        }
+        // STIC 20230905 - ART - Enable custom email template for assigned user
+        // STIC#1224
+        // if (!empty($account)) {
+        //     $replacementObjects[] = $account;
+        // }
 
-        if (!empty($payment)) {
-            $replacementObjects[] = $payment;
-            if ($payment->load_relationship('stic_payments_stic_payment_commitments')) {
-                $relatedBeans = $payment->stic_payments_stic_payment_commitments->getBeans();
-                foreach ($relatedBeans as $fpBean) {
-                    $replacementObjects[] = $fpBean;
-                }
-            }
-        }
+        // if (!empty($payment)) {
+        //     $replacementObjects[] = $payment;
+        //     if ($payment->load_relationship('stic_payments_stic_payment_commitments')) {
+        //         $relatedBeans = $payment->stic_payments_stic_payment_commitments->getBeans();
+        //         foreach ($relatedBeans as $fpBean) {
+        //             $replacementObjects[] = $fpBean;
+        //         }
+        //     }
+        // }
 
         // Parse the template
-        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Parsing template ...");
-        if (false === parent::parseEmailTemplateById($templateId, $replacementObjects, $lang)) {
-            $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Error parsing the template.");
-            return false;
-        }
+        // $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Parsing template ...");
+        // if (false === parent::parseEmailTemplateById($templateId, $replacementObjects, $lang)) {
+        //     $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Error parsing the template.");
+        //     return false;
+        // }
+
+        // Function to parse the email
+        $this->parsingEmail($templateId, $account, $payment, $replacementObjects, $lang);
+        // End STIC 20230921 - ART
 
         // Send the mail
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Sending mail ...");
         return $this->send();
     }
+
+
+    // STIC 20230905 - ART - Enable custom email template for assigned user
+    // STIC#1224
+    /**
+     * Send the notification email to the assigned user
+     *
+     * @param $templateId id of the template
+     * @param $objContactWeb data of the contact from the form
+     * @param $event data of the event
+     * @param $inscription data of the inscription
+     * @param $account data of the account if this exist
+     * @param $payment data of the payment
+     * @param $lang
+     * @return void
+     */
+    protected function sendAssignedUserMail($templateId, $objWeb, $event, $inscription, $account = null, $payment, $lang = null)
+    {
+        // Reset the recipient list
+        $this->resetDest();
+
+        // Get the candidates from the form
+        $candidates = $this->eventInscriptionBO->getContactCandidates();
+        $objWeb = array_pop($candidates);
+
+        // Get the accounts of the candidates from the form
+        $candidates = $this->eventInscriptionBO->getAccountCandidates();
+        $account = (!empty($candidates) ? array_pop($candidates) : null);
+
+        // Add the recipient
+        $user = BeanFactory::getBean('Users', $_REQUEST['assigned_user_id']);
+        // Use the primary address of the assigned user
+        $userEmail = $user->emailAddress->getPrimaryAddress($user);
+        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Adding recipient [{$userEmail}] ...");
+        $this->addMailsDest($userEmail);
+
+        // Get the Contact from the CRM
+        include_once 'SticInclude/Utils.php';
+        $contactBean = SticUtils::getRelatedBeanObject($payment, 'stic_payments_contacts'); 
+
+        // Build the array of objects to parse
+        $replacementObjects = array();
+        $replacementObjects[0] = $objWeb;
+        $replacementObjects[1] = $event;
+        $replacementObjects[2] = $inscription;
+        $replacementObjects[3] = $user;
+        $replacementObjects[4] = $contactBean;
+
+        // If there is an attached document it is added to the array
+        if(!empty($contactBean->documents)){
+            $documents = $contactBean->documents->tempBeans;
+            foreach($documents as $key => $valueDocument) {
+                $replacementObjects[5] = $valueDocument;
+            }
+        }
+
+        // Function to parse the email
+        $this->parsingEmail($templateId, $account, $payment, $replacementObjects, $lang);
+
+        // Send the mail
+        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Sending mail ...");
+        return $this->send();
+    }
+    // End STIC 20230920
 
     /**
      * Prepare the necessary information for deferred mail delivery

--- a/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionMailer.php
+++ b/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionMailer.php
@@ -95,7 +95,6 @@ class EventInscriptionMailer extends WebFormMailer
                 // STIC#1224
                 // $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Generating information for CONTACT_NEW or CONTACT_UNIQUE");
                 //     $html .= $this->newObjectBodyHTML($objWeb, $formParams, $contactObject, $contactResult == EventInscriptionBO::CONTACT_NEW);
-                $paymentMailer = new PaymentMailer();
 
                 // Function that verify if the form have the 'custom_assigned_email_template' input
                 if(!empty($_REQUEST['custom_assigned_email_template'])) {
@@ -104,7 +103,6 @@ class EventInscriptionMailer extends WebFormMailer
                 } else { 
                     $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Generating information for CONTACT_NEW or CONTACT_UNIQUE");
                     $html .= $this->newObjectBodyHTML($objWeb, $formParams, $contactObject, $contactResult == EventInscriptionBO::CONTACT_NEW);
-                    $html .= $paymentMailer->paymentToHTML($this->payment);
                 }
                 // End STIC 20240109
 
@@ -151,7 +149,6 @@ class EventInscriptionMailer extends WebFormMailer
                 // STIC 20230905 - ART - Enable custom email template for assigned user
                 // STIC#1224
                 //$html .= $this->newObjectBodyHTML($objWeb, $formParams, $accountObject, $accountResult == EventInscriptionBO::ACCOUNT_NEW);
-                $paymentMailer = new PaymentMailer();
 
                 // Function that verify if the form have the 'custom_assigned_email_template' input
                 if(!empty($_REQUEST['custom_assigned_email_template'])) {
@@ -159,7 +156,6 @@ class EventInscriptionMailer extends WebFormMailer
                 // If the form doesn't have the input send the generic email
                 } else {
                     $html .= $this->newObjectBodyHTML($objWeb, $formParams, $accountObject, $accountResult == EventInscriptionBO::ACCOUNT_NEW);
-                    $html .= $paymentMailer->paymentToHTML($this->payment);
                 }
                 // End STIC 20230920
                 

--- a/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionMailer.php
+++ b/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionMailer.php
@@ -99,16 +99,14 @@ class EventInscriptionMailer extends WebFormMailer
 
                 // Function that verify if the form have the 'custom_assigned_email_template' input
                 if(!empty($_REQUEST['custom_assigned_email_template'])) {
-                    if($this->sendAssignedUserMail($_REQUEST['custom_assigned_email_template'], $objWeb, $this->eventInscriptionBO->getEvent(), $this->eventInscriptionBO->getInscriptionObject(), null, $this->payment)) {
-                        return;
-                    }
+                    return $this->sendAssignedUserMail($_REQUEST['custom_assigned_email_template'], $objWeb, $this->eventInscriptionBO->getEvent(), $this->eventInscriptionBO->getInscriptionObject(), null, $this->payment);
                 // If the form doesn't have the input send the generic email
                 } else { 
                     $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Generating information for CONTACT_NEW or CONTACT_UNIQUE");
                     $html .= $this->newObjectBodyHTML($objWeb, $formParams, $contactObject, $contactResult == EventInscriptionBO::CONTACT_NEW);
                     $html .= $paymentMailer->paymentToHTML($this->payment);
                 }
-                // End STIC 20230920
+                // End STIC 20240109
 
                 break;
         }
@@ -157,9 +155,7 @@ class EventInscriptionMailer extends WebFormMailer
 
                 // Function that verify if the form have the 'custom_assigned_email_template' input
                 if(!empty($_REQUEST['custom_assigned_email_template'])) {
-                    if($this->sendAssignedUserMail($_REQUEST['custom_assigned_email_template'], $objWeb, $this->eventInscriptionBO->getEvent(), $this->eventInscriptionBO->getInscriptionObject(), $accountObject, $this->payment)) {
-                        return;
-                    }
+                    return $this->sendAssignedUserMail($_REQUEST['custom_assigned_email_template'], $objWeb, $this->eventInscriptionBO->getEvent(), $this->eventInscriptionBO->getInscriptionObject(), $accountObject, $this->payment);
                 // If the form doesn't have the input send the generic email
                 } else {
                     $html .= $this->newObjectBodyHTML($objWeb, $formParams, $accountObject, $accountResult == EventInscriptionBO::ACCOUNT_NEW);
@@ -172,24 +168,18 @@ class EventInscriptionMailer extends WebFormMailer
                 $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  The form does not include organizational data.");
         }
 
-
-        // STIC 20231220 - ART - Enable custom email template for assigned user
-        // STIC#1224
-        if(empty($_REQUEST['custom_assigned_email_template'])) {
-            $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Payment data ...");
-            if ($this->payment == null) {
-                $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Payment data have not been included.");
-            } else {
-                $paymentMailer = new PaymentMailer();
-                $html .= $paymentMailer->paymentToHTML($this->payment);
-                $this->subject = "{$this->payment->transaction_code} - {$this->subject}"; // If there is linked payment, include the payment number in the subject of the mail
-            }
-            $this->body = $html;
-
-            $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Sending mail ...");
-            return $this->send();
+        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Payment data ...");
+        if ($this->payment == null) {
+            $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Payment data have not been included.");
+        } else {
+            $paymentMailer = new PaymentMailer();
+            $html .= $paymentMailer->paymentToHTML($this->payment);
+            $this->subject = "{$this->payment->transaction_code} - {$this->subject}"; // If there is linked payment, include the payment number in the subject of the mail
         }
-        // End STIC 20231220
+        $this->body = $html;
+
+        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Sending mail ...");
+        return $this->send();
     }
 
     /**

--- a/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionMailer.php
+++ b/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionMailer.php
@@ -91,11 +91,6 @@ class EventInscriptionMailer extends WebFormMailer
             case EventInscriptionBO::CONTACT_NEW:
             case EventInscriptionBO::CONTACT_UNIQUE:
 
-                // STIC 20230905 - ART - Enable custom email template for assigned user
-                // STIC#1224
-                // $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Generating information for CONTACT_NEW or CONTACT_UNIQUE");
-                //     $html .= $this->newObjectBodyHTML($objWeb, $formParams, $contactObject, $contactResult == EventInscriptionBO::CONTACT_NEW);
-
                 // Function that verify if the form have the 'custom_assigned_email_template' input
                 if(!empty($_REQUEST['custom_assigned_email_template'])) {
                     return $this->sendAssignedUserMail($_REQUEST['custom_assigned_email_template'], $objWeb, $this->eventInscriptionBO->getEvent(), $this->eventInscriptionBO->getInscriptionObject(), null, $this->payment);
@@ -104,7 +99,6 @@ class EventInscriptionMailer extends WebFormMailer
                     $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Generating information for CONTACT_NEW or CONTACT_UNIQUE");
                     $html .= $this->newObjectBodyHTML($objWeb, $formParams, $contactObject, $contactResult == EventInscriptionBO::CONTACT_NEW);
                 }
-                // End STIC 20240109
 
                 break;
         }
@@ -146,10 +140,6 @@ class EventInscriptionMailer extends WebFormMailer
             case EventInscriptionBO::ACCOUNT_NEW:
             case EventInscriptionBO::ACCOUNT_UNIQUE:
 
-                // STIC 20230905 - ART - Enable custom email template for assigned user
-                // STIC#1224
-                //$html .= $this->newObjectBodyHTML($objWeb, $formParams, $accountObject, $accountResult == EventInscriptionBO::ACCOUNT_NEW);
-
                 // Function that verify if the form have the 'custom_assigned_email_template' input
                 if(!empty($_REQUEST['custom_assigned_email_template'])) {
                     return $this->sendAssignedUserMail($_REQUEST['custom_assigned_email_template'], $objWeb, $this->eventInscriptionBO->getEvent(), $this->eventInscriptionBO->getInscriptionObject(), $accountObject, $this->payment);
@@ -157,7 +147,6 @@ class EventInscriptionMailer extends WebFormMailer
                 } else {
                     $html .= $this->newObjectBodyHTML($objWeb, $formParams, $accountObject, $accountResult == EventInscriptionBO::ACCOUNT_NEW);
                 }
-                // End STIC 20230920
                 
                 break;
             case EventInscriptionBO::ACCOUNT_NO_DATA:
@@ -201,8 +190,6 @@ class EventInscriptionMailer extends WebFormMailer
             $lang);
     }
 
-    // STIC 20230905 - ART - Enable custom email template for assigned user
-    // STIC#1224
     /**
      * Function to parse the email
      *
@@ -237,7 +224,6 @@ class EventInscriptionMailer extends WebFormMailer
             return false;
         }
     }
-    // End STIC 20230921 - ART
 
     /**
      * Send the notification email to the registered user
@@ -262,29 +248,6 @@ class EventInscriptionMailer extends WebFormMailer
         $replacementObjects[1] = $event;
         $replacementObjects[2] = $inscription;
 
-        // STIC 20230905 - ART - Enable custom email template for assigned user
-        // STIC#1224
-        // if (!empty($account)) {
-        //     $replacementObjects[] = $account;
-        // }
-
-        // if (!empty($payment)) {
-        //     $replacementObjects[] = $payment;
-        //     if ($payment->load_relationship('stic_payments_stic_payment_commitments')) {
-        //         $relatedBeans = $payment->stic_payments_stic_payment_commitments->getBeans();
-        //         foreach ($relatedBeans as $fpBean) {
-        //             $replacementObjects[] = $fpBean;
-        //         }
-        //     }
-        // }
-
-        // Parse the template
-        // $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Parsing template ...");
-        // if (false === parent::parseEmailTemplateById($templateId, $replacementObjects, $lang)) {
-        //     $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Error parsing the template.");
-        //     return false;
-        // }
-
         // Function to parse the email
         $this->parsingEmail($templateId, $account, $payment, $replacementObjects, $lang);
         
@@ -295,12 +258,9 @@ class EventInscriptionMailer extends WebFormMailer
         if(!empty($templateId)) {
             return $this->send();
         }
-        // End STIC 20240116 - ART
     }
 
 
-    // STIC 20230905 - ART - Enable custom email template for assigned user
-    // STIC#1224
     /**
      * Send the notification email to the assigned user
      *
@@ -360,7 +320,6 @@ class EventInscriptionMailer extends WebFormMailer
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Sending mail ...");
         return $this->send();
     }
-    // End STIC 20230920
 
     /**
      * Prepare the necessary information for deferred mail delivery

--- a/modules/stic_Web_Forms/Catcher/Include/Mailer/WebFormMailer.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Mailer/WebFormMailer.php
@@ -312,11 +312,8 @@ class WebFormMailer
      */
     public function parseEmailTemplateById($templateId, $replacementObjects, $lang = null)
     {
-        // STIC 20231205 - ART - Enable custom email template for assigned user
-        // STIC#1224
         // Calling the object from the form to parse the entire template
         $objWeb = $replacementObjects[0];
-        // End STIC 20231205
 
         if (empty($templateId)) {
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  No ID received.");
@@ -331,11 +328,7 @@ class WebFormMailer
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Template with ID  [{$templateId}]  not found.");
             return false;
         }
-        // STIC 20231205 - ART - Enable custom email template for assigned user
-        // STIC#1224
-        // return $this->parseEmailTemplate($template, $replacementObjects, $lang);
         return $this->parseEmailTemplate($template, $replacementObjects, $objWeb, $lang);
-        // End STIC 20231205
     }
 
     /**
@@ -348,11 +341,8 @@ class WebFormMailer
      */
     public function parseEmailTemplateByName($templateName, $replacementObjects, $lang = null, $type = 'email')
     {
-        // STIC 20231205 - ART - Enable custom email template for assigned user
-        // STIC#1224
         // Calling the object from the form to parse the entire template
         $objWeb = $replacementObjects[0];
-        // End STIC 20231205
 
         if (empty($templateName)) {
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  No name has been received.");
@@ -367,11 +357,7 @@ class WebFormMailer
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Template not found with name [{$templateName}]");
             return false;
         }
-        // STIC 20231205 - ART - Enable custom email template for assigned user
-        // STIC#1224
-        // return $this->parseEmailTemplate($template, $replacementObjects, $lang);
         return $this->parseEmailTemplate($template, $replacementObjects, $objWeb, $lang);
-        // End STIC 20231205
     }
 
     /**
@@ -381,12 +367,8 @@ class WebFormMailer
      * @param $replacementObjects Array of objects to be parsed
      * @return String Mail body in html
      */
-    // STIC 20231205 - ART - Enable custom email template for assigned user
-    // STIC#1224
-    // protected function parseEmailTemplate($template, $replacementObjects, $lang) {
     protected function parseEmailTemplate($template, $replacementObjects, $objWeb, $lang)
     {
-    // End STIC 20231205
         global $current_language, $app_list_strings, $app_strings;
 
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Parsing template ...");
@@ -409,20 +391,11 @@ class WebFormMailer
         $app_strings = return_application_language($current_language);
         $app_list_strings = return_app_list_strings_language($current_language);
 
-        // STIC 20231205 - ART - Enable custom email template for assigned user
-        // STIC#1224
-        // $parseArr = array("subject0" => $template->subject, "text0" => $template->body, "html0" => $template->body_html);
         $parseArr = array("subject1" => $template->subject, "text1" => $template->body, "html1" => $template->body_html);
-        // End STIC 20231205
         $replacementObjectsLength = (empty($replacementObjects) || !is_array($replacementObjects) ? 0 : count($replacementObjects));
 
-        // STIC 20231205 - ART - Enable custom email template for assigned user
-        // STIC#1224
-        // $j = 0;
-        // for ($i = 0; $i < $replacementObjectsLength; $i++) {
         $j = 1;
         for ($i = 1; $i < $replacementObjectsLength ; $i++) {
-        // End STIC 20231205
             $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Parsing object [{$i}] [{$replacementObjects[$i]->module_dir}] ... ");
             $macro_nv = array();
             $obj = $this->prepareBean2EmailTemplate($replacementObjects[$i]);
@@ -434,9 +407,7 @@ class WebFormMailer
             $parseArr["subject{$j}"] = $parseArr["subject{$i}"];
             $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Result [{$i}] -> " . $parseArr["html{$j}"]);
         }
-        
-        // STIC 20230905 - ART - Enable custom email template for assigned user
-        // STIC#1224
+
         // Replace on the email template the param of form_contact to contact
         $parseArr["html{$i}"] = str_replace('$form_contact', '$contact', $parseArr["html{$i}"]);
         $obj = $this->prepareBean2EmailTemplate($objWeb);
@@ -446,7 +417,6 @@ class WebFormMailer
         $parseArr["text{$j}"] = $parseArr["text{$i}"];
         $parseArr["html{$j}"] = $parseArr["html{$i}"];
         $parseArr["subject{$j}"] = $parseArr["subject{$i}"];
-        // End STIC 20231205
 
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ": Recovering original language files ...");
         $current_language = $prev_lang;

--- a/modules/stic_Web_Forms/Catcher/Include/Mailer/WebFormMailer.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Mailer/WebFormMailer.php
@@ -312,6 +312,12 @@ class WebFormMailer
      */
     public function parseEmailTemplateById($templateId, $replacementObjects, $lang = null)
     {
+        // STIC 20231205 - ART - Enable custom email template for assigned user
+        // STIC#1224
+        // Calling the object from the form to parse the entire template
+        $objWeb = $replacementObjects[0];
+        // End STIC 20231205
+
         if (empty($templateId)) {
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  No ID received.");
             return false;
@@ -325,7 +331,11 @@ class WebFormMailer
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Template with ID  [{$templateId}]  not found.");
             return false;
         }
-        return $this->parseEmailTemplate($template, $replacementObjects, $lang);
+        // STIC 20231205 - ART - Enable custom email template for assigned user
+        // STIC#1224
+        // return $this->parseEmailTemplate($template, $replacementObjects, $lang);
+        return $this->parseEmailTemplate($template, $replacementObjects, $objWeb, $lang);
+        // End STIC 20231205
     }
 
     /**
@@ -338,6 +348,12 @@ class WebFormMailer
      */
     public function parseEmailTemplateByName($templateName, $replacementObjects, $lang = null, $type = 'email')
     {
+        // STIC 20231205 - ART - Enable custom email template for assigned user
+        // STIC#1224
+        // Calling the object from the form to parse the entire template
+        $objWeb = $replacementObjects[0];
+        // End STIC 20231205
+
         if (empty($templateName)) {
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  No name has been received.");
             return false;
@@ -351,7 +367,11 @@ class WebFormMailer
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Template not found with name [{$templateName}]");
             return false;
         }
-        return $this->parseEmailTemplate($template, $replacementObjects, $lang);
+        // STIC 20231205 - ART - Enable custom email template for assigned user
+        // STIC#1224
+        // return $this->parseEmailTemplate($template, $replacementObjects, $lang);
+        return $this->parseEmailTemplate($template, $replacementObjects, $objWeb, $lang);
+        // End STIC 20231205
     }
 
     /**
@@ -361,8 +381,12 @@ class WebFormMailer
      * @param $replacementObjects Array of objects to be parsed
      * @return String Mail body in html
      */
-    protected function parseEmailTemplate($template, $replacementObjects, $lang)
+    // STIC 20231205 - ART - Enable custom email template for assigned user
+    // STIC#1224
+    // protected function parseEmailTemplate($template, $replacementObjects, $lang) {
+    protected function parseEmailTemplate($template, $replacementObjects, $objWeb, $lang)
     {
+    // End STIC 20231205
         global $current_language, $app_list_strings, $app_strings;
 
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Parsing template ...");
@@ -385,11 +409,20 @@ class WebFormMailer
         $app_strings = return_application_language($current_language);
         $app_list_strings = return_app_list_strings_language($current_language);
 
-        $parseArr = array("subject0" => $template->subject, "text0" => $template->body, "html0" => $template->body_html);
+        // STIC 20231205 - ART - Enable custom email template for assigned user
+        // STIC#1224
+        // $parseArr = array("subject0" => $template->subject, "text0" => $template->body, "html0" => $template->body_html);
+        $parseArr = array("subject1" => $template->subject, "text1" => $template->body, "html1" => $template->body_html);
+        // End STIC 20231205
         $replacementObjectsLength = (empty($replacementObjects) || !is_array($replacementObjects) ? 0 : count($replacementObjects));
 
-        $j = 0;
-        for ($i = 0; $i < $replacementObjectsLength; $i++) {
+        // STIC 20231205 - ART - Enable custom email template for assigned user
+        // STIC#1224
+        // $j = 0;
+        // for ($i = 0; $i < $replacementObjectsLength; $i++) {
+        $j = 1;
+        for ($i = 1; $i < $replacementObjectsLength ; $i++) {
+        // End STIC 20231205
             $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Parsing object [{$i}] [{$replacementObjects[$i]->module_dir}] ... ");
             $macro_nv = array();
             $obj = $this->prepareBean2EmailTemplate($replacementObjects[$i]);
@@ -401,6 +434,19 @@ class WebFormMailer
             $parseArr["subject{$j}"] = $parseArr["subject{$i}"];
             $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Result [{$i}] -> " . $parseArr["html{$j}"]);
         }
+        
+        // STIC 20230905 - ART - Enable custom email template for assigned user
+        // STIC#1224
+        // Replace on the email template the param of form_contact to contact
+        $parseArr["html{$i}"] = str_replace('$form_contact', '$contact', $parseArr["html{$i}"]);
+        $obj = $this->prepareBean2EmailTemplate($objWeb);
+        $parseArr = $template->parse_email_template($parseArr, $obj->module_dir, $obj, $macro_nv);
+
+        // Parse the entire email template again
+        $parseArr["text{$j}"] = $parseArr["text{$i}"];
+        $parseArr["html{$j}"] = $parseArr["html{$i}"];
+        $parseArr["subject{$j}"] = $parseArr["subject{$i}"];
+        // End STIC 20231205
 
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ": Recovering original language files ...");
         $current_language = $prev_lang;


### PR DESCRIPTION
- Closes #26 

**Desarrollo del issue**
Al enviar un formulario web se quiere que el usuario asignado reciba un email personalizado y no el genérico de los formularios web. Por ello, se implementa un input que recoja dicha plantilla personalizada y envíe el email al usuario.

**Solución implementada:**
Se ha añadido una función que recoge el input de _custom_assigned_email_template_, en caso de que exista en el formulario, y envía un email de la plantilla personalizada al usuario asignado.

**Pruebas**
1. Crear una plantilla personalizada.
2. Crear un formulario web de captación de fondos o de eventos.
3. Si se quiere mostrar ambas informaciones, la persona del formulario como la del CRM, se deberá de añadir las siguientes variables en la plantilla:
- **CRM: _$contact_Campo_**
- **Formulario: _$form_contact_Campo_**

3. 1. Si un formulario recibe documentos, se deberá de añadir en la plantilla de email lo siguiente si se desea mostrar el enlace al documento: **_index.php?action=DetailView&module=Documents&record=$document_id_**

4. Añadir en el HTML del formulario la siguiente línea de input `<input type="hidden" name="custom_assigned_email_template" value=""/>` pasando el valor del id de la plantilla personalizada.
5. Comprobar que al enviar el formulario, el usuario asignado haya recibido el email personalizado y no el genérico.