### PR TITLE
Hotfix - General - Añadir modulos stic en addAjaxBannedModules de config_override

### DIFF
--- a/SticUpdates/Scripts/AddSticModulesToAjaxBanned.php
+++ b/SticUpdates/Scripts/AddSticModulesToAjaxBanned.php
@@ -1,0 +1,13 @@
+<?php
+
+require_once 'modules/Configurator/Configurator.php';
+$configurator = new Configurator();
+
+if(!array_search('stic_Import_Validation', $configurator->config['addAjaxBannedModules']))
+    $configurator->config['addAjaxBannedModules'][] = 'stic_Import_Validation';
+
+if(!array_search('stic_Security_Groups_Rules', $configurator->config['addAjaxBannedModules']))
+    $configurator->config['addAjaxBannedModules'][] = 'stic_Security_Groups_Rules';
+
+$configurator->saveConfig();
+


### PR DESCRIPTION
Este PR substituye al #67 y al #68
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Descripcion
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Al especificar el addAjaxBannedModules en el config.php, es posible que no surja efecto en todas las instancias: si tienen configurados módulos con ajax deshabilitado, estos se añaden en el config_override, sobreescribiendo el contenido del array addAjaxBannedModules

Se crea un script que carga la configuración de la instancia, y si los módulos stic (stic_Import_Validation y stic_Security_Groups_Rules) no están incluídos en el array addAjaxBannedModules, los añade y guarda la configuración

## Pruebas
1. Editar el config_override y añadir:
```
$sugar_config['addAjaxBannedModules'][0] = 'SecurityGroups';
$sugar_config['addAjaxBannedModules'][1] = 'KReports';
$sugar_config['addAjaxBannedModules'][2] = 'Calls';
$sugar_config['addAjaxBannedModules'][3] = 'Contacts';
$sugar_config['addAjaxBannedModules'][4] = 'Notes';
$sugar_config['addAjaxBannedModules'][5] = 'Meetings';
```
2. En navegador, ir a: http://[INSTANCIA]/SticRunScripts.php?file=SticUpdates/Scripts/AddSticModulesToAjaxBanned.php
3. Verificar que el config_override contiene los módulos stic_Import_Validation y stic_Security_Groups_Rules:
```
$sugar_config['addAjaxBannedModules'][0] = 'SecurityGroups';
$sugar_config['addAjaxBannedModules'][1] = 'KReports';
$sugar_config['addAjaxBannedModules'][2] = 'Calls';
$sugar_config['addAjaxBannedModules'][3] = 'Contacts';
$sugar_config['addAjaxBannedModules'][4] = 'Notes';
$sugar_config['addAjaxBannedModules'][5] = 'Meetings';
$sugar_config['addAjaxBannedModules'][6] = 'stic_Import_Validation';
$sugar_config['addAjaxBannedModules'][7] = 'stic_Security_Groups_Rules';
```