### PR TITLE
Feature - SinergiaDA - Varias mejoras en Script de reconstrucción

### DIFF
--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -266,7 +266,7 @@ class ExternalReporting
 
             // Get module bean for use later
             $moduleBean = BeanFactory::getBean($moduleName);
-            
+
             // recover module labels
             $modStrings = return_module_language($this->langCode, $moduleName);
 
@@ -291,8 +291,10 @@ class ExternalReporting
                     continue;
                 }
 
-                // If field is in detailview, set as visible, hidden if not.
-                if (in_array($fieldV['name'], $detailViewVisibleFields) || $fieldV['name'] == 'id') {
+                // Conditionally controls the visibility of fields in the detail view:
+                // * Shows fields present in the detail view.
+                // * Always shows the "full_name" & "id" field, regardless of its presence in the detail view.
+                if (in_array($fieldV['name'], $detailViewVisibleFields) || in_array($fieldV['name'], ['id', 'full_name'])) {
                     $sdaHiddenField = false;
                 } else {
                     $sdaHiddenField = true;
@@ -300,7 +302,6 @@ class ExternalReporting
 
                 $fieldV['label'] = $this->sanitizeText($modStrings[$fieldV['vname']]);
 
-                
                 // Attempts to assign a translated label to the field.
                 // If no translation is found, it tries to translate it directly.
                 // The field is skipped if no translation is obtained.

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -266,7 +266,9 @@ class ExternalReporting
 
             // Get module bean for use later
             $moduleBean = BeanFactory::getBean($moduleName);
-
+            // if($moduleName=='stic_Sessions'){
+            //     var_dump($moduleBean->getFieldDefinitions());die();
+            // }
             // recover module labels
             $modStrings = return_module_language($this->langCode, $moduleName);
 
@@ -309,7 +311,7 @@ class ExternalReporting
                     if (!empty($directTranslate)) {
                         $fieldV['label'] = $this->sanitizeText($directTranslate);
                     } else {
-                    continue;
+                        continue;
                     }
                 }
 
@@ -424,13 +426,7 @@ class ExternalReporting
                                  *    if it's a 'Person' type module.
                                  *    This column allows for easy use of the related record's name, without the
                                  *    need for establishing additional relationships.
-                                 * 3) Fields related to the module itself are omitted since they cannot be represented in EDA,
-                                 *    and using subqueries to display the name of the related record would negatively impact performance.
                                  */
-
-                                if ($fieldV['module'] == $moduleName) {
-                                    continue 2;
-                                }
 
                                 $secureName = preg_replace('([^A-Za-z0-9])', '_', $app_list_strings['moduleList'][$fieldV['module']]) . ' (' . $fieldV['label'] . ')';
 
@@ -1539,7 +1535,7 @@ class ExternalReporting
                  '{$listElement['code']}' as 'code'
                  FROM
                     {$multiField['source_table']}
-                 WHERE ({$multiField['source_column']} LIKE '%^{$listElement['code']}^%' OR {$multiField['source_column']} = '{$listElement['code']}') 
+                 WHERE ({$multiField['source_column']} LIKE '%^{$listElement['code']}^%' OR {$multiField['source_column']} = '{$listElement['code']}')
                  ";
             }
 

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -300,9 +300,17 @@ class ExternalReporting
 
                 $fieldV['label'] = $this->sanitizeText($modStrings[$fieldV['vname']]);
 
-                // If there is no translation for the label we go to the next and do not include the field
+                
+                // Attempts to assign a translated label to the field.
+                // If no translation is found, it tries to translate it directly.
+                // The field is skipped if no translation is obtained.
                 if (empty($fieldV['label']) && $fieldV['name'] != 'id') {
+                    $directTranslate = translate($fieldV['vname'], $fieldV['module']);
+                    if (!empty($directTranslate)) {
+                        $fieldV['label'] = $this->sanitizeText($directTranslate);
+                    } else {
                     continue;
+                    }
                 }
 
                 // There are some exceptions that must be applied in specific modules that have not been seen how to solve otherwise

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -266,9 +266,7 @@ class ExternalReporting
 
             // Get module bean for use later
             $moduleBean = BeanFactory::getBean($moduleName);
-            // if($moduleName=='stic_Sessions'){
-            //     var_dump($moduleBean->getFieldDefinitions());die();
-            // }
+            
             // recover module labels
             $modStrings = return_module_language($this->langCode, $moduleName);
 


### PR DESCRIPTION
Se añaden varias mejoras en el script de reconstrucción de origen de datos de SinergiaDA:

**1. Habilitación de autorelaciones mediante campos relacionados:**

* **Situación anterior:** Las autorelaciones (mismo módulo) de todo tipo estaban deshabilitadas.
* **Mejora:** Se habilitan las autorelaciones mediante campos relacionados, mostrando el nombre del registro en el otro lado de la relación.
* **Limitaciones:** Los demás campos del módulo correspondientes al registro relacionado aún no pueden mostrarse en SinergiaDA debido a limitaciones actuales de la plataforma.
* **Pruebas a realizar:** Crear un campo relacionado con el propio módulo y verificar que se ha incluido en la vista del módulo generada tras la reconstrucción.

**2. Visibilidad del campo _Nombre completo_:**

* **Situación anterior:** El nombre completo de los módulos del tipo Persona (Interesados, Personas y Usuarios,...) se incluía, pero se establecía como oculto en SinergiaDA si en SinergiaCRM el campo no estaba incluido en la vista de detalle (situación habitual por la compatibilidad con la edición inline).
* **Mejora:** Se fuerza la inclusión del campo _Nombre completo_ como visible en los módulos que lo tienen.
* **Pruebas a realizar:** Tras la reconstrucción, verificar que el campo _Nombre completo_ se ha incluido como visible. En la tabla _sda_def_columns_, este campo debe aparecer con la columna _hidden_ a `0`.

**3. Inclusión de campos sin etiqueta válida:**

* **Situación anterior:** Se omitían los campos de un módulo que no tenían una etiqueta válida en el idioma de la instancia de SinergiaCRM.
* **Mejora:** Se asegura que todos los campos se incluyen, incluso si no tienen una etiqueta válida. Se mostrarán con el valor interno de la etiqueta, al igual que en SinergiaCRM.
* **Pruebas a realizar:** Crear un campo de cualquier tipo en estudio y eliminar la etiqueta correspondiente, de manera que en SinergiaCRM debe verse como _LBL_NOMBRE_DEL_CAMPO_. Verificar que tras la reconstrucción el campo está disponible en SinergiaDA con la misma etiqueta.
