### PR TITLE
Incidencia - Emails - Evitar que se autocomplete la contraseña

### DIFF
--- a/modules/EmailMan/tpls/config.tpl
+++ b/modules/EmailMan/tpls/config.tpl
@@ -181,7 +181,11 @@ function change_state(radiobutton) {
 										<tr id="smtp_auth2">
 											<td width="20%" scope="row"><span id="mail_smtppass_label">{$MOD.LBL_MAIL_SMTPPASS}</span> <span class="required">{$APP.LBL_REQUIRED_SYMBOL}</span></td>
 											<td width="30%" >
-												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1'>
+												<!-- STIC-Custom - MHP - 20250125 - Prevent password autofill
+    											https://github.com/SinergiaTIC/SinergiaCRM/pull/84
+												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1'> --!>
+												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1' autocomplete="new-password" />
+												<!-- END STIC-Custom -->
 												<a href="javascript:void(0)" id='mail_smtppass_link' onClick="SUGAR.util.setEmailPasswordEdit('mail_smtppass')" style="display: none">{$APP.LBL_CHANGE_PASSWORD}</a>
 											</td>
 											<td width="20%">&nbsp;</td>

--- a/modules/EmailMan/tpls/config.tpl
+++ b/modules/EmailMan/tpls/config.tpl
@@ -183,7 +183,7 @@ function change_state(radiobutton) {
 											<td width="30%" >
 												<!-- STIC-Custom - MHP - 20250125 - Prevent password autofill
     											https://github.com/SinergiaTIC/SinergiaCRM/pull/84
-												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1'> --!>
+												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1'> -->
 												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1' autocomplete="new-password" />
 												<!-- END STIC-Custom -->
 												<a href="javascript:void(0)" id='mail_smtppass_link' onClick="SUGAR.util.setEmailPasswordEdit('mail_smtppass')" style="display: none">{$APP.LBL_CHANGE_PASSWORD}</a>

--- a/modules/EmailMan/tpls/config.tpl
+++ b/modules/EmailMan/tpls/config.tpl
@@ -182,7 +182,7 @@ function change_state(radiobutton) {
 											<td width="20%" scope="row"><span id="mail_smtppass_label">{$MOD.LBL_MAIL_SMTPPASS}</span> <span class="required">{$APP.LBL_REQUIRED_SYMBOL}</span></td>
 											<td width="30%" >
 												<!-- STIC-Custom - MHP - 20250125 - Prevent password autofill
-    											https://github.com/SinergiaTIC/SinergiaCRM/pull/84
+    											https://github.com/SinergiaTIC/SinergiaCRM/pull/85
 												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1'> -->
 												<input type="password" id="mail_smtppass" name="mail_smtppass" size="25" maxlength="255" tabindex='1' autocomplete="new-password" />
 												<!-- END STIC-Custom -->

--- a/modules/OutboundEmailAccounts/OutboundEmailAccounts.php
+++ b/modules/OutboundEmailAccounts/OutboundEmailAccounts.php
@@ -98,7 +98,7 @@ var passwordToggle = function(elem, sel) {
 </script>
 <div id="password_toggle" style="display:none;">
 	<!-- STIC-Custom - MHP - 20250125 - Prevent password autofill
-    https://github.com/SinergiaTIC/SinergiaCRM/pull/84
+    https://github.com/SinergiaTIC/SinergiaCRM/pull/85
 	<input type="password" id="mail_smtppass" name="mail_smtppass" /> -->
 	<input type="password" id="mail_smtppass" name="mail_smtppass" autocomplete="new-password" />
 	<!-- END STIC-Custom -->

--- a/modules/OutboundEmailAccounts/OutboundEmailAccounts.php
+++ b/modules/OutboundEmailAccounts/OutboundEmailAccounts.php
@@ -97,7 +97,11 @@ var passwordToggle = function(elem, sel) {
 }
 </script>
 <div id="password_toggle" style="display:none;">
-	<input type="password" id="mail_smtppass" name="mail_smtppass" />
+	<!-- STIC-Custom - MHP - 20250125 - Prevent password autofill
+    https://github.com/SinergiaTIC/SinergiaCRM/pull/84
+	<input type="password" id="mail_smtppass" name="mail_smtppass" /> -->
+	<input type="password" id="mail_smtppass" name="mail_smtppass" autocomplete="new-password" />
+	<!-- END STIC-Custom -->
 </div>
 <a href="javascript:;" onclick="passwordToggle(this, '#password_toggle');">{$mod_strings['LBL_CHANGE_PASSWORD']}</a>
 


### PR DESCRIPTION
Se detecta, tanto en la vista de **Configuración General de Email** como en la vista de edición del módulo de **Cuentas de correo salientes**, que si el navegador tiene almacenada la contraseña, el autocompletado de este campo se realiza ya que a pesar de que aparece el enlace de **Cambiar Contraseña** y parece que el input de tipo password no forma parte del formulario, este si se encuentra pero con la propiedad `display: none`. 

Si la contraseña guardada en el navegador está desactualizada o es errónea, al realizarse el autocompletado de la  contraseña  genera que se produzca un error de autenticación en el envío del correo de prueba aunque visiblemente se vea el enlace de **Cambiar contraseña**.  

Este PR resuelve esta incidencia haciendo que no se realice ese autocompletado a través de añadir la propiedad `autocomplete='new-password'` al campo de tipo password. 


Esta incidencia también se reproduce en SuiteCRM aunque hemos comprobado que en la versión 7.14.2, donde SA ha realizado cambios profundos en los módulos de Emails, la incidencia del módulo de **Cuentas de correo salientes** no se soluciona como en este PR y se puede solucionar de la siguiente manera: 

- En el fichero: modules/OutboundEmailAccounts/vardefs.php --> Añadir la siguiente propiedad al campo `mail_smtppass` en la línea 286: `'autocomplete' => 'new-password',`
 
- En el fichero: include/SugarFields/Fields/Password/EditView.tpl --> Añadir la siguiente propiedad en la línea 51: `autocomplete='{{$vardef.autocomplete}}'`


**Pruebas**

1. Acceder a la Vista de **Configuración General de Email** y guardar una primera configuración con la contraseña correcta + almacenar la contraseña en el navegador (Tras guardar el registro suele mostrarse un cuadro de dialogo para almacenar el usuario y la contraseña en el navegador) 
2. Salir del registro y volver a acceder. Pulsar en el botón de **Cambiar contraseña** y comprobar que no se recupera la contraseña aunque esta esté almacenada en el navegador. 
3. Ir al módulo de **Cuentas de correo salientes** y acceder a la vista de edición del registros de system. Pulsar en el botón de **Cambiar contraseña** y comprobar que tampoco se recupera la contraseña aunque esta esté almacenada en el navegador. 
4. Salir del registro
5. Acceder al gestor de contraseñas del navegador y modificar la contraseña a una errónea. 
6. Acceder a ambas vistas de edición y, con el input de contraseña "oculto" y mostrándose el texto de "Cambiar Contraseña", comprobar que el envío de prueba se realiza correctamente ya que debe recuperar la contraseña de la base de datos. 


