### PR TITLE
Hotfix - Medicación - Búsqueda por rango añadida a los campos de tipo fecha en los filtros de los módulos Prescripción médica y Registro de Medicación

### DIFF
--- a/modules/stic_Medication_Log/metadata/SearchFields.php
+++ b/modules/stic_Medication_Log/metadata/SearchFields.php
@@ -60,6 +60,21 @@ $searchFields[$module_name] = array(
         'enable_range_search' => true,
         'is_date_field' => true
     ),
+    'range_intake_date' => array(
+        'query_type' => 'default',
+        'enable_range_search' => true,
+        'is_date_field' => true,
+    ),
+    'start_range_intake_date' => array(
+        'query_type' => 'default',
+        'enable_range_search' => true,
+        'is_date_field' => true,
+    ),
+    'end_range_intake_date' => array(
+        'query_type' => 'default',
+        'enable_range_search' => true,
+        'is_date_field' => true,
+    ),
     //Range Search Support
     'favorites_only' => array(
         'query_type' => 'format',

--- a/modules/stic_Medication_Log/vardefs.php
+++ b/modules/stic_Medication_Log/vardefs.php
@@ -46,7 +46,8 @@ $dictionary['stic_Medication_Log'] = array(
     'unified_search' => false,
     'merge_filter' => 'disabled',
     'size' => '20',
-    'enable_range_search' => false,
+    'options' => 'date_range_search_dom',
+    'enable_range_search' => 1,
   ),
   'medication' => 
   array (

--- a/modules/stic_Prescription/metadata/SearchFields.php
+++ b/modules/stic_Prescription/metadata/SearchFields.php
@@ -60,6 +60,36 @@ $searchFields[$module_name] = array(
         'enable_range_search' => true,
         'is_date_field' => true
     ),
+    'range_start_date' => array(
+        'query_type' => 'default',
+        'enable_range_search' => true,
+        'is_date_field' => true,
+    ),
+    'start_range_start_date' => array(
+        'query_type' => 'default',
+        'enable_range_search' => true,
+        'is_date_field' => true,
+    ),
+    'end_range_start_date' => array(
+        'query_type' => 'default',
+        'enable_range_search' => true,
+        'is_date_field' => true,
+    ),
+    'range_end_date' => array(
+        'query_type' => 'default',
+        'enable_range_search' => true,
+        'is_date_field' => true,
+    ),
+    'start_range_end_date' => array(
+        'query_type' => 'default',
+        'enable_range_search' => true,
+        'is_date_field' => true,
+    ),
+    'end_range_end_date' => array(
+        'query_type' => 'default',
+        'enable_range_search' => true,
+        'is_date_field' => true,
+    ),
     //Range Search Support
     'favorites_only' => array(
         'query_type' => 'format',

--- a/modules/stic_Prescription/vardefs.php
+++ b/modules/stic_Prescription/vardefs.php
@@ -46,7 +46,8 @@ $dictionary['stic_Prescription'] = array(
     'unified_search' => false,
     'merge_filter' => 'disabled',
     'size' => '20',
-    'enable_range_search' => false,
+    'options' => 'date_range_search_dom',
+    'enable_range_search' => 1,
   ),
   'end_date' => 
   array (
@@ -67,7 +68,8 @@ $dictionary['stic_Prescription'] = array(
     'unified_search' => false,
     'merge_filter' => 'disabled',
     'size' => '20',
-    'enable_range_search' => false,
+    'options' => 'date_range_search_dom',
+    'enable_range_search' => 1,
   ),
   'active' => 
   array (


### PR DESCRIPTION
- closes #54 

Se añade la búsqueda por rango a los campos de fecha de los módulos de _Prescripción_ y _Registro de Medicación_.

### Pruebas
1. Crear algunas prescripciones, aprovechando para que se generen también los registros de medicación (se generan desde la fecha de inicio de la prescripción hasta el día de hoy)
2. Comprobar en Precripción que los campos del filtro referentes a fecha de inicio y fin de la prescripción presentan la interfaz para realizar búsqueda por rango y que funciona
3. 3. Comrpobar en Registro de Medicación que el campo de filtro referente a la fecha de la tomca presenta la interfaz de búsqueda por rango y funciona