### PR TITLE
Improvement - Remesas - Ajuste de validaciones en generación de ficheros

### DIFF
--- a/modules/stic_Remittances/GenerateSEPACreditTransfers.php
+++ b/modules/stic_Remittances/GenerateSEPACreditTransfers.php
@@ -199,7 +199,7 @@ function generateSEPACreditTransfers($remittance)
                 ->setCreditorIBAN(trim($paymentResult['bank_account']))
                 ->setCreditorName($receptorName)
                 ->setEndToEndId(str_replace('-', '', $paymentResult['id']))
-                ->setRemittanceInformation(SticUtils::cleanText(trim($finalConcept)));
+                ->setRemittanceInformation(SticUtils::cleanText(trim(substr($finalConcept, 0, 140))));
             $paymentInformation->addPayments($paymentXML);
 
             // We update totals of amount and number of operations

--- a/modules/stic_Remittances/GenerateSEPACreditTransfers.php
+++ b/modules/stic_Remittances/GenerateSEPACreditTransfers.php
@@ -197,7 +197,7 @@ function generateSEPACreditTransfers($remittance)
                 ->setCreditorIBAN(trim($paymentResult['bank_account']))
                 ->setCreditorName($receptorName)
                 ->setEndToEndId(str_replace('-', '', $paymentResult['id']))
-                ->setRemittanceInformation(SticUtils::cleanText(trim(substr($finalConcept, 0, 140))));
+                ->setRemittanceInformation(SticUtils::cleanText(trim(mb_substr($finalConcept, 0, 140))));
             $paymentInformation->addPayments($paymentXML);
 
             // We update totals of amount and number of operations

--- a/modules/stic_Remittances/GenerateSEPACreditTransfers.php
+++ b/modules/stic_Remittances/GenerateSEPACreditTransfers.php
@@ -81,10 +81,8 @@ function generateSEPACreditTransfers($remittance)
         SticUtils::showErrorMessagesAndDie($remittance, $mod_strings['LBL_MISSING_SEPA_VARIABLES'] . ' <br>' . join('<br>', $missingSettings));
     }
 
-    // Checking the length of GENERAL_ORGANIZATION_NAME
-    if (strlen($directCreditsVars['GENERAL_ORGANIZATION_NAME']) > 70) {
-        SticUtils::showErrorMessagesAndDie($remittance, $mod_strings['LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG'] . ' <br>' . join('<br>', $missingSettings));
-    }
+    // Truncate GENERAL_ORGANIZATION_NAME to 70 characters as allowed
+    $directCreditsVars['GENERAL_ORGANIZATION_NAME'] = substr($directCreditsVars['GENERAL_ORGANIZATION_NAME'],0,70);
 
     // We start variables to count and add the total payments to be made (and then indicate them in the header)
     $controlSum = 0;

--- a/modules/stic_Remittances/GenerateSEPACreditTransfers.php
+++ b/modules/stic_Remittances/GenerateSEPACreditTransfers.php
@@ -27,7 +27,8 @@
  * @param Object $remittance Corresponds to the $this object of the corresponding action of the module controller.php file, from which this function is invoked, including the View and the Bean of the remittance
  * @return void
  */
