### PR TITLE
Hotfix - Objetivos - Arrastrar persona/familia en subpaneles de Objetivos

### DIFF
--- a/modules/stic_Goals/Utils.js
+++ b/modules/stic_Goals/Utils.js
@@ -324,10 +324,10 @@ function getContactOrFamilyAsync(assessmentId, callbackFunction) {
 }
 
 // Utility function to extract params from the URL
-$.urlParam = function(name){
-	var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(window.location.href);
-	return results[1] || 0;
-}
+// $.urlParam = function(name){
+// 	var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(window.location.href);
+// 	return results[1] || 0;
+// }
 
 $(document).ready(() => {
   // Redefine set_return function to act upon receiving value from popup
@@ -345,11 +345,8 @@ $(document).ready(() => {
     };
   }
 
-  const sticModule = $.urlParam('module');
-  const sticAction = $.urlParam('action');
-  
   // We look for the assessment person or family only if we are at Assessment view
-  if (sticModule == 'stic_Assessments') {
+  if (currentModule == 'stic_Assessments') {
     // Check assessment on page load in case we are at quick create goal from assessment
     let assessmentId = $('#stic_goals_stic_assessmentsstic_assessments_ida').val();
     if (assessmentId != null && assessmentId != '') {
@@ -367,7 +364,7 @@ $(document).ready(() => {
 
   // If we are in stic_Goals DetailView and that fields exist, it's beacause we are in goals subpanel
   // We take Persona and Family from parent Goal.
-  if (sticModule == 'stic_Goals' && sticAction == 'DetailView' &&
+  if (currentModule == 'stic_Goals' && viewType() == 'quickcreate' &&
       ($("#stic_goals_contacts_name").length > 0 || $("#stic_families_stic_goals_name").length)) {
     const personaName = $("span#stic_goals_contactscontacts_ida").text();
     const personaId = $('span#stic_goals_contactscontacts_ida').attr('data-id-value');

--- a/modules/stic_Goals/Utils.js
+++ b/modules/stic_Goals/Utils.js
@@ -335,7 +335,6 @@ $(document).ready(() => {
     // only redefine the function if it is not already redefined
     old_set_return = set_return;
     set_return = function (popup_reply_data) {
-      debugger;
       old_set_return(popup_reply_data);
       // After 1/2 second, we activate the goalchanged event. If called before, the confirm action is not execute due to security issues
       // Only call when the assessment has been changed and not on other changes

--- a/modules/stic_Goals/Utils.js
+++ b/modules/stic_Goals/Utils.js
@@ -266,7 +266,6 @@ function removeCustomRelationManyToMany(subpanelName, goalId) {
 YAHOO.util.Event.addListener('stic_goals_stic_assessmentsstic_assessments_ida','change',goalchanged);
 
 function goalchanged() {
-  console.log('@@@@@@@@');
   let assessmentName = $('#stic_goals_stic_assessments_name').val();
   let assessmentId = $('#stic_goals_stic_assessmentsstic_assessments_ida').val();
   // We check the name and not the id because when removed manually the name, the id is not automatically cleared
@@ -310,7 +309,6 @@ function getContactOrFamilyAsync(assessmentId, callbackFunction) {
       "assessmentId": assessmentId
     },
     success: function(resultado) {
-      console.log(resultado);
       if (resultado.code == 'OK') {
         callbackFunction(resultado.data);
       }
@@ -333,7 +331,6 @@ $.urlParam = function(name){
 
 $(document).ready(() => {
   // Redefine set_return function to act upon receiving value from popup
-  console.log(typeof old_set_return);
   if (typeof old_set_return === 'undefined'){
     // only redefine the function if it is not already redefined
     old_set_return = set_return;
@@ -361,7 +358,6 @@ $(document).ready(() => {
         if(contactOrFamily!= null) {
           Object.entries(contactOrFamily).forEach((element) => {
             const [key, value] = element;
-            console.log(key, value);
             $('#' + key).val(value);
           });
         }

--- a/modules/stic_Goals/Utils.js
+++ b/modules/stic_Goals/Utils.js
@@ -266,6 +266,7 @@ function removeCustomRelationManyToMany(subpanelName, goalId) {
 YAHOO.util.Event.addListener('stic_goals_stic_assessmentsstic_assessments_ida','change',goalchanged);
 
 function goalchanged() {
+  console.log('@@@@@@@@');
   let assessmentName = $('#stic_goals_stic_assessments_name').val();
   let assessmentId = $('#stic_goals_stic_assessmentsstic_assessments_ida').val();
   // We check the name and not the id because when removed manually the name, the id is not automatically cleared
@@ -337,9 +338,13 @@ $(document).ready(() => {
     // only redefine the function if it is not already redefined
     old_set_return = set_return;
     set_return = function (popup_reply_data) {
+      debugger;
       old_set_return(popup_reply_data);
       // After 1/2 second, we activate the goalchanged event. If called before, the confirm action is not execute due to security issues
-      // setTimeout(() => {goalchanged();}, 500);
+      // Only call when the assessment has been changed and not on other changes
+      if (popup_reply_data.name_to_value_array.stic_goals_stic_assessmentsstic_assessments_ida !== 'undefined'){
+        setTimeout(() => {goalchanged();}, 500);
+      }
     };
   }
 


### PR DESCRIPTION
- Closes #109 

## Description
En el PR en que se añadió la funcionalidad para asignar por defecto la persona o familia de la Valoración a los objetivos relacionados con la misma (https://github.com/SinergiaTIC/SinergiaCRM-SuiteCRM/pull/1230) no se tuvo en cuenta que en la propia vista de Objetivos también es posible crear otros objetivos mediante subpanel, y que ahí estaría bien arrastras la persoan / familia del objetivo origen. 

Se ha modificado el JS para tratar este caso y se ha aprovechado para mejorar algunos aspectos del JS anterior.

## Motivation and Context
Cuando un objetivo se crea a partir de otro objetivo, la persona / familia será compartida y ahora mismo se estaba obligando a los usuarios a entrar manualmente cada vez la misma persona o familia.

## How To Test This
1. Ir a Objetivos
2. Crear un objetivo relacionándolo con una familia o persona
3. Crear objetivos "Convertido a" y/o "Convertido desde"
4. Comprobar que se arrastra la persona / familia del objetivo padre
5. Comprobar que se puede modificar manualmente la familia / persona asignada
6. Ir a Valoraciones y comprobar que sigue funcionando la fucionalidad del PR anterior (STIC#1230)

