### PR TITLE
Enhancement - Home / Calendario - Hacer visibles las flechas del dashlet del calendario

### DIFF
--- a/custom/modules/Calendar/tpls/header.tpl
+++ b/custom/modules/Calendar/tpls/header.tpl
@@ -143,4 +143,14 @@
 	<div style='float: left; width: 60%; text-align: center;'><h3>{$date_info}</h3></div>
 	<div style='float: right;'>{$next}</div>
 	<br style='clear:both;'>
+	{* STIC-custom 20240222 ART -  *}
+    {* https://github.com/SinergiaTIC/SinergiaCRM/pull/ *}
+    {literal}
+        <style>
+            .dashletPanel #rect3120, .dashletPanel #rect3124{
+                fill: #474f50 !important;
+            }
+        </style>
+    {/literal}
+    {* END STIC *}
 </div>

--- a/custom/modules/Calendar/tpls/header.tpl
+++ b/custom/modules/Calendar/tpls/header.tpl
@@ -137,20 +137,20 @@
 
 {/if}
 
+{* STIC-custom 20240222 ART - Make the arrows of the calendar dashlet visible *}
+{* https://github.com/SinergiaTIC/SinergiaCRM/pull/136 *}
+{literal}
+	<style>
+		.dashletPanel #rect3120, .dashletPanel #rect3124{
+			fill: #474f50 !important;
+		}
+	</style>
+{/literal}
+{* END STIC *}
 
 <div class="{if $controls}monthHeader{/if}">
 	<div style='float: left; width: 20%;'>{$previous}</div>
 	<div style='float: left; width: 60%; text-align: center;'><h3>{$date_info}</h3></div>
 	<div style='float: right;'>{$next}</div>
 	<br style='clear:both;'>
-	{* STIC-custom 20240222 ART - Make the arrows of the calendar dashlet visible *}
-    {* https://github.com/SinergiaTIC/SinergiaCRM/pull/136 *}
-    {literal}
-        <style>
-            .dashletPanel #rect3120, .dashletPanel #rect3124{
-                fill: #474f50 !important;
-            }
-        </style>
-    {/literal}
-    {* END STIC *}
 </div>

--- a/custom/modules/Calendar/tpls/header.tpl
+++ b/custom/modules/Calendar/tpls/header.tpl
@@ -143,8 +143,8 @@
 	<div style='float: left; width: 60%; text-align: center;'><h3>{$date_info}</h3></div>
 	<div style='float: right;'>{$next}</div>
 	<br style='clear:both;'>
-	{* STIC-custom 20240222 ART -  *}
-    {* https://github.com/SinergiaTIC/SinergiaCRM/pull/ *}
+	{* STIC-custom 20240222 ART - Make the arrows of the calendar dashlet visible *}
+    {* https://github.com/SinergiaTIC/SinergiaCRM/pull/136 *}
     {literal}
         <style>
             .dashletPanel #rect3120, .dashletPanel #rect3124{


### PR DESCRIPTION
- Closes #133 

**Desarrollo del issue**
Cuando se agrega el calendario a la pestaña de Inicio, no se muestran las flechas para cambiar entre semanas aunque si que hace la función. En cambio, en SuiteCRM sí que se muestran dichas flechas.

**Solución implementada:**
Se ha implementado el color a dichas flechas, solamente las del dashlet.

**Pruebas**
1. Agregar el dashlet de Calendario a Inicio.
2. Comprobar que se ven y que el funcionamiento es el correcto.
3. Comprobar que las flechas del módulo de Calendario no se han cambiado de color.