-function generateSEPACreditTransfers($remittance) {
+function generateSEPACreditTransfers($remittance)
+{
     /**
      * This function generates a remittance of SEPA bank transfers in XML format.
      * Based on the Credit Transfer SEPA library:
@@ -78,6 +79,11 @@ function generateSEPACreditTransfers($remittance) {
 
     if (count($missingSettings) > 0) {
         SticUtils::showErrorMessagesAndDie($remittance, $mod_strings['LBL_MISSING_SEPA_VARIABLES'] . ' <br>' . join('<br>', $missingSettings));
+    }
+
+    // Checking the length of GENERAL_ORGANIZATION_NAME
+    if (strlen($directCreditsVars['GENERAL_ORGANIZATION_NAME']) > 70) {
+        SticUtils::showErrorMessagesAndDie($remittance, $mod_strings['LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG'] . ' <br>' . join('<br>', $missingSettings));
     }
 
     // We start variables to count and add the total payments to be made (and then indicate them in the header)

--- a/modules/stic_Remittances/GenerateSEPACreditTransfers.php
+++ b/modules/stic_Remittances/GenerateSEPACreditTransfers.php
@@ -81,8 +81,8 @@ function generateSEPACreditTransfers($remittance)
         SticUtils::showErrorMessagesAndDie($remittance, $mod_strings['LBL_MISSING_SEPA_VARIABLES'] . ' <br>' . join('<br>', $missingSettings));
     }
 
-    // Truncate GENERAL_ORGANIZATION_NAME to 70 characters as allowed
-    $directCreditsVars['GENERAL_ORGANIZATION_NAME'] = substr($directCreditsVars['GENERAL_ORGANIZATION_NAME'],0,70);
+    // Truncate & clean GENERAL_ORGANIZATION_NAME to 70 characters as allowed
+    $directCreditsVars['GENERAL_ORGANIZATION_NAME'] = mb_substr(trim(SticUtils::cleanText($directCreditsVars['GENERAL_ORGANIZATION_NAME'])), 0, 70, 'UTF-8');
 
     // We start variables to count and add the total payments to be made (and then indicate them in the header)
     $controlSum = 0;
@@ -217,7 +217,7 @@ function generateSEPACreditTransfers($remittance)
         // Group Header
         $groupHeader = new \Sepa\CreditTransfer\GroupHeader();
         $groupHeader->setControlSum(number_format($controlSum, 2, '.', ''))
-            ->setInitiatingPartyName(mb_substr(trim(SticUtils::cleanText($directCreditsVars['GENERAL_ORGANIZATION_NAME'])), 0, 70, 'UTF-8'))
+            ->setInitiatingPartyName($directCreditsVars['GENERAL_ORGANIZATION_NAME'])
             ->setMessageIdentification('SEPACREDIT' . time())
             ->setInitiatingPartyOrgIdOthrId(SticUtils::cleanText($directCreditsVars['SEPA_TRANSFER_DEBITOR_IDENTIFIER']))
             ->setNumberOfTransactions($controlNumOperations);
@@ -228,7 +228,7 @@ function generateSEPACreditTransfers($remittance)
         // We add the total number of operations and the total amount in the header of the consignment
         $paymentInformation
             ->setDebtorIBAN(trim($remittance->bean->bank_account))
-            ->setDebtorName(trim(SticUtils::cleanText($directCreditsVars['GENERAL_ORGANIZATION_NAME'])))
+            ->setDebtorName($directCreditsVars['GENERAL_ORGANIZATION_NAME'])
             ->setPaymentInformationIdentification(str_replace('-', '', $remittance->bean->id))
             ->setRequestedExecutionDate(date('Y-m-d', strtotime(str_replace('/', '-', $remittance->bean->charge_date))))
             ->setControlSum(number_format($controlSum, 2, '.', ''))

--- a/modules/stic_Remittances/GenerateSEPADirectDebits.php
+++ b/modules/stic_Remittances/GenerateSEPADirectDebits.php
@@ -194,7 +194,7 @@ function generateSEPADirectDebits($remittance) {
         !verify_iban($paymentResult['bank_account'], true) === true ? $errorMsg .= '<p class="msg-error">' . $mod_strings['LBL_SEPA_INVALID_IBAN'] . " " . stic_RemittancesUtils::goToEdit('stic_Payments', $paymentResult['id'], $paymentResult['name']) : '';
 
         // 4) That the mandate is set and is valid
-        empty($paymentResult['mandate']) || $paymentResult['mandate'] == '' || strlen($paymentResult['mandate']) > 35 ? $errorMsg .= '<p class="msg-error">' . $mod_strings['LBL_SEPA_DEBIT_INVALID_MANDATE'] . " " . stic_RemittancesUtils::goToEdit('stic_Payments', $paymentResult['id'], $paymentResult['name']) : '';
+        empty($paymentResult['mandate']) || $paymentResult['mandate'] == '' || strlen($paymentResult['mandate']) > 35 || strpos($paymentResult['mandate'], ' ') !== false  ? $errorMsg .= '<p class="msg-error">' . $mod_strings['LBL_SEPA_DEBIT_INVALID_MANDATE'] . " " . stic_RemittancesUtils::goToEdit('stic_Payments', $paymentResult['id'], $paymentResult['name']) : '';
 
         // 5) That the date of signature of the mandate exists
         $sqlSignatureDate = "SELECT

--- a/modules/stic_Remittances/GenerateSEPADirectDebits.php
+++ b/modules/stic_Remittances/GenerateSEPADirectDebits.php
@@ -96,10 +96,8 @@ function generateSEPADirectDebits($remittance)
         SticUtils::showErrorMessagesAndDie($remittance, $mod_strings['LBL_MISSING_SEPA_VARIABLES'] . ' <br>' . join('<br>', $missingSettings));
     }
 
-    // Checking the length of GENERAL_ORGANIZATION_NAME
-    if (strlen($directDebitsVars['GENERAL_ORGANIZATION_NAME']) > 70) {
-        SticUtils::showErrorMessagesAndDie($remittance, $mod_strings['LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG'] . ' <br>' . join('<br>', $missingSettings));
-    }
+   // Truncate GENERAL_ORGANIZATION_NAME to 70 characters as allowed
+   $directDebitsVars['GENERAL_ORGANIZATION_NAME'] = substr($directDebitsVars['GENERAL_ORGANIZATION_NAME'],0,70);
 
     $message = new SEPAMessage('urn:iso:std:iso:20022:tech:xsd:pain.008.001.02');
 

--- a/modules/stic_Remittances/GenerateSEPADirectDebits.php
+++ b/modules/stic_Remittances/GenerateSEPADirectDebits.php
@@ -96,6 +96,11 @@ function generateSEPADirectDebits($remittance)
         SticUtils::showErrorMessagesAndDie($remittance, $mod_strings['LBL_MISSING_SEPA_VARIABLES'] . ' <br>' . join('<br>', $missingSettings));
     }
 
+    // Checking the length of GENERAL_ORGANIZATION_NAME
+    if (strlen($directDebitsVars['GENERAL_ORGANIZATION_NAME']) > 70) {
+        SticUtils::showErrorMessagesAndDie($remittance, $mod_strings['LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG'] . ' <br>' . join('<br>', $missingSettings));
+    }
+
     $message = new SEPAMessage('urn:iso:std:iso:20022:tech:xsd:pain.008.001.02');
 
     // Header of the remittance

--- a/modules/stic_Remittances/language/ca_ES.lang.php
+++ b/modules/stic_Remittances/language/ca_ES.lang.php
@@ -89,7 +89,6 @@ $mod_strings = array (
     'LBL_SEPA_WITHOUT_CONTACT_OR_ACCOUNT' => 'No hi ha cap persona o organització relacionada al pagament: ',
     'LBL_SEPA_XML_HAS_ERRORS' => "El fitxer XML no s'ha generat perquè hi ha errors que cal corregir.",
     'LBL_MISSING_SEPA_VARIABLES' => "Alguns paràmetres de configuració necessaris per a la generació de remeses no tenen valor. Reviseu-los a l'àrea d'administració del CRM abans de continuar:",
-    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'El valor del paràmetre de configuració <b>GENERAL_ORGANIZATION_NAME</b> excedeix els 70 caràcters permesos.',
     
     // Missatges SEPA per a transferències
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'El fitxer no es pot generar perquè el seu tipus hauria de ser <b>transferències emeses</b>.',

--- a/modules/stic_Remittances/language/ca_ES.lang.php
+++ b/modules/stic_Remittances/language/ca_ES.lang.php
@@ -94,6 +94,7 @@ $mod_strings = array (
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'El fitxer no es pot generar perquè el seu tipus hauria de ser <b>transferències emeses</b>.',
 
     // Missatges SEPA per a rebuts
+    'LBL_SEPA_DEBIT_INVALID_PAYMENT_COMMITMENT' => 'El pagament <b>no està relacionat</b> amb cap compromís de pagament: ',
     'LBL_SEPA_DEBIT_INVALID_SIGNATURE_DATE' => 'La <b>data de signatura</b> del compromís de pagament està buida: ',
     'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'El <b>mandat</b> del pagament no és vàlid. Està buit, supera els 35 caràcters o conté espais en blanc (comproveu també el compromís de pagament): ',
     'LBL_SEPA_DEBIT_INVALID_NIF' => "El <b>número d'identificació</b> (NIF, NIE...) de la persona/organització està buit: ",

--- a/modules/stic_Remittances/language/ca_ES.lang.php
+++ b/modules/stic_Remittances/language/ca_ES.lang.php
@@ -89,6 +89,7 @@ $mod_strings = array (
     'LBL_SEPA_WITHOUT_CONTACT_OR_ACCOUNT' => 'No hi ha cap persona o organització relacionada al pagament: ',
     'LBL_SEPA_XML_HAS_ERRORS' => "El fitxer XML no s'ha generat perquè hi ha errors que cal corregir.",
     'LBL_MISSING_SEPA_VARIABLES' => "Alguns paràmetres de configuració necessaris per a la generació de remeses no tenen valor. Reviseu-los a l'àrea d'administració del CRM abans de continuar:",
+    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'El valor de la configuració <b>GENERAL_ORGANIZATION_NAME</b> excedeix els 70 caràcters permesos.',
     
     // Missatges SEPA per a transferències
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'El fitxer no es pot generar perquè el seu tipus hauria de ser <b>transferències emeses</b>.',

--- a/modules/stic_Remittances/language/ca_ES.lang.php
+++ b/modules/stic_Remittances/language/ca_ES.lang.php
@@ -95,7 +95,7 @@ $mod_strings = array (
 
     // Missatges SEPA per a rebuts
     'LBL_SEPA_DEBIT_INVALID_SIGNATURE_DATE' => 'La <b>data de signatura</b> del compromís de pagament està buida: ',
-    'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'El <b>mandat</b> del pagament no és vàlid. Està buit o supera els 35 caràcters (comproveu també el compromís de pagament): ',
+    'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'El <b>mandat</b> del pagament no és vàlid. Està buit, supera els 35 caràcters o conté espais en blanc (comproveu també el compromís de pagament): ',
     'LBL_SEPA_DEBIT_INVALID_NIF' => "El <b>número d'identificació</b> (NIF, NIE...) de la persona/organització està buit: ",
     'LBL_SEPA_DEBIT_INVALID_TYPE' => 'El fitxer no es pot generar perquè el seu tipus hauria de ser <b>rebuts domiciliats</b>.',
 

--- a/modules/stic_Remittances/language/ca_ES.lang.php
+++ b/modules/stic_Remittances/language/ca_ES.lang.php
@@ -89,7 +89,7 @@ $mod_strings = array (
     'LBL_SEPA_WITHOUT_CONTACT_OR_ACCOUNT' => 'No hi ha cap persona o organització relacionada al pagament: ',
     'LBL_SEPA_XML_HAS_ERRORS' => "El fitxer XML no s'ha generat perquè hi ha errors que cal corregir.",
     'LBL_MISSING_SEPA_VARIABLES' => "Alguns paràmetres de configuració necessaris per a la generació de remeses no tenen valor. Reviseu-los a l'àrea d'administració del CRM abans de continuar:",
-    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'El valor de la configuració <b>GENERAL_ORGANIZATION_NAME</b> excedeix els 70 caràcters permesos.',
+    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'El valor del paràmetre de configuració <b>GENERAL_ORGANIZATION_NAME</b> excedeix els 70 caràcters permesos.',
     
     // Missatges SEPA per a transferències
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'El fitxer no es pot generar perquè el seu tipus hauria de ser <b>transferències emeses</b>.',

--- a/modules/stic_Remittances/language/ca_ES.lang.php
+++ b/modules/stic_Remittances/language/ca_ES.lang.php
@@ -95,7 +95,7 @@ $mod_strings = array (
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'El fitxer no es pot generar perquè el seu tipus hauria de ser <b>transferències emeses</b>.',
 
     // Missatges SEPA per a rebuts
-    'LBL_SEPA_DEBIT_INVALID_PAYMENT_COMMITMENT' => 'El pagament <b>no està relacionat</b> amb cap compromís de pagament: ',
+    'LBL_SEPA_DEBIT_INVALID_PAYMENT_COMMITMENT' => 'El pagament no està relacionat amb cap compromís de pagament: ',
     'LBL_SEPA_DEBIT_INVALID_SIGNATURE_DATE' => 'La <b>data de signatura</b> del compromís de pagament està buida: ',
     'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'El <b>mandat</b> del pagament no és vàlid. Està buit, supera els 35 caràcters o conté espais en blanc (comproveu també el compromís de pagament): ',
     'LBL_SEPA_DEBIT_INVALID_NIF' => "El <b>número d'identificació</b> (NIF, NIE...) de la persona/organització està buit: ",

--- a/modules/stic_Remittances/language/en_us.lang.php
+++ b/modules/stic_Remittances/language/en_us.lang.php
@@ -94,6 +94,7 @@ $mod_strings = array(
     'LBL_SEPA_CREDIT_INVALID_TYPE' => "File won't be generated because its type should be <b>credit transfers</b>.",
 
     // SEPA direct debits messages
+    'LBL_SEPA_DEBIT_INVALID_PAYMENT_COMMITMENT' => 'The payment <b>is not related</b> to any payment commitment: ',
     'LBL_SEPA_DEBIT_INVALID_SIGNATURE_DATE' => 'The <b>date of signature</b> of the payment commitment is empty: ',
     'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'The payment <b>mandate</b> is invalid. It is empty, exceeds 35 characters or contains white spaces (check the payment commitment too): ',
     'LBL_SEPA_DEBIT_INVALID_NIF' => 'The contact/account <b>identification number</b> is empty:  ',

--- a/modules/stic_Remittances/language/en_us.lang.php
+++ b/modules/stic_Remittances/language/en_us.lang.php
@@ -89,7 +89,6 @@ $mod_strings = array(
     'LBL_SEPA_WITHOUT_CONTACT_OR_ACCOUNT' => 'No related contact or account in payment: ',
     'LBL_SEPA_XML_HAS_ERRORS' => 'The XML file has not been generated because there are errors that should be corrected.',
     'LBL_MISSING_SEPA_VARIABLES' => 'Some settings needed for remittances generation are empty. Please check next settings in admin area: ',
-    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'The value of the <b>GENERAL_ORGANIZATION_NAME</b> setting exceeds the allowed 70 characters.',
 
     // SEPA transfers messages
     'LBL_SEPA_CREDIT_INVALID_TYPE' => "File won't be generated because its type should be <b>credit transfers</b>.",

--- a/modules/stic_Remittances/language/en_us.lang.php
+++ b/modules/stic_Remittances/language/en_us.lang.php
@@ -95,7 +95,7 @@ $mod_strings = array(
 
     // SEPA direct debits messages
     'LBL_SEPA_DEBIT_INVALID_SIGNATURE_DATE' => 'The <b>date of signature</b> of the payment commitment is empty: ',
-    'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'The payment <b>mandate</b> is invalid. It is empty or exceeds 35 characters (check the payment commitment too): ',
+    'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'The payment <b>mandate</b> is invalid. It is empty, exceeds 35 characters or contains white spaces (check the payment commitment too): ',
     'LBL_SEPA_DEBIT_INVALID_NIF' => 'The contact/account <b>identification number</b> is empty:  ',
     'LBL_SEPA_DEBIT_INVALID_TYPE' => "File won't be generated because its type should be <b>direct debits</b>.",
 

--- a/modules/stic_Remittances/language/en_us.lang.php
+++ b/modules/stic_Remittances/language/en_us.lang.php
@@ -95,7 +95,7 @@ $mod_strings = array(
     'LBL_SEPA_CREDIT_INVALID_TYPE' => "File won't be generated because its type should be <b>credit transfers</b>.",
 
     // SEPA direct debits messages
-    'LBL_SEPA_DEBIT_INVALID_PAYMENT_COMMITMENT' => 'The payment <b>is not related</b> to any payment commitment: ',
+    'LBL_SEPA_DEBIT_INVALID_PAYMENT_COMMITMENT' => 'The payment is not related to any payment commitment: ',
     'LBL_SEPA_DEBIT_INVALID_SIGNATURE_DATE' => 'The <b>date of signature</b> of the payment commitment is empty: ',
     'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'The payment <b>mandate</b> is invalid. It is empty, exceeds 35 characters or contains white spaces (check the payment commitment too): ',
     'LBL_SEPA_DEBIT_INVALID_NIF' => 'The contact/account <b>identification number</b> is empty:  ',

--- a/modules/stic_Remittances/language/en_us.lang.php
+++ b/modules/stic_Remittances/language/en_us.lang.php
@@ -89,6 +89,7 @@ $mod_strings = array(
     'LBL_SEPA_WITHOUT_CONTACT_OR_ACCOUNT' => 'No related contact or account in payment: ',
     'LBL_SEPA_XML_HAS_ERRORS' => 'The XML file has not been generated because there are errors that should be corrected.',
     'LBL_MISSING_SEPA_VARIABLES' => 'Some settings needed for remittances generation are empty. Please check next settings in admin area: ',
+    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'The value of the <b>GENERAL_ORGANIZATION_NAME</b> setting exceeds the allowed 70 characters.',
 
     // SEPA transfers messages
     'LBL_SEPA_CREDIT_INVALID_TYPE' => "File won't be generated because its type should be <b>credit transfers</b>.",

--- a/modules/stic_Remittances/language/es_ES.lang.php
+++ b/modules/stic_Remittances/language/es_ES.lang.php
@@ -95,7 +95,7 @@ $mod_strings = array(
 
     // Mensajes SEPA para recibos
     'LBL_SEPA_DEBIT_INVALID_SIGNATURE_DATE' => 'La <b>fecha de firma</b> del compromiso de pago está vacía: ',
-    'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'El <b>mandato</b> del pago es inválido. Está vacío o supera los 35 caracteres (verifique también el compromiso de pago): ',
+    'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'El <b>mandato</b> del pago es inválido. Está vacío, supera los 35 caracteres o contiene espacios en blanco (verifique también el compromiso de pago): ',
     'LBL_SEPA_DEBIT_INVALID_NIF' => 'El <b>número de identificación</b> (NIF, NIE...) de la persona/organización está vacío: ',
     'LBL_SEPA_DEBIT_INVALID_TYPE' => 'El fichero no se puede generar porque su tipo debería ser <b>recibos domiciliados</b>.',
 

--- a/modules/stic_Remittances/language/es_ES.lang.php
+++ b/modules/stic_Remittances/language/es_ES.lang.php
@@ -94,6 +94,7 @@ $mod_strings = array(
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'El fichero no se puede generar porque su tipo debería ser <b>transferencias emitidas</b>.',
 
     // Mensajes SEPA para recibos
+    'LBL_SEPA_DEBIT_INVALID_PAYMENT_COMMITMENT' => 'El pago <b>no esta relacionado</b> con ningún compromiso de pago: ',
     'LBL_SEPA_DEBIT_INVALID_SIGNATURE_DATE' => 'La <b>fecha de firma</b> del compromiso de pago está vacía: ',
     'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'El <b>mandato</b> del pago es inválido. Está vacío, supera los 35 caracteres o contiene espacios en blanco (verifique también el compromiso de pago): ',
     'LBL_SEPA_DEBIT_INVALID_NIF' => 'El <b>número de identificación</b> (NIF, NIE...) de la persona/organización está vacío: ',

--- a/modules/stic_Remittances/language/es_ES.lang.php
+++ b/modules/stic_Remittances/language/es_ES.lang.php
@@ -89,7 +89,6 @@ $mod_strings = array(
     'LBL_SEPA_WITHOUT_CONTACT_OR_ACCOUNT' => 'No hay ninguna persona u organización relacionada en el pago: ',
     'LBL_SEPA_XML_HAS_ERRORS' => 'El archivo XML no se ha generado porque existen errores que deben ser corregidos.',
     'LBL_MISSING_SEPA_VARIABLES' => 'Algunos parámetros de configuración necesarios para la generación de remesas están vacíos. Revíselos en el área de administración del CRM antes de continuar:',
-    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'El valor del parámetro de configuración <b>GENERAL_ORGANIZATION_NAME</b> excede los 70 caracteres permitidos.',
 
     // Mensajes SEPA para transferencias
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'El fichero no se puede generar porque su tipo debería ser <b>transferencias emitidas</b>.',

--- a/modules/stic_Remittances/language/es_ES.lang.php
+++ b/modules/stic_Remittances/language/es_ES.lang.php
@@ -89,13 +89,13 @@ $mod_strings = array(
     'LBL_SEPA_WITHOUT_CONTACT_OR_ACCOUNT' => 'No hay ninguna persona u organización relacionada en el pago: ',
     'LBL_SEPA_XML_HAS_ERRORS' => 'El archivo XML no se ha generado porque existen errores que deben ser corregidos.',
     'LBL_MISSING_SEPA_VARIABLES' => 'Algunos parámetros de configuración necesarios para la generación de remesas están vacíos. Revíselos en el área de administración del CRM antes de continuar:',
-    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'El valor de la configuración <b>GENERAL_ORGANIZATION_NAME</b> excede los 70 caracteres permitidos.',
+    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'El valor del parámetro de configuración <b>GENERAL_ORGANIZATION_NAME</b> excede los 70 caracteres permitidos.',
 
     // Mensajes SEPA para transferencias
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'El fichero no se puede generar porque su tipo debería ser <b>transferencias emitidas</b>.',
 
     // Mensajes SEPA para recibos
-    'LBL_SEPA_DEBIT_INVALID_PAYMENT_COMMITMENT' => 'El pago <b>no esta relacionado</b> con ningún compromiso de pago: ',
+    'LBL_SEPA_DEBIT_INVALID_PAYMENT_COMMITMENT' => 'El pago no está relacionado con ningún compromiso de pago: ',
     'LBL_SEPA_DEBIT_INVALID_SIGNATURE_DATE' => 'La <b>fecha de firma</b> del compromiso de pago está vacía: ',
     'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'El <b>mandato</b> del pago es inválido. Está vacío, supera los 35 caracteres o contiene espacios en blanco (verifique también el compromiso de pago): ',
     'LBL_SEPA_DEBIT_INVALID_NIF' => 'El <b>número de identificación</b> (NIF, NIE...) de la persona/organización está vacío: ',

--- a/modules/stic_Remittances/language/es_ES.lang.php
+++ b/modules/stic_Remittances/language/es_ES.lang.php
@@ -89,6 +89,7 @@ $mod_strings = array(
     'LBL_SEPA_WITHOUT_CONTACT_OR_ACCOUNT' => 'No hay ninguna persona u organización relacionada en el pago: ',
     'LBL_SEPA_XML_HAS_ERRORS' => 'El archivo XML no se ha generado porque existen errores que deben ser corregidos.',
     'LBL_MISSING_SEPA_VARIABLES' => 'Algunos parámetros de configuración necesarios para la generación de remesas están vacíos. Revíselos en el área de administración del CRM antes de continuar:',
+    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'El valor de la configuración <b>GENERAL_ORGANIZATION_NAME</b> excede los 70 caracteres permitidos.',
 
     // Mensajes SEPA para transferencias
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'El fichero no se puede generar porque su tipo debería ser <b>transferencias emitidas</b>.',

--- a/modules/stic_Remittances/language/gl_ES.lang.php
+++ b/modules/stic_Remittances/language/gl_ES.lang.php
@@ -89,13 +89,13 @@ $mod_strings = array(
     'LBL_SEPA_WITHOUT_CONTACT_OR_ACCOUNT' => 'Non hai ningunha persoa ou organización relacionada no pago: ',
     'LBL_SEPA_XML_HAS_ERRORS' => 'O arquivo XML non se xerou porque existen erros que deben ser corrigidos.',
     'LBL_MISSING_SEPA_VARIABLES' => 'Algúns parámetros de configuración necesarios para a xeración de remesas están baleiros. Revíseos na área de administración do CRM antes de continuar:',
-    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'El valor de la configuración <b>GENERAL_ORGANIZATION_NAME</b> excede los 70 caracteres permitidos.',
+    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'El valor del parámetro de configuración <b>GENERAL_ORGANIZATION_NAME</b> excede los 70 caracteres permitidos.',
 
     // Mensaxes SEPA para transferencias
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'O ficheiro non se pode xerar porque o seu tipo debería ser <b>transferencias emitidas</b>.',
 
     // Mensaxes SEPA para recibos
-    'LBL_SEPA_DEBIT_INVALID_PAYMENT_COMMITMENT' => 'El pago <b>no esta relacionado</b> con ningún compromiso de pago: ',
+    'LBL_SEPA_DEBIT_INVALID_PAYMENT_COMMITMENT' => 'El pago no está relacionado con ningún compromiso de pago: ',
     'LBL_SEPA_DEBIT_INVALID_SIGNATURE_DATE' => 'A <b>data de sinatura</b> do compromiso de pago está baleira: ',
     'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'O <b>mandato</b> do pago non é válido. Está baleiro, supera os 35 caracteres o contiene espacios en blanco (verifique tamén o compromiso de pago): ',
     'LBL_SEPA_DEBIT_INVALID_NIF' => 'O <b>número de identificación</b> (NIF, NIE...) da persoa/organización está baleiro: ',

--- a/modules/stic_Remittances/language/gl_ES.lang.php
+++ b/modules/stic_Remittances/language/gl_ES.lang.php
@@ -89,6 +89,7 @@ $mod_strings = array(
     'LBL_SEPA_WITHOUT_CONTACT_OR_ACCOUNT' => 'Non hai ningunha persoa ou organización relacionada no pago: ',
     'LBL_SEPA_XML_HAS_ERRORS' => 'O arquivo XML non se xerou porque existen erros que deben ser corrigidos.',
     'LBL_MISSING_SEPA_VARIABLES' => 'Algúns parámetros de configuración necesarios para a xeración de remesas están baleiros. Revíseos na área de administración do CRM antes de continuar:',
+    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'El valor de la configuración <b>GENERAL_ORGANIZATION_NAME</b> excede los 70 caracteres permitidos.',
 
     // Mensaxes SEPA para transferencias
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'O ficheiro non se pode xerar porque o seu tipo debería ser <b>transferencias emitidas</b>.',

--- a/modules/stic_Remittances/language/gl_ES.lang.php
+++ b/modules/stic_Remittances/language/gl_ES.lang.php
@@ -94,6 +94,7 @@ $mod_strings = array(
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'O ficheiro non se pode xerar porque o seu tipo debería ser <b>transferencias emitidas</b>.',
 
     // Mensaxes SEPA para recibos
+    'LBL_SEPA_DEBIT_INVALID_PAYMENT_COMMITMENT' => 'El pago <b>no esta relacionado</b> con ningún compromiso de pago: ',
     'LBL_SEPA_DEBIT_INVALID_SIGNATURE_DATE' => 'A <b>data de sinatura</b> do compromiso de pago está baleira: ',
     'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'O <b>mandato</b> do pago non é válido. Está baleiro, supera os 35 caracteres o contiene espacios en blanco (verifique tamén o compromiso de pago): ',
     'LBL_SEPA_DEBIT_INVALID_NIF' => 'O <b>número de identificación</b> (NIF, NIE...) da persoa/organización está baleiro: ',

--- a/modules/stic_Remittances/language/gl_ES.lang.php
+++ b/modules/stic_Remittances/language/gl_ES.lang.php
@@ -95,7 +95,7 @@ $mod_strings = array(
 
     // Mensaxes SEPA para recibos
     'LBL_SEPA_DEBIT_INVALID_SIGNATURE_DATE' => 'A <b>data de sinatura</b> do compromiso de pago está baleira: ',
-    'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'O <b>mandato</b> do pago non é válido. Está baleiro ou supera os 35 caracteres (verifique tamén o compromiso de pago): ',
+    'LBL_SEPA_DEBIT_INVALID_MANDATE' => 'O <b>mandato</b> do pago non é válido. Está baleiro, supera os 35 caracteres o contiene espacios en blanco (verifique tamén o compromiso de pago): ',
     'LBL_SEPA_DEBIT_INVALID_NIF' => 'O <b>número de identificación</b> (NIF, NIE...) da persoa/organización está baleiro: ',
     'LBL_SEPA_DEBIT_INVALID_TYPE' => 'O ficheiro non se pode xerar porque o seu tipo debería ser <b>recibos domiciliados</b>.',
 

--- a/modules/stic_Remittances/language/gl_ES.lang.php
+++ b/modules/stic_Remittances/language/gl_ES.lang.php
@@ -89,7 +89,6 @@ $mod_strings = array(
     'LBL_SEPA_WITHOUT_CONTACT_OR_ACCOUNT' => 'Non hai ningunha persoa ou organización relacionada no pago: ',
     'LBL_SEPA_XML_HAS_ERRORS' => 'O arquivo XML non se xerou porque existen erros que deben ser corrigidos.',
     'LBL_MISSING_SEPA_VARIABLES' => 'Algúns parámetros de configuración necesarios para a xeración de remesas están baleiros. Revíseos na área de administración do CRM antes de continuar:',
-    'LBL_GENERAL_ORGANIZATION_NAME_TOO_LONG' => 'El valor del parámetro de configuración <b>GENERAL_ORGANIZATION_NAME</b> excede los 70 caracteres permitidos.',
 
     // Mensaxes SEPA para transferencias
     'LBL_SEPA_CREDIT_INVALID_TYPE' => 'O ficheiro non se pode xerar porque o seu tipo debería ser <b>transferencias emitidas</b>.',

--- a/modules/stic_Settings/gettpvsettings.php
+++ b/modules/stic_Settings/gettpvsettings.php
@@ -1,3 +1,0 @@
-<?php
-require_once "modules/stic_Settings/Utils.php";
-var_dump(stic_SettingsUtils::getTPVSettings($_REQUEST['m']));die();

--- a/modules/stic_Settings/gettpvsettings.php
+++ b/modules/stic_Settings/gettpvsettings.php
@@ -1,0 +1,3 @@
+<?php
+require_once "modules/stic_Settings/Utils.php";
+var_dump(stic_SettingsUtils::getTPVSettings($_REQUEST['m']));die();


### PR DESCRIPTION
- solves #149
- solves #50

## Descripción
Se han mejorado algunas validaciones existentes y se ha añadido alguna nueva en la generación de ficheros XML de remesas de Domiciliaciones y de Transferencias emitidas:

**En las remesas de Domiciliaciones:**
1. Se trunca el nombre de la organización a los 70 caracteres permitidos en las remesas.
2. Se asegura que el mandato no incluya espacios en blanco; de ser así, se genera un error bloqueante. En este caso se ha optado por generar el error y no permitir el uso de espacios en blanco por considerarse una opción más segura, a pesar que SEPA no lo prohíbe de manera expresa.
3. Se verifica que cada pago tenga un Compromiso de pago relacionado; si no es así, se genera un error bloqueante. Adicionalmente, la validación de "Fecha de firma" del mandato se condiciona a la existencia del compromiso de pago, ya que se extrae directamente de este.

**En las remesas de Transferencias:**
1. Se trunca el nombre de la organización a los 70 caracteres permitidos en las remesas.
2. Se trunca el valor del concepto bancario que se usa en el fichero XML a los primeros 140 caracteres, tal como ya ocurre en las remesas de Domiciliaciones.

## Pruebas a realizar
- Crear remesas de Domiciliaciones y de Transferencias y provocar el error en cada una de las situaciones descritas, comprobando el error generado y que el fichero se genera correctamente tras subsanarlo.
