### PR TITLE
Hotfix - Formularios - Tratamiento de apóstrofes en el nombre de la Organización

### DIFF
--- a/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionBO.php
+++ b/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionBO.php
@@ -492,7 +492,9 @@ class EventInscriptionBO extends WebFormDataBO
         if ($ret == self::ACCOUNT_ERROR) // This indicates that it has not been found yet.
         {
             $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Retrieving list of named organizations = [{$name}] ...");
-            $objCandidates = $accounts->get_full_list("name", "accounts.name = '{$name}'");
+            $db = DBManagerFactory::getInstance();
+            $sqlName = $db->quote($name);
+            $objCandidates = $accounts->get_full_list("name", "accounts.name = '{$sqlName}'");
 
             $nCandidates = count($objCandidates); // Count the number of results obtained
             $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Found {$nCandidates} candidates.");


### PR DESCRIPTION
- Closes #96 

## Descripción
Cuando no se rellena el NIF de la organización, se hace una búsqueda por nombre de la organización.
El problema era que en la SQL para realizar la búsqueda se insertaba directamente el $name recuperado del formulario. Se ha modificado para utilizar préviamente la función _quote_ que realiza un escapado de carácteres especiales.

## Pruebas
1. Crear un formulario de inscripción a eventos que contenga campos de organización (no el NIF)
2. Introducir vía el formulario una organización cuyo nombre contenga un apóstrofe
3. Repetir el envío del formulario
4. Comprobar que la organización no se duplica

