### PR TITLE
Hotfix - KReporter - Cambiar nombre lista

### DIFF
--- a/custom/Extension/application/Ext/Language/ca_ES.KReporterCore.php
+++ b/custom/Extension/application/Ext/Language/ca_ES.KReporterCore.php
@@ -28,5 +28,5 @@ $app_list_strings['kreportstatus']['2'] = 'Distribució limitada';
 $app_list_strings['kreportstatus']['3'] = 'Distribució general';
 
 $app_list_strings['stic_kreports_segmentations_list'][''] = '';
-$app_list_strings['stic_kreports_segmentations_list']['sample_value_1'] = "Valor d'exemple 1";
-$app_list_strings['stic_kreports_segmentations_list']['sample_value_2'] = "Valor d'exemple 2";
+$app_list_strings['stic_kreports_segmentations_list']['sample_value_1'] = "Valor exemple 1";
+$app_list_strings['stic_kreports_segmentations_list']['sample_value_2'] = "Valor exemple 2";


### PR DESCRIPTION


## Description
La etiqueta en catalán genera problemas por lo que se ha cambiado de `Valor d'exemple 1` a `Valor exemple 1`
