### PR TITLE
Incidencia - Flujos de trabajo - Formateo de hora en campos calculados que no usan funciones de fecha.

### DIFF
--- a/modules/AOW_Actions/actions/actionComputeField.php
+++ b/modules/AOW_Actions/actions/actionComputeField.php
@@ -199,7 +199,7 @@ class actionComputeField extends actionBase
                     $resolvedParameters[$i] = "";
                 } 
                 // STIC-Custom 20230212 PCS - Format datetime fields in compute field actions when not using formulas.
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/113
                 if($type == 'datetimecombodatetime'){
                    global $timedate;
                    $resolvedParameters[$i] = $timedate->to_display_date_time($bean->{$parameters[$i]});

--- a/modules/AOW_Actions/actions/actionComputeField.php
+++ b/modules/AOW_Actions/actions/actionComputeField.php
@@ -197,6 +197,13 @@ class actionComputeField extends actionBase
                 }                
                 if ($bean->{$parameters[$i]} == null) {
                     $resolvedParameters[$i] = "";
+                } 
+                // STIC-Custom 20230212 PCS - Format datetime fields in compute field actions when not using formulas.
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                if($type == 'datetimecombodatetime'){
+                   global $timedate;
+                   $resolvedParameters[$i] = $timedate->to_display_date_time($bean->{$parameters[$i]});
+                // END STIC-Custom
                 } elseif (
                     (strpos($type, 'char') !== false || strpos($type, 'text') !== false || $type == 'enum') &&
                     !empty($bean->{$parameters[$i]})


### PR DESCRIPTION
- Closes #112 

## Descripción
En los flujos de trabajo, al realizar una acción de campos calculados sin utilizar fórmulas para los campos de fecha y hora, estos se mostraban en el formato de base de datos en lugar de respetar el formato de hora del perfil de usuario. Por otro lado, si se utiliza alguna fórmula, como date(), en este proceso, la fecha se formatea correctamente. Esto llevaba a usar fórmulas que no realizaran ninguna operación {addHours(Y-m-d H:i:s;{P0};0)} para evitar errores.
 
## Pruebas
1. Crear un FdT en Sesiones que se ejecute "Al guardar" en "Todos los registros".
2. En el FdT, agregar la acción "Campos calculados" con el nombre (P0) y el campo "fecha de inicio (P1)". Fórmula: {P0} {P1}.
3. Comprobar que al guardar una Sesión, la descripción se rellena con la fecha en el formato correcto (el mismo que la fecha original).

## Cambios realizados.
Se ha modificado la función `resolveParameters($bean, $parameters, $parameterTypes)` para que, si el tipo es datetimecombo, se realice un formateo de fecha. Anteriormente se pasaba como dato directamente la fecha de la base de datos sin formatear.