### PR TITLE
Hotfix - General - Misma sensibilidad en minutos entre actualización masiva y la vista de Edición

### DIFF
--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -674,7 +674,11 @@ eoq;
                             break;
                         case "datetimecombo":
                             $even = !$even;
-                            $newhtml .= $this->addDatetime($displayname, $field["name"]);
+                            // STIC-Custom 20240122 PCS - Mass update datetime sensitivity same as EditView
+                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                            // $newhtml .= $this->addDatetime($displayname, $field["name"]);
+                            $newhtml .= $this->addDatetime($displayname, $field["name"],$field["display_default"]);
+                            // END STIC-Custom
                             break;
                         case "datetime":
                         case "date":
@@ -1428,13 +1432,17 @@ EOQ;
      * @param displayname Name to display in the popup window
      * @param varname name of the variable
      */
-    public function addDatetime($displayname, $varname)
+    // STIC-Custom 20240122 PCS - Mass update datetime sensitivity same as EditView
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // public function addDatetime($displayname, $varname)
+    public function addDatetime($displayname, $varname, $fieldtimeformat)
     {
+    // END STIC-Custom
         global $timedate, $app_strings, $app_list_strings, $theme, $current_user;
         // STIC-Custom 20220224 AAM - Adding slashes to avoid sintax error with single quotes. Replicating solution as in addDate() function
         // STIC#617/
         $displayname = addslashes($displayname);
-        // END STIC
+        // END STIC-Custom
         $userformat = $timedate->get_user_time_format();
         $cal_dateformat = $timedate->get_cal_date_format();
 	    $cal_fdow = $current_user->get_first_day_of_week() ? $current_user->get_first_day_of_week() : '0';
@@ -1443,7 +1451,11 @@ EOQ;
 		 
 	<span id="{$varname}_trigger" class="suitepicon suitepicon-module-calendar" onclick="return false;"></span>
 EOQ;
-        $dtscript = getVersionedScript('include/SugarFields/Fields/Datetimecombo/Datetimecombo.js');
+        // STIC-Custom 20240122 PCS - Mass update datetime sensitivity same as EditView
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // $dtscript = getVersionedScript('include/SugarFields/Fields/Datetimecombo/Datetimecombo.js');
+        $dtscript = getVersionedScript('custom/include/SugarFields/Fields/Datetimecombo/Datetimecombo.js');
+        // END STIC-Custom
         $html = <<<EOQ
 		<td scope="row" width="20%">$displayname</td>
 		<td class='dataField' width="30%"><input onblur="parseDate(this, '$cal_dateformat')" type="text" name='$varname' size="12" id='{$varname}_date' maxlength='10' value="">
@@ -1454,7 +1466,11 @@ EOQ;
 		<input type="hidden" id="{$varname}" name="{$varname}">
 		$dtscript
 		<script type="text/javascript">
-		var combo_{$varname} = new Datetimecombo(" ", "$varname", "$userformat", '','','',1);
+        // STIC-Custom 20240122 PCS - Mass update datetime sensitivity same as EditView
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // var combo_{$varname} = new Datetimecombo(" ", "$varname", "$userformat", '','','',1,);
+		var combo_{$varname} = new Datetimecombo(" ", "$varname", "$userformat", '','','',1,"$fieldtimeformat");
+        // END STIC-Custom
 		//Render the remaining widget fields
 		text = combo_{$varname}.html('');
 		document.getElementById('{$varname}_time_section').innerHTML = text;

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -675,7 +675,7 @@ eoq;
                         case "datetimecombo":
                             $even = !$even;
                             // STIC-Custom 20240122 PCS - Mass update datetime sensitivity same as EditView
-                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/79
                             // $newhtml .= $this->addDatetime($displayname, $field["name"]);
                             $newhtml .= $this->addDatetime($displayname, $field["name"],$field["display_default"]);
                             // END STIC-Custom
@@ -1433,7 +1433,7 @@ EOQ;
      * @param varname name of the variable
      */
     // STIC-Custom 20240122 PCS - Mass update datetime sensitivity same as EditView
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/79
     // public function addDatetime($displayname, $varname)
     public function addDatetime($displayname, $varname, $fieldtimeformat)
     {
@@ -1452,7 +1452,7 @@ EOQ;
 	<span id="{$varname}_trigger" class="suitepicon suitepicon-module-calendar" onclick="return false;"></span>
 EOQ;
         // STIC-Custom 20240122 PCS - Mass update datetime sensitivity same as EditView
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/79
         // $dtscript = getVersionedScript('include/SugarFields/Fields/Datetimecombo/Datetimecombo.js');
         $dtscript = getVersionedScript('custom/include/SugarFields/Fields/Datetimecombo/Datetimecombo.js');
         // END STIC-Custom
@@ -1467,7 +1467,7 @@ EOQ;
 		$dtscript
 		<script type="text/javascript">
         // STIC-Custom 20240122 PCS - Mass update datetime sensitivity same as EditView
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/79
         // var combo_{$varname} = new Datetimecombo(" ", "$varname", "$userformat", '','','',1,);
 		var combo_{$varname} = new Datetimecombo(" ", "$varname", "$userformat", '','','',1,"$fieldtimeformat");
         // END STIC-Custom


### PR DESCRIPTION
- Closes #78 

**Descripción**

Corrige el problema en el que los campos de fecha y hora en el formulario de actualización masiva no mostraban la misma sensibilidad de minutos que en la vista de edición.

**Solución implementada:**

_La solución extiende los cambios realizados en los antiguos PRs 949 y 1275._

Se modificó el archivo `include/MassUpdate.php` para que se llame  al archivo `custom/include/SugarFields/Fields/Datetimecombo/Datetimecombo.js.` Siguiendo la lógica de este archivo, se utiliza la cadena de texto **NOW** en la propiedad `display_default` para indicar si se debe mostrar el intervalo minuto a minuto en campos de tipo DateTime.

**Pruebas**

1. Acceder a Estudio / Sesiones / Campos / y editar el campo Fecha de inicio. Guardar indicando el valor NOW en la propiedad Valor por defecto. Aunque al entrar se indique NOW, guardar igualmente para que el valor por defecto cambie de now&09:00am a now.
2. Crear una o dos sesiones y comprobar que la sensibilidad en minutos de la Fecha de Inicio es de un minuto.
3. Seleccionar una o varias sesiones y pulsar en Actualización masiva.
4. Comprobar que la sensibilidad en minutos del campo Fecha de Inicio es de un minuto.
5. Ir al módulo de Inscripciones y comprobar que la sensibilidad para el campo Fecha  de inscripción no es de un minuto.