### PR TITLE
Incidencia - Emails - Evitar que se autocomplete la contraseña

### DIFF
--- a/modules/EmailMan/tpls/config.tpl
+++ b/modules/EmailMan/tpls/config.tpl
@@ -181,7 +181,11 @@ function change_state(radiobutton) {
 										<tr id="smtp_auth2">
 											<td width="20%" scope="row"><span id="mail_smtppass_label">{$MOD.LBL_MAIL_SMTPPASS}</span> <span class="required">{$APP.LBL_REQUIRED_SYMBOL}</span></td>
 											<td width="30%" >
-												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1'>
+												<!-- STIC-Custom - MHP - 20250125 - Prevent password autofill
+    											https://github.com/SinergiaTIC/SinergiaCRM/pull/84
+												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1'> --!>
+												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1' autocomplete="new-password" />
+												<!-- END STIC-Custom -->
 												<a href="javascript:void(0)" id='mail_smtppass_link' onClick="SUGAR.util.setEmailPasswordEdit('mail_smtppass')" style="display: none">{$APP.LBL_CHANGE_PASSWORD}</a>
 											</td>
 											<td width="20%">&nbsp;</td>

--- a/modules/OutboundEmailAccounts/OutboundEmailAccounts.php
+++ b/modules/OutboundEmailAccounts/OutboundEmailAccounts.php
@@ -97,7 +97,11 @@ var passwordToggle = function(elem, sel) {
 }
 </script>
 <div id="password_toggle" style="display:none;">
-	<input type="password" id="mail_smtppass" name="mail_smtppass" />
+	<!-- STIC-Custom - MHP - 20250125 - Prevent password autofill
+    https://github.com/SinergiaTIC/SinergiaCRM/pull/84
+	<input type="password" id="mail_smtppass" name="mail_smtppass" /> -->
+	<input type="password" id="mail_smtppass" name="mail_smtppass" autocomplete="new-password" />
+	<!-- END STIC-Custom -->
 </div>
 <a href="javascript:;" onclick="passwordToggle(this, '#password_toggle');">{$mod_strings['LBL_CHANGE_PASSWORD']}</a>
 


### PR DESCRIPTION
Se cierra este PR y se abre otro por que la rama contiene el carácter Ñ.