### PR TITLE
Enhancements - General - Mostrar el nombre del registro en el tooltip de registros recientes y favoritos

### DIFF
--- a/custom/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/custom/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -928,7 +928,11 @@
                                                     href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}"
                                                     class="recent-links-detail">
                                                     <span class="suitepicon suitepicon-module-{$item.module_name|lower|replace:'_':'-'}"></span>
+                                                    {* STIC-Custom - JCH - 20240305 -  Add record tooltip *}
+                                                    {* https://github.com/SinergiaTIC/SinergiaCRM/pull/151 *}
+                                                    {* <span>{$item.item_summary_short}</span> *}
                                                     <span title="{$item.item_summary}">{$item.item_summary_short}</span>
+                                                    {* END STIC *}
                                                 </a>
                                                 {capture assign='access'}{suite_check_access module=$item.module_name action='edit' record=$item.item_id }{/capture}
                                                 {if $access}
@@ -962,7 +966,11 @@
                                                 href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}"
                                                 class="favorite-links-detail">
                                                 <span class="suitepicon suitepicon-module-{$item.module_name|lower|replace:'_':'-'}"></span>
+                                                {* STIC-Custom - JCH - 20240305 -  Add record tooltip *}
+                                                {* https://github.com/SinergiaTIC/SinergiaCRM/pull/151 *}
+                                                {* <span title="{$item.item_summary}" aria-hidden="true">{$item.item_summary_short}</span> *}
                                                 <span title="{$item.item_summary}" aria-hidden="true">{$item.item_summary_short}</span>
+                                                {* END STIC *}
                                             </a>
                                             {capture assign='access'}{suite_check_access module=$item.module_name action='edit' record=$item.item_id }{/capture}
                                             {if $access}

--- a/custom/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/custom/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -972,7 +972,7 @@
                                                 <span class="suitepicon suitepicon-module-{$item.module_name|lower|replace:'_':'-'}"></span>
                                                 {* STIC-Custom - JCH - 20240305 -  Add record tooltip *}
                                                 {* https://github.com/SinergiaTIC/SinergiaCRM/pull/151 *}
-                                                {* <span title="{$item.item_summary}" aria-hidden="true">{$item.item_summary_short}</span> *}
+                                                {* <span aria-hidden="true">{$item.item_summary_short}</span> *}
                                                 <span title="{$item.item_summary}" aria-hidden="true">{$item.item_summary_short}</span>
                                                 {* END STIC *}
                                             </a>

--- a/custom/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/custom/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -928,7 +928,7 @@
                                                     href="{sugar_link module=$item.module_name action='DetailView' record=$item.item_id link_only=1}"
                                                     class="recent-links-detail">
                                                     <span class="suitepicon suitepicon-module-{$item.module_name|lower|replace:'_':'-'}"></span>
-                                                    <span>{$item.item_summary_short}</span>
+                                                    <span title="{$item.item_summary}">{$item.item_summary_short}</span>
                                                 </a>
                                                 {capture assign='access'}{suite_check_access module=$item.module_name action='edit' record=$item.item_id }{/capture}
                                                 {if $access}
@@ -962,7 +962,7 @@
                                                 href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}"
                                                 class="favorite-links-detail">
                                                 <span class="suitepicon suitepicon-module-{$item.module_name|lower|replace:'_':'-'}"></span>
-                                                <span aria-hidden="true">{$item.item_summary_short}</span>
+                                                <span title="{$item.item_summary}" aria-hidden="true">{$item.item_summary_short}</span>
                                             </a>
                                             {capture assign='access'}{suite_check_access module=$item.module_name action='edit' record=$item.item_id }{/capture}
                                             {if $access}

--- a/custom/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/custom/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -962,7 +962,11 @@
                                 {if $smarty.foreach.lastViewed.index < 5}
                                     <div class="recently_viewed_link_container_sidebar">
                                         <li class="recentlinks" role="presentation">
-                                            <a title="{$item.module_name}" accessKey="{$smarty.foreach.lastViewed.iteration}"
+                                            {* STIC-Custom - JCH - 20240305 -  Add record tooltip *}
+                                            {* https://github.com/SinergiaTIC/SinergiaCRM/pull/151 *}
+                                            {* <a title="{module=$item.module_name}" accessKey="{$smarty.foreach.lastViewed.iteration}" *}
+                                            <a title="{sugar_translate module=$item.module_name label=LBL_MODULE_NAME}" accessKey="{$smarty.foreach.lastViewed.iteration}"
+                                            {* END STIC *}
                                                 href="{sugar_link module=$item.module_name action='DetailView' record=$item.id link_only=1}"
                                                 class="favorite-links-detail">
                                                 <span class="suitepicon suitepicon-module-{$item.module_name|lower|replace:'_':'-'}"></span>


### PR DESCRIPTION
- solves #152 

## Descripción
Se añaden tooltips para mostrar el nombre del registro completo al pasar el ratón por el nombre de los elementos _Recientes_ y _Favoritos_ de la barra lateral

 ## Pruebas
 Pasar el ratón por el nombre de los elementos que aparecen en _Recientes_ y _Favoritos_ y comprobar que se visualiza el nombre completo del registro en el tooltip.