### PR TITLE
Incidencia - General - Modificar el nombre del subpanel Historial

### DIFF
--- a/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
+++ b/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
@@ -261,11 +261,11 @@ class ActivitiesRelationship extends OneToManyRelationship
             'order' => 20 ,
             'sort_order' => 'desc' ,
             'sort_by' => 'date_modified' ,
-            // STIC Custom 20240116 MHP - Assign the correct label to the titel_key field
+            // STIC-Custom 20240116 MHP - Assign the correct label to the titel_key field
             // STIC#64
             // 'title_key' => 'LBL_HISTORY' ,
             'title_key' => 'LBL_HISTORY_SUBPANEL_TITLE' ,
-            // END STIC Custom
+            // END STIC-Custom
             'type' => 'collection' ,
             'subpanel_name' => 'history' , //this values is not associated with a physical file.
             'module' => 'History' ,

--- a/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
+++ b/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
@@ -261,11 +261,11 @@ class ActivitiesRelationship extends OneToManyRelationship
             'order' => 20 ,
             'sort_order' => 'desc' ,
             'sort_by' => 'date_modified' ,
-            // STIC Custom 20211025 MHP - Assign the correct label to the titel_key field
+            // STIC Custom 20240116 MHP - Assign the correct label to the titel_key field
             // STIC#64
             // 'title_key' => 'LBL_HISTORY' ,
             'title_key' => 'LBL_HISTORY_SUBPANEL_TITLE' ,
-            // STIC Custom 20211025 MHP -             
+            // END STIC Custom
             'type' => 'collection' ,
             'subpanel_name' => 'history' , //this values is not associated with a physical file.
             'module' => 'History' ,

--- a/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
+++ b/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
@@ -261,7 +261,11 @@ class ActivitiesRelationship extends OneToManyRelationship
             'order' => 20 ,
             'sort_order' => 'desc' ,
             'sort_by' => 'date_modified' ,
-            'title_key' => 'LBL_HISTORY' ,
+            // STIC Custom 20211025 MHP - Assign the correct label to the titel_key field
+            // STIC#64
+            // 'title_key' => 'LBL_HISTORY' ,
+            'title_key' => 'LBL_HISTORY_SUBPANEL_TITLE' ,
+            // STIC Custom 20211025 MHP -             
             'type' => 'collection' ,
             'subpanel_name' => 'history' , //this values is not associated with a physical file.
             'module' => 'History' ,

--- a/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
+++ b/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
@@ -262,7 +262,7 @@ class ActivitiesRelationship extends OneToManyRelationship
             'sort_order' => 'desc' ,
             'sort_by' => 'date_modified' ,
             // STIC-Custom 20240116 MHP - Assign the correct label to the titel_key field
-            // STIC#64
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/64
             // 'title_key' => 'LBL_HISTORY' ,
             'title_key' => 'LBL_HISTORY_SUBPANEL_TITLE' ,
             // END STIC-Custom


### PR DESCRIPTION
- Closes #63

Este PR resuelve la incidencia planteada en el issue sustituyendo la etiqueta asignada en la propiedad **title_key** (  
 **LBL_HISTORY** por **LBL_HISTORY_SUBPANEL_TITLE**) de la definición de las propiedades que serán usadas en el en el automatismo que genera el subpanel Historial durante el proceso de creación de la relación entre un módulo y el metamódulo de Actividades. 

**Pruebas**
1. Crear un módulo nuevo, publicarlo y cargarlo en el CRM.
2. Desde Estudio, crear una relación entre este módulo y el metamódulo de Actividades. 
3. Acceder al apartado de etiquetas, seleccionar **Todas las etiquetas** en el desplegable de la esquina superior derecha y cambiar el valor de las etiquetas:  **LBL_ACTIVITIES_SUBPANEL_TITLE** y **LBL_HISTORY_SUBPANEL_TITLE**
4. Crear un registro en el módulo nuevo y acceder a su vista de detalle.
5. Comprobar que el nombre de los subpaneles de Actividades e Historial se han actualizado.


**Información adicional**
El cambio que implementa este PR resuelve el problema para las nuevas relaciones que se generen. Para relaciones ya creadas tendremos que acceder al siguiente fichero: _custom/Extension/modules/**<Módulo>**/Ext/Layoutdefs/**<Nombre_Relación>**.php_ , cambiar el valor de la propiedad **title_key** con la etiqueta **LBL_HISTORY_SUBPANEL_TITLE** y realizar una reparación.
