### PR TITLE
Hotfix - Ventas - Incluir líneas de producto al Generar documento PDF desde vista lista

### DIFF
--- a/modules/AOS_PDF_Templates/formLetterPdf.php
+++ b/modules/AOS_PDF_Templates/formLetterPdf.php
@@ -102,6 +102,20 @@ $count = 0;
 foreach ($recordIds as $recordId) {
     $bean->retrieve($recordId);
 
+    // STIC-Custom 20240122 JBL - Product line items in pdf
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    $variableName = strtolower($bean->module_dir);
+    $lineItemsGroups = array();
+    $lineItems = array();
+
+    $sql = "SELECT pg.id, pg.product_id, pg.group_id FROM aos_products_quotes pg LEFT JOIN aos_line_item_groups lig ON pg.group_id = lig.id WHERE pg.parent_type = '" . $bean->object_name . "' AND pg.parent_id = '" . $bean->id . "' AND pg.deleted = 0 ORDER BY lig.number ASC, pg.number ASC";
+    $res = $bean->db->query($sql);
+    while ($row = $bean->db->fetchByAssoc($res)) {
+        $lineItemsGroups[$row['group_id']][$row['id']] = $row['product_id'];
+        $lineItems[$row['id']] = $row['product_id'];
+    }
+    // END STIC-Custom 20240122
+
     try {
         $pdfHistory = PDFWrapper::getPDFEngine();
         $pdfHistory->configurePDF($pdfConfig);
@@ -116,21 +130,75 @@ foreach ($recordIds as $recordId) {
         $object_arr['Accounts'] = $bean->account_id;
     }
 
-    $search = array(
-        '@<script[^>]*?>.*?</script>@si',        // Strip out javascript
-        '@<[\/\!]*?[^<>]*?>@si',        // Strip out HTML tags
-        '@([\r\n])[\s]+@',            // Strip out white space
-        '@&(quot|#34);@i',            // Replace HTML entities
-        '@&(amp|#38);@i',
-        '@&(lt|#60);@i',
-        '@&(gt|#62);@i',
-        '@&(nbsp|#160);@i',
-        '@&(iexcl|#161);@i',
-        '@<address[^>]*?>@si'
+    // STIC-Custom 20240122 JBL - Product line items in pdf
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    /*
+    // $search = array(
+    //     '@<script[^>]*?>.*?</script>@si',        // Strip out javascript
+    //     '@<[\/\!]*?[^<>]*?>@si',        // Strip out HTML tags
+    //     '@([\r\n])[\s]+@',            // Strip out white space
+    //     '@&(quot|#34);@i',            // Replace HTML entities
+    //     '@&(amp|#38);@i',
+    //     '@&(lt|#60);@i',
+    //     '@&(gt|#62);@i',
+    //     '@&(nbsp|#160);@i',
+    //     '@&(iexcl|#161);@i',
+    //     '@<address[^>]*?>@si'
+    // );
+    */
+    // $replace = array(
+    //     '',
+    //     '',
+    //     '\1',
+    //     '"',
+    //     '&',
+    //     '<',
+    //     '>',
+    //     ' ',
+    //     chr(161),
+    //     '<br>'
+    // );
+    
+    // $text = preg_replace($search, $replace, $template->description);
+    // $text = preg_replace_callback(
+    //     '/{DATE\s+(.*?)}/',
+    //     function ($matches) {
+    //         return date($matches[1]);
+    //     },
+    //     $text
+    // );
+    // $header = preg_replace($search, $replace, $template->pdfheader);
+    // $footer = preg_replace($search, $replace, $template->pdffooter);
+
+    //backward compatibility
+    if (isset($bean->billing_account_id)) {
+        $object_arr['Accounts'] = $bean->billing_account_id;
+    }
+    if (isset($bean->billing_contact_id)) {
+        $object_arr['Contacts'] = $bean->billing_contact_id;
+    }
+    if (isset($bean->assigned_user_id)) {
+        $object_arr['Users'] = $bean->assigned_user_id;
+    }
+    if (isset($bean->currency_id)) {
+        $object_arr['Currencies'] = $bean->currency_id;
+    }
+
+    $search = array('/<script[^>]*?>.*?<\/script>/si',      // Strip out javascript
+        '/<[\/\!]*?[^<>]*?>/si',        // Strip out HTML tags
+        '/([\r\n])[\s]+/',          // Strip out white space
+        '/&(quot|#34);/i',          // Replace HTML entities
+        '/&(amp|#38);/i',
+        '/&(lt|#60);/i',
+        '/&(gt|#62);/i',
+        '/&(nbsp|#160);/i',
+        '/&(iexcl|#161);/i',
+        '/<address[^>]*?>/si',
+        '/&(apos|#0*39);/',
+        '/&#(\d+);/'
     );
 
-    $replace = array(
-        '',
+    $replace = array('',
         '',
         '\1',
         '"',
@@ -139,19 +207,33 @@ foreach ($recordIds as $recordId) {
         '>',
         ' ',
         chr(161),
-        '<br>'
+        '<br>',
+        "'",
+        'chr(%1)'
     );
 
+    $header = preg_replace($search, $replace, $template->pdfheader);
+    $footer = preg_replace($search, $replace, $template->pdffooter);
     $text = preg_replace($search, $replace, $template->description);
+    $text = str_replace("<p><pagebreak /></p>", "<pagebreak />", $text);
     $text = preg_replace_callback(
-        '/{DATE\s+(.*?)}/',
+        '/\{DATE\s+(.*?)\}/',
         function ($matches) {
             return date($matches[1]);
         },
         $text
     );
-    $header = preg_replace($search, $replace, $template->pdfheader);
-    $footer = preg_replace($search, $replace, $template->pdffooter);
+    $text = str_replace("\$aos_quotes", "\$" . $variableName, $text);
+    $text = str_replace("\$aos_invoices", "\$" . $variableName, $text);
+    $text = str_replace("\$total_amt", "\$" . $variableName . "_total_amt", $text);
+    $text = str_replace("\$discount_amount", "\$" . $variableName . "_discount_amount", $text);
+    $text = str_replace("\$subtotal_amount", "\$" . $variableName . "_subtotal_amount", $text);
+    $text = str_replace("\$tax_amount", "\$" . $variableName . "_tax_amount", $text);
+    $text = str_replace("\$shipping_amount", "\$" . $variableName . "_shipping_amount", $text);
+    $text = str_replace("\$total_amount", "\$" . $variableName . "_total_amount", $text);
+    
+    $text = populate_group_lines($text, $lineItemsGroups, $lineItems);
+    // END STIC-Custom 20240122
 
     $converted = templateParser::parse_template($text, $object_arr);
     $header = templateParser::parse_template($header, $object_arr);
@@ -198,3 +280,267 @@ foreach ($recordIds as $recordId) {
 }
 
 $pdf->outputPDF($file_name, 'D');
+
+// STIC-Custom 20240122 JBL - Product line items in pdf
+// https://github.com/SinergiaTIC/SinergiaCRM/pull/
+function populate_group_lines($text, $lineItemsGroups, $lineItems, $element = 'table')
+{
+    $firstValue = '';
+    $firstNum = 0;
+
+    $lastValue = '';
+    $lastNum = 0;
+
+    $startElement = '<' . $element;
+    $endElement = '</' . $element . '>';
+
+
+    $groups = BeanFactory::newBean('AOS_Line_Item_Groups');
+    foreach ($groups->field_defs as $name => $arr) {
+        if (!((isset($arr['dbType']) && strtolower($arr['dbType']) == 'id') || $arr['type'] == 'id' || $arr['type'] == 'link')) {
+            $curNum = strpos($text, '$aos_line_item_groups_' . $name);
+            if ($curNum) {
+                if ($curNum < $firstNum || $firstNum == 0) {
+                    $firstValue = '$aos_line_item_groups_' . $name;
+                    $firstNum = $curNum;
+                }
+                if ($curNum > $lastNum) {
+                    $lastValue = '$aos_line_item_groups_' . $name;
+                    $lastNum = $curNum;
+                }
+            }
+        }
+    }
+    if ($firstValue !== '' && $lastValue !== '') {
+        //Converting Text
+        $parts = explode($firstValue, $text);
+        $text = $parts[0];
+        $parts = explode($lastValue, $parts[1]);
+        if ($lastValue == $firstValue) {
+            $groupPart = $firstValue . $parts[0];
+        } else {
+            $groupPart = $firstValue . $parts[0] . $lastValue;
+        }
+
+        if (count($lineItemsGroups) != 0) {
+            //Read line start <tr> value
+            $tcount = strrpos($text, $startElement);
+            $lsValue = substr($text, $tcount);
+            $tcount = strpos($lsValue, ">") + 1;
+            $lsValue = substr($lsValue, 0, $tcount);
+
+
+            //Read line end values
+            $tcount = strpos($parts[1], $endElement) + strlen($endElement);
+            $leValue = substr($parts[1], 0, $tcount);
+
+            //Converting Line Items
+            $obb = array();
+
+            $tdTemp = explode($lsValue, $text);
+
+            $groupPart = $lsValue . $tdTemp[count($tdTemp) - 1] . $groupPart . $leValue;
+
+            $text = $tdTemp[0];
+
+            foreach ($lineItemsGroups as $group_id => $lineItemsArray) {
+                $groupPartTemp = populate_product_lines($groupPart, $lineItemsArray);
+                $groupPartTemp = populate_service_lines($groupPartTemp, $lineItemsArray);
+
+                $obb['AOS_Line_Item_Groups'] = $group_id;
+                $text .= templateParser::parse_template($groupPartTemp, $obb);
+                $text .= '<br />';
+            }
+            $tcount = strpos($parts[1], $endElement) + strlen($endElement);
+            $parts[1] = substr($parts[1], $tcount);
+        } else {
+            $tcount = strrpos($text, $startElement);
+            $text = substr($text, 0, $tcount);
+
+            $tcount = strpos($parts[1], $endElement) + strlen($endElement);
+            $parts[1] = substr($parts[1], $tcount);
+        }
+
+        $text .= $parts[1];
+    } else {
+        $text = populate_product_lines($text, $lineItems);
+        $text = populate_service_lines($text, $lineItems);
+    }
+
+
+    return $text;
+}
+
+function populate_product_lines($text, $lineItems, $element = 'tr')
+{
+    $firstValue = '';
+    $firstNum = 0;
+
+    $lastValue = '';
+    $lastNum = 0;
+
+    $startElement = '<' . $element;
+    $endElement = '</' . $element . '>';
+
+    //Find first and last valid line values
+    $product_quote = BeanFactory::newBean('AOS_Products_Quotes');
+    foreach ($product_quote->field_defs as $name => $arr) {
+        if (!((isset($arr['dbType']) && strtolower($arr['dbType']) == 'id') || $arr['type'] == 'id' || $arr['type'] == 'link')) {
+            $curNum = strpos($text, '$aos_products_quotes_' . $name);
+
+            if ($curNum) {
+                if ($curNum < $firstNum || $firstNum == 0) {
+                    $firstValue = '$aos_products_quotes_' . $name;
+                    $firstNum = $curNum;
+                }
+                if ($curNum > $lastNum) {
+                    $lastValue = '$aos_products_quotes_' . $name;
+                    $lastNum = $curNum;
+                }
+            }
+        }
+    }
+
+    $product = BeanFactory::newBean('AOS_Products');
+    foreach ($product->field_defs as $name => $arr) {
+        if (!((isset($arr['dbType']) && strtolower($arr['dbType']) == 'id') || $arr['type'] == 'id' || $arr['type'] == 'link')) {
+            $curNum = strpos($text, '$aos_products_' . $name);
+            if ($curNum) {
+                if ($curNum < $firstNum || $firstNum == 0) {
+                    $firstValue = '$aos_products_' . $name;
+
+
+                    $firstNum = $curNum;
+                }
+                if ($curNum > $lastNum) {
+                    $lastValue = '$aos_products_' . $name;
+                    $lastNum = $curNum;
+                }
+            }
+        }
+    }
+
+    if ($firstValue !== '' && $lastValue !== '') {
+
+        //Converting Text
+        $tparts = explode($firstValue, $text);
+        $temp = $tparts[0];
+
+        //check if there is only one line item
+        if ($firstNum == $lastNum) {
+            $linePart = $firstValue;
+        } else {
+            $tparts = explode($lastValue, $tparts[1]);
+            $linePart = $firstValue . $tparts[0] . $lastValue;
+        }
+
+
+        $tcount = strrpos($temp, $startElement);
+        $lsValue = substr($temp, $tcount);
+        $tcount = strpos($lsValue, ">") + 1;
+        $lsValue = substr($lsValue, 0, $tcount);
+
+        //Read line end values
+        $tcount = strpos($tparts[1], $endElement) + strlen($endElement);
+        $leValue = substr($tparts[1], 0, $tcount);
+        $tdTemp = explode($lsValue, $temp);
+
+        $linePart = $lsValue . $tdTemp[count($tdTemp) - 1] . $linePart . $leValue;
+        $parts = explode($linePart, $text);
+        $text = $parts[0];
+
+        //Converting Line Items
+        if (count($lineItems) != 0) {
+            foreach ($lineItems as $id => $productId) {
+                if ($productId != null && $productId != '0') {
+                    $obb['AOS_Products_Quotes'] = $id;
+                    $obb['AOS_Products'] = $productId;
+                    $text .= templateParser::parse_template($linePart, $obb);
+                }
+            }
+        }
+
+        for ($i = 1; $i < count($parts); $i++) {
+            $text .= $parts[$i];
+        }
+    }
+    return $text;
+}
+
+function populate_service_lines($text, $lineItems, $element = 'tr')
+{
+    $firstValue = '';
+    $firstNum = 0;
+
+    $lastValue = '';
+    $lastNum = 0;
+
+    $startElement = '<' . $element;
+    $endElement = '</' . $element . '>';
+
+    $text = str_replace("\$aos_services_quotes_service", "\$aos_services_quotes_product", $text);
+
+    //Find first and last valid line values
+    $product_quote = BeanFactory::newBean('AOS_Products_Quotes');
+    foreach ($product_quote->field_defs as $name => $arr) {
+        if (!((isset($arr['dbType']) && strtolower($arr['dbType']) == 'id') || $arr['type'] == 'id' || $arr['type'] == 'link')) {
+            $curNum = strpos($text, '$aos_services_quotes_' . $name);
+            if ($curNum) {
+                if ($curNum < $firstNum || $firstNum == 0) {
+                    $firstValue = '$aos_products_quotes_' . $name;
+                    $firstNum = $curNum;
+                }
+                if ($curNum > $lastNum) {
+                    $lastValue = '$aos_products_quotes_' . $name;
+                    $lastNum = $curNum;
+                }
+            }
+        }
+    }
+    if ($firstValue !== '' && $lastValue !== '') {
+        $text = str_replace("\$aos_products", "\$aos_null", $text);
+        $text = str_replace("\$aos_services", "\$aos_products", $text);
+
+        //Converting Text
+        $tparts = explode($firstValue, $text);
+        $temp = $tparts[0];
+
+        //check if there is only one line item
+        if ($firstNum == $lastNum) {
+            $linePart = $firstValue;
+        } else {
+            $tparts = explode($lastValue, $tparts[1]);
+            $linePart = $firstValue . $tparts[0] . $lastValue;
+        }
+
+        $tcount = strrpos($temp, $startElement);
+        $lsValue = substr($temp, $tcount);
+        $tcount = strpos($lsValue, ">") + 1;
+        $lsValue = substr($lsValue, 0, $tcount);
+
+        //Read line end values
+        $tcount = strpos($tparts[1], $endElement) + strlen($endElement);
+        $leValue = substr($tparts[1], 0, $tcount);
+        $tdTemp = explode($lsValue, $temp);
+
+        $linePart = $lsValue . $tdTemp[count($tdTemp) - 1] . $linePart . $leValue;
+        $parts = explode($linePart, $text);
+        $text = $parts[0];
+
+        //Converting Line Items
+        if (count($lineItems) != 0) {
+            foreach ($lineItems as $id => $productId) {
+                if ($productId == null || $productId == '0') {
+                    $obb['AOS_Products_Quotes'] = $id;
+                    $text .= templateParser::parse_template($linePart, $obb);
+                }
+            }
+        }
+
+        for ($i = 1; $i < count($parts); $i++) {
+            $text .= $parts[$i];
+        }
+    }
+    return $text;
+}
+// END STIC-Custom 20240122

--- a/modules/AOS_PDF_Templates/formLetterPdf.php
+++ b/modules/AOS_PDF_Templates/formLetterPdf.php
@@ -103,7 +103,7 @@ foreach ($recordIds as $recordId) {
     $bean->retrieve($recordId);
 
     // STIC-Custom 20240122 JBL - Product line items in pdf
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/76
     $variableName = strtolower($bean->module_dir);
     $lineItemsGroups = array();
     $lineItems = array();
@@ -131,7 +131,7 @@ foreach ($recordIds as $recordId) {
     }
 
     // STIC-Custom 20240122 JBL - Product line items in pdf
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/76
     /*
     // $search = array(
     //     '@<script[^>]*?>.*?</script>@si',        // Strip out javascript
@@ -282,7 +282,7 @@ foreach ($recordIds as $recordId) {
 $pdf->outputPDF($file_name, 'D');
 
 // STIC-Custom 20240122 JBL - Product line items in pdf
-// https://github.com/SinergiaTIC/SinergiaCRM/pull/
+// https://github.com/SinergiaTIC/SinergiaCRM/pull/76
 function populate_group_lines($text, $lineItemsGroups, $lineItems, $element = 'table')
 {
     $firstValue = '';


### PR DESCRIPTION
- Closes #75 

### Descripción
Este PR soluciona la incidencia descrita en el Issue #75

Se ha detectado un comportamiento distinto en la generación de PDFs dependiendo de si se ejecuta desde la vista de detalle o bien desde la vista de lista mediante "acción masiva" de sus registros, concretamente en su uso en el módulo de Presupuestos: En la generación de Pdf desde la vista de lista no se mostraban los datos de los ítems de línea.

La solución implementada ha estado la adaptación del código ejecutado en la generación de pdf desde la vista de lista [AOS_PDF_Templates/formLetterPdf.php](https://github.com/SinergiaTIC/SinergiaCRM/blob/develop/modules/AOS_PDF_Templates/formLetterPdf.php) con el código de generación de pdf desde la vista de detalle [AOS_PDF_Templates/generatePdf.php](https://github.com/SinergiaTIC/SinergiaCRM/blob/develop/modules/AOS_PDF_Templates/generatePdf.php)

Esta adaptación sólo se aplicará a los módulos de ventas (AOS_*)

### Pruebas
1. Crear una plantilla de pdf basada en Presupuestos, que contenga ítems de línea. Como ejemplo, se adjunta el código html de una que puede ser usada en las pruebas:
```html
<div class="translate-tooltip-mtz green sm-root translate hidden_translate" style="font-family: Arial, Helvetica, sans-serif; vertical-align: middle; text-align: justify;">
<div class="header-wrapper">
<table style="width: 100%;">
<tbody>
<tr>
<td style="width: 75%;">
<h1><span style="font-size: larger;"><strong>PRESUPUESTO</strong></span></h1>
</td>
</tr>
<tr>
<td style="width: 75%;">
<p style="line-height: 1.8;"><strong>Fecha:</strong>$aos_quotes_expiration <br /> <strong>Nº Albarán: </strong> $aos_quotes_number</p>
</td>
</tr>
</tbody>
</table>
<table style="font-size: small;">
<tbody>
<tr style="font-size: 9pt; line-height: 1.6; vertical-align: middle;" valign="middle"><th style="padding: 10px; width: 60%;"><strong>PRODUCTO</strong></th><th style="padding: 10px; width: 10%; text-align: center;"><strong>UDS.</strong></th><th style="padding: 10px; width: 10%; text-align: center;"><strong>IVA</strong></th><th style="padding: 10px; width: 10%;"><strong>PRECIO</strong></th><th style="padding: 10px; width: 10%;"><strong>TOTAL</strong></th></tr>
<tr style="font-size: small; vertical-align: middle; text-align: right; line-height: 1.2;" valign="middle">
<td style="text-align: left; width: 60%;">$aos_products_quotes_name</td>
<td><span style="padding: 10px; text-align: center;">$aos_products_quotes_product_qty</span></td>
<td><span style="padding: 10px; text-align: center;">$aos_products_quotes_vat</span></td>
<td><span style="padding: 10px;">$aos_products_quotes_product_list_price €</span></td>
<td><span style="padding: 10px;">$aos_products_quotes_product_total_price €</span></td>
</tr>
<tr style="font-size: small; line-height: 1.6; text-align: right;">
<td colspan="4"><strong>Subtotal:</strong></td>
<td>$aos_quotes_subtotal_amount €</td>
</tr>
<tr style="font-size: small; line-height: 1.6; text-align: right;">
<td colspan="4"><strong>IVA:</strong></td>
<td>$aos_quotes_tax_amount €</td>
</tr>
<tr style="font-size: medium; line-height: 1.6; text-align: right;">
<td colspan="4"><strong> TOTAL (IVA incluido):</strong></td>
<td>
<p><strong>$aos_quotes_total_amount €</strong></p>
</td>
</tr>
</tbody>
</table>
</div>
</div>
```
3. Crear dos presupuestos distintos
4. Generar PDF desde la vista de detalle de cada uno de ellos
5. En la vista de lista de Presupuestos, seleccionar los dos presupuestos y generar pdf desde la opción del menú de Acción masiva
6. Verificar que los pdf generados en ambas vistas son correctos (las variables se han substituido por sus valores)

