### PR TITLE
Hotfix - SinergiaDA - Permitir valores simples en multienum sin `^`

### DIFF
--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1527,6 +1527,10 @@ class ExternalReporting
         while ($multiField = $db->fetchByAssoc($res, false)) {
 
             $list = $multiField['master_table'];
+
+            if ($list = 'sda_l_contacts_stic_professional_profile_c_stic_professional_pro'){
+                echo '';
+            }
             $this->info .= "<li>{$list}</li>";
 
             $unionSelectPiece = array();
@@ -1546,7 +1550,7 @@ class ExternalReporting
                  '{$listElement['code']}' as 'code'
                  FROM
                     {$multiField['source_table']}
-                 WHERE {$multiField['source_column']} LIKE '%^{$listElement['code']}^%'
+                 WHERE ({$multiField['source_column']} LIKE '%^{$listElement['code']}^%' OR {$multiField['source_column']} = '{$listElement['code']}') 
                  ";
             }
 

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1527,10 +1527,6 @@ class ExternalReporting
         while ($multiField = $db->fetchByAssoc($res, false)) {
 
             $list = $multiField['master_table'];
-
-            if ($list = 'sda_l_contacts_stic_professional_profile_c_stic_professional_pro'){
-                echo '';
-            }
             $this->info .= "<li>{$list}</li>";
 
             $unionSelectPiece = array();


### PR DESCRIPTION
- solves #52 

Este PR añade una condición a la consulta que crea las tablas puente usadas para publicar los campos multienum en SinergiaDA de manera que se incluyan los valores simples (con un solo elemento) aunque no estén envueltos con el símbolos `^` (caret).

## Pruebas a realizar
 1. En el módulo Personas añadir varios registros, añadiendo varios valores en el campo  el campo multiselección  _Perfil del trabajador_, algunos con varios elementos y alguno con un solo elemento.
 2. En la base de datos, en este campo, modificar el valor almacenado para alguno de los registros con un solo elemento quitándole el simbolo `^` de los lados.
 3. Ejecutar la reconstrucción de SinergiaDA
 4. Verificar la tabla `sda_contacts__stic_professional_profile_c` creada durante el proceso y verificar que se ha creado un registro por cada id/elemento, incluidos aquellos que no están rodeados del caracter `^` 
 
 
 
