### PR TITLE
Hotfix - Flujos de trabajo - Error en fórmula del cálculo de mes

### DIFF
--- a/modules/AOW_Actions/actions/actionComputeField.php
+++ b/modules/AOW_Actions/actions/actionComputeField.php
@@ -123,16 +123,16 @@ class actionComputeField extends actionBase
                 } else {
                     $value = $calculator->calculateFormula($formulaContents[$i]);
                     $fieldType = $bean->field_defs[$formulas[$i]]['type'] ?? 'string';
-                    if (in_array($fieldType, ['float', 'decimal', 'currency'])) {
+                    if (in_array($fieldType, ['float', 'decimal', 'currency', 'double'])) {
                         $value = (float) $value;
                     }
-                    elseif ($fieldType === 'int') {
+                    elseif (in_array($fieldType, ['int', 'uint', 'ulong', 'long', 'short', 'tinyint'])) {
                         $value = (int) $value;
                     }
                     $bean->{$formulas[$i]} = $value;
                 }
             }
-            // End STIC-Custom 20240110
+            // End STIC-Custom 20240118
 
             if ($in_save) {
                 global $current_user;

--- a/modules/AOW_Actions/actions/actionComputeField.php
+++ b/modules/AOW_Actions/actions/actionComputeField.php
@@ -103,8 +103,8 @@ class actionComputeField extends actionBase
 
             $relateFields = $this->getAllRelatedFields($bean);
 
-            // STIC 20240110 - ART - Error in formula to calculate month
-            // STIC#
+            // STIC-Custom 20240110 - ART - Error in formula to calculate month
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/49
             // for ($i = 0; $i < count($formulas); $i++) {
             //     if (array_key_exists($formulas[$i], $relateFields) && isset($relateFields[$formulas[$i]]['id_name'])) {
             //         $calcValue = $calculator->calculateFormula($formulaContents[$i]);
@@ -132,7 +132,7 @@ class actionComputeField extends actionBase
                     $bean->{$formulas[$i]} = $value;
                 }
             }
-            // End STIC 20240110
+            // End STIC-Custom 20240110
 
             if ($in_save) {
                 global $current_user;

--- a/modules/AOW_Actions/actions/actionComputeField.php
+++ b/modules/AOW_Actions/actions/actionComputeField.php
@@ -103,15 +103,36 @@ class actionComputeField extends actionBase
 
             $relateFields = $this->getAllRelatedFields($bean);
 
-            for ($i = 0; $i < count($formulas); $i++) {
+            // STIC 20240110 - ART - Error in formula to calculate month
+            // STIC#
+            // for ($i = 0; $i < count($formulas); $i++) {
+            //     if (array_key_exists($formulas[$i], $relateFields) && isset($relateFields[$formulas[$i]]['id_name'])) {
+            //         $calcValue = $calculator->calculateFormula($formulaContents[$i]);
+            //         $bean->{$relateFields[$formulas[$i]]['id_name']} = ( is_numeric($calcValue) ? (float)$calcValue : $calcValue );
+            //     } else {
+            //         $calcValue = $calculator->calculateFormula($formulaContents[$i]);
+            //         $bean->{$formulas[$i]} = ( is_numeric($calcValue) ? (float)$calcValue : $calcValue );
+            //     }
+            // }
+
+            $formulasCount = is_countable($formulas) ? count($formulas) : 0;
+
+            for ($i = 0; $i < $formulasCount; $i++) {
                 if (array_key_exists($formulas[$i], $relateFields) && isset($relateFields[$formulas[$i]]['id_name'])) {
-                    $calcValue = $calculator->calculateFormula($formulaContents[$i]);
-                    $bean->{$relateFields[$formulas[$i]]['id_name']} = ( is_numeric($calcValue) ? (float)$calcValue : $calcValue );
+                    $bean->{$relateFields[$formulas[$i]]['id_name']} = $calculator->calculateFormula($formulaContents[$i]);
                 } else {
-                    $calcValue = $calculator->calculateFormula($formulaContents[$i]);
-                    $bean->{$formulas[$i]} = ( is_numeric($calcValue) ? (float)$calcValue : $calcValue );
+                    $value = $calculator->calculateFormula($formulaContents[$i]);
+                    $fieldType = $bean->field_defs[$formulas[$i]]['type'] ?? 'string';
+                    if (in_array($fieldType, ['float', 'decimal', 'currency'])) {
+                        $value = (float) $value;
+                    }
+                    elseif ($fieldType === 'int') {
+                        $value = (int) $value;
+                    }
+                    $bean->{$formulas[$i]} = $value;
                 }
             }
+            // End STIC 20240110
 
             if ($in_save) {
                 global $current_user;


### PR DESCRIPTION
- Closes #48 

**Desarrollo del issue**
Al crear un flujo de trabajo para que calcule el mes, con ceros a la izquierda, de un campo fecha, devuelve el mes sin dichos ceros.

**Solución implementada de https://github.com/salesagility/SuiteCRM/pull/10112:**
Este código recorre en iteración una lista de fórmulas, calcula sus valores y los establece en los campos apropiados del objeto bean. Garantizando que los valores numéricos se almacenen en el tipo de datos correcto.

**Pruebas**
1. Crear un FdT
- Módulo de Flujo de Trabajo: Personas
- Ejecutar en: Nuevos registros
- Ejecutar: Al guardar

2. Acción: Calcular campos
- Parámetros ->Fecha de nacimiento{P0}
- Fórmulas-> Descripción {date(m;{P0})}

3. Crear una nueva persona rellenando el campo Fecha de nacimiento
4. Comprobar que en descripción se ha guardado el valor del mes con el cero a la izquierda.