### PR TITLE
Hotfix - Campañas - No eliminar emails que no debían ser excluidos de la cola de mensajes

### DIFF
--- a/modules/Campaigns/QueueCampaign.php
+++ b/modules/Campaigns/QueueCampaign.php
@@ -181,7 +181,7 @@ if (!$test) {
             WHERE plp.deleted = 0 AND plc.deleted = 0
             AND pl.deleted = 0 AND pl.list_type = 'exempt'
             AND plc.campaign_id = '{$campaign->id}'
-            -- STIC 12/01/2024 MHP - Do not remove messages from the queue that do not belong to the campaign with exempt LPO
+            -- STIC-Custom 12/01/2024 MHP - Do not remove messages from the queue that do not belong to the campaign with exempt LPO
             -- STIC#61
             AND emailman.campaign_id = '{$campaign->id}') em
             -- END STIC-Custom

--- a/modules/Campaigns/QueueCampaign.php
+++ b/modules/Campaigns/QueueCampaign.php
@@ -182,7 +182,7 @@ if (!$test) {
             AND pl.deleted = 0 AND pl.list_type = 'exempt'
             AND plc.campaign_id = '{$campaign->id}'
             -- STIC 12/01/2024 MHP - Do not remove messages from the queue that do not belong to the campaign with exempt LPO
-            -- STIC#
+            -- STIC#61
             AND emailman.campaign_id = '{$campaign->id}') em
             -- END STIC-Custom
     )";

--- a/modules/Campaigns/QueueCampaign.php
+++ b/modules/Campaigns/QueueCampaign.php
@@ -182,7 +182,7 @@ if (!$test) {
             AND pl.deleted = 0 AND pl.list_type = 'exempt'
             AND plc.campaign_id = '{$campaign->id}'
             -- STIC-Custom 12/01/2024 MHP - Do not remove messages from the queue that do not belong to the campaign with exempt LPO
-            -- STIC#61
+            -- https://github.com/SinergiaTIC/SinergiaCRM/pull/61
             AND emailman.campaign_id = '{$campaign->id}') em
             -- END STIC-Custom
     )";

--- a/modules/Campaigns/QueueCampaign.php
+++ b/modules/Campaigns/QueueCampaign.php
@@ -180,7 +180,11 @@ if (!$test) {
             ON plp.prospect_list_id = plc.prospect_list_id 
             WHERE plp.deleted = 0 AND plc.deleted = 0
             AND pl.deleted = 0 AND pl.list_type = 'exempt'
-            AND plc.campaign_id = '{$campaign->id}') em
+            AND plc.campaign_id = '{$campaign->id}'
+            -- STIC 12/01/2024 MHP - Do not remove messages from the queue that do not belong to the campaign with exempt LPO
+            -- STIC#
+            AND emailman.campaign_id = '{$campaign->id}') em
+            -- END STIC-Custom
     )";
     $campaign->db->query($delete_query);
 }


### PR DESCRIPTION
## Description
- Closes #47

En el proceso de envío de un email de marketing, el CRM añade a la cola de mensajes todos los mensajes que debería enviar para posteriormente eliminar aquellos que formen parte de las **LPO de Exclusión por ID** que se relacionen con la campaña. 

En este PR se soluciona la incidencia indicada en el issue añadiendo una condición al código SQL que elimina los mensajes de la cola de envío excluidos por alguna **LPO de Exclusión por ID** relacionada con la campaña para que compruebe que el mensaje pertenece a la campaña que se está enviando, de manera que si un mensaje no se relaciona con la campaña que se está enviando, no será eliminado.

**Pruebas**
1. Crear una LPO de envío con dos personas (Persona 1 y Persona 2) y otra de Exclusión por ID con una de las dos personas (Persona 2)
2. Crear dos campañas, una que solo tenga la LPO de envío y otra que tenga ambas LPOs. 
3. Enviar la campaña que no tiene la LPO de exclusión y comprobar que aparecen ambas personas en la cola de mensajes.
4. Enviar la campaña que sí tiene la LPO de exclusión y comprobar que en la cola de mensajes no ha sido eliminado el envío de la campaña sin LPO de exclusión. 
5. Probar dividiendo los receptores en diferentes LPOs, tanto Por defecto como de exclusión por ID.