### PR TITLE
Hotfix - Mail Merge - Los documentos DOCX generados a partir de una lista de registros son incorrectos

### DIFF
--- a/modules/DHA_PlantillasDocumentos/librerias/TinyButStrong/tbs_class.php
+++ b/modules/DHA_PlantillasDocumentos/librerias/TinyButStrong/tbs_class.php
@@ -2370,6 +2370,7 @@ function meth_Merge_BlockSections(&$Txt,&$LocR,&$Src,&$RecSpe) {
 	$Src->DataFetch();
 
 	// STIC-Custom 20230903 EPS - Only one tag w:body will be used in the document
+	// https://github.com/SinergiaTIC/SinergiaCRM/pull/29
 	$bodyPresent = false;
 	// END STIC-Custom
 

--- a/modules/DHA_PlantillasDocumentos/librerias/TinyButStrong/tbs_class.php
+++ b/modules/DHA_PlantillasDocumentos/librerias/TinyButStrong/tbs_class.php
@@ -2369,6 +2369,10 @@ function meth_Merge_BlockSections(&$Txt,&$LocR,&$Src,&$RecSpe) {
 	// Main loop
 	$Src->DataFetch();
 
+	// STIC-Custom 20230903 EPS - Only one tag w:body will be used in the document
+	$bodyPresent = false;
+	// END STIC-Custom
+
 	while($Src->CurrRec!==false) {
 
 		// Headers and Footers
@@ -2478,7 +2482,15 @@ function meth_Merge_BlockSections(&$Txt,&$LocR,&$Src,&$RecSpe) {
 				}
 			}
 			if ($piOMS) $this->meth_PlugIn_RunAll($this->_piOnMergeSection,$ArgLst);
+
+			// STIC-Custom 20230903 EPS - Only one tag w:body will be used in the document
+			if ($bodyPresent){
+				$SecSrc = str_replace('<w:body>', '', $SecSrc);
+				$BlockRes = str_replace('</w:body>', '', $BlockRes);
+			}
 			$BlockRes .= $SecSrc;
+			$bodyPresent = true;
+			//END STIC-Custom
 		}
 
 		// Next row


### PR DESCRIPTION
- Closes #53 

** Solución implementada **
En el punto de la librería utilizada internamente (las clases están incrustadas en elpropio directorio de MM y no en vendor) donde realiza la sustitución de la plantilla por el texto con los datos, se comprueba si ya hay un documento anterior (es decir ya existen los tags de w:body) y en ese caso no se generannuevos tags w:body.

** Información adicinal **
A pesar de cambiar un fichero de TinyButStrong, el origen del problema no es un bug de la librería si no en cómo se usa desde MM y el CRM y el conocimiento que tenemos de la misma. 
Si intentamos no poner un block_w:body, no se genera documento y si lo ponemos y se escoge más de un registro acaba más de un tag w:body en el documento final.

La solución presentada en este PR simplemente evita que se añadan varios tags w:body a un documento Word, sin entrar al detalle del motivo por el que se produce y si se pueden manipular las plantillas de alguna forma para evitarlo.

** Pruebas **
1. Generar un documento DOCX de un sólo registro
2. Generar un documento DOCX con varios registros 
3. Comprobar que os documentos generados se visualizan correctamente tanto con Word como con el visor de Google Drive (esto último se puede hacer fácilmente si se utiliza la opción enviar por e-mail al generar el documento).
4. Probar distintos tipos de plantillas para ver que no se ven afectadas
5. Generar documentos Excel y comprobar que siguen funcionando correctamente