### PR TITLE
Hotfix - Ubicaciones - Error al importar Ubicaciones

### DIFF
--- a/modules/FP_Event_Locations/FP_Event_Locations_sugar.php
+++ b/modules/FP_Event_Locations/FP_Event_Locations_sugar.php
@@ -51,7 +51,11 @@ class FP_Event_Locations_sugar extends Basic
     public $module_dir = 'FP_Event_Locations';
     public $object_name = 'FP_Event_Locations';
     public $table_name = 'fp_event_locations';
-    public $importable = false;
+    // STIC 20240312 ART - Error importing Locations module
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // public $importable = false;
+    public $importable = true;
+    // End STIC
     public $disable_row_level_security = true ; // to ensure that modules created and deployed under CE will continue to function under team security if the instance is upgraded to PRO
     public $id;
     public $name;

--- a/modules/FP_Event_Locations/FP_Event_Locations_sugar.php
+++ b/modules/FP_Event_Locations/FP_Event_Locations_sugar.php
@@ -52,7 +52,7 @@ class FP_Event_Locations_sugar extends Basic
     public $object_name = 'FP_Event_Locations';
     public $table_name = 'fp_event_locations';
     // STIC 20240312 ART - Error importing Locations module
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/163
     // public $importable = false;
     public $importable = true;
     // End STIC


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/101

**Desarrollo del issue**
Al intentar importar en el módulo de Ubicaciones, se presentaba un error en el cual no dejaba lanzar el asistente de importación.

**Solución implementada**
Se ha cambiado la variable de `importable` del módulo de `false` a `true`.

**Pruebas**
1. Ir al módulo de Ubicaciones.
2. Dar a Importar.
3. Ver que se puede importar ubicaciones.