### PR TITLE
Hotfix - Organizaciones - El * del campo Name se mantenía aunque el campo no fuese requerido

### DIFF
--- a/custom/modules/Accounts/metadata/editviewdefs.php
+++ b/custom/modules/Accounts/metadata/editviewdefs.php
@@ -96,10 +96,6 @@ array (
           array (
             'name' => 'name',
             'label' => 'LBL_NAME',
-            'displayParams' => 
-            array (
-              'required' => true,
-            ),
           ),
           1 => 
           array (


### PR DESCRIPTION
- Closes #94 

## Descripción
En los ficheros modules/Accounts/metadata/editviewdefs.php y custom/modules/Accounts/metadata/editviewdefs.php la definición correspondiente al campo name incluía un displayParams que marcaba el campo como requerido. Se ha eliminado dicha asignación en el fichero custom de manera que futuras instancias ya no incorporarán el error.
Se descarta aplicar un script que intente reparar los editviewdefs existentes ya que las ocasiones en que este campo no se quiera obligatorio seránminoritarías.

## Pruebas
1. Mediante estudio marcar el campo name de Organizaciones como no requerido
2. Acceder a la creación de organización y comprobar que el asterisco ya no aparece al lado de la etiqueta "Nombre"
