### PR TITLE
Hotfix - Grupos de Seguridad - Importación con reglas custom

### DIFF
--- a/modules/stic_Security_Groups_Rules/Utils.php
+++ b/modules/stic_Security_Groups_Rules/Utils.php
@@ -403,7 +403,7 @@ class stic_Security_Groups_RulesUtils
                     // In such cases, retrieve the id in one of the three following ways, or continue.
 
                     // 1) Check if the related field is present in the subpanel's form
-                    if (!is_string($relatedId)) {
+                    if (!is_string($relatedId) && !empty($relatedId)) {
                         $relatedId = key($bean->{$value['field']}->rows);
                     }
 
@@ -419,13 +419,15 @@ class stic_Security_Groups_RulesUtils
 
                     }
                     
-                    $currentRecordGroups = self::getRelatedSecurityGroupIDs($relatedId);
-
-                    foreach ($currentRecordGroups as $val2) {
-                        $securityGroupsCandidatesToInherit = array_merge(
-                            $securityGroupsCandidatesToInherit,
-                            [['record_id' => $bean->id, 'securitygroup_id' => $val2]]
-                        );
+                    if (!empty($relatedId)) {
+                        $currentRecordGroups = self::getRelatedSecurityGroupIDs($relatedId);
+    
+                        foreach ($currentRecordGroups as $val2) {
+                            $securityGroupsCandidatesToInherit = array_merge(
+                                $securityGroupsCandidatesToInherit,
+                                [['record_id' => $bean->id, 'securitygroup_id' => $val2]]
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Closes #156 

## Description
Se añade la validación de null al recuperar el valor de un campo relacionado ya que se observa que, a diferencia de lo que ocurre cuando se viene de un subpanel en que el campo está inicializado a "", al importar el campo está inicializado a null. Ello provoca que se entrase en algún if que no debería, generando un warning de PHP. La acumulación de warnings de PHP provocaba el aborto del proceso de importación cuando hay muchos registros.

## Motivation and Context
Se detecta a instancia de una entidad que la importación en un módulo con reglas custom estaba generando problemas. Se comprueba que el problema se produce cuando no se indica el campo correspondiente almódulo del que deben heredarse los grupos y se localiza como origen del problema un campo que se carga a null.

## How To Test This
1.- Definir reglas custom para "Relación con personas", de manera que herede grupos de proyecto
2.- Cargar un fichero con relaciones con personas (con unos cuantos registros) que no especifique proyecto
3.- Comprobar que no se generan warnings
4.- [Opcional] Cargar un fichero con muchas relaciones (> 100) para comprobar que el proceso se realiza sin problema
5.- [Opcional] Comprobar vía debugger que cuando se carga sin información del campo relacionado, no se entra por las ramas por donde no se debe (ver código en líneas 406 en adelante de Util.php del módulo de reglas)

