### PR TITLE
Hotfix - SinergiaDA - Asegurar inclusión de todos los campos

### DIFF
--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -11,12 +11,6 @@ class ExternalReporting
     // It is important during the development phase to not use previously used versions in order to avoid breaking existing reports.
     private $versionPrefix = 'sda';
 
-    // Sets the field visibility configuration:
-    // true: Includes only the available fields in the detail views for each module.
-    // false: Includes all the fields of the modules. Sets the sda_hidden=1 property in sda_def_columns
-    //        to initially hide the fields in the detail view and prevent user management.
-    private $showOnlyFieldsInDetailView = false;
-
     // Fields that we always exclude in our operations
     private $evenExcludedFields = ['template_ddown_c', 'currency_name', 'assigned_user_id', 'parent_name', 'deleted', 'created_by', 'created_by_name', 'created_by_link', 'modified_user_link', 'modified_by_name', 'jjwg_maps_address_c', 'jjwg_maps_geocode_status_c', 'jjwg_maps_lat_c', 'jjwg_maps_lng_c'];
 
@@ -297,20 +291,11 @@ class ExternalReporting
                     continue;
                 }
 
-                if ($this->showOnlyFieldsInDetailView) {
-                    if (!in_array($fieldV['name'], $detailViewVisibleFields)
-                        // If the field is not in the detailview we exclude it, except the ID & name & full_name fields, which must always be included. Array EventincludedModules modules are always included too.
-                        && !in_array($fieldV['type'], ['id', 'fullname', 'name'])
-                    ) {
-                        continue;
-                    }
+                // If field is in detailview, set as visible, hidden if not.
+                if (in_array($fieldV['name'], $detailViewVisibleFields) || $fieldV['name'] == 'id') {
+                    $sdaHiddenField = false;
                 } else {
-                    if (in_array($fieldV['name'], $detailViewVisibleFields) || $fieldV['name'] == 'id') {
-                        $sdaHiddenField = false;
-                    } else {
-                        $sdaHiddenField = true;
-                    }
-
+                    $sdaHiddenField = true;
                 }
 
                 $fieldV['label'] = $this->sanitizeText($modStrings[$fieldV['vname']]);


### PR DESCRIPTION
## Descripción

Se ha modificado el proceso de reconstrucción de SinergiaDA para que incluya siempre todos los campos de un módulo, aunque no estén en la vista de detalle de los módulos. Anteriormente, existía una opción que permitía publicar exclusivamente aquellos campos presentes en la vista de detalle. Sin embargo, se ha identificado un comportamiento inconsistente: a pesar de no estar activa esta opción, ciertos campos eran omitidos si no aparecían en la vista de detalle del módulo correspondiente.

Dado que se ha comprobado que el método de publicar todos los campos resulta eficaz y sin errores en las instancias de SinergiaDA, se ha decidido eliminar la opción de publicación limitada. Esta decisión busca simplificar el proceso y eliminar una potencial fuente de fallos.

## Pruebas a Realizar

1. Eliminar algunos campos de la vista de detalle en diferentes módulos. Es importante enfocarse en campos como Fecha de creación, Fecha de modificación, Usuario creador, entre otros.
2. Ejecutar el proceso de reconstrucción de las vistas.
3. Verificar que los campos eliminados se incluyen en las vistas correspondientes a cada módulo. 
4. Confirmar que estos campos están correctamente informados en la tabla `sda_def_columns`, con el atributo `hidden` establecido en `true`