### PR TITLE
Hotfix - Flujos de Trabajo - Error identificación formato de campos custom datetime

### DIFF
--- a/modules/AOW_Actions/FormulaCalculator.php
+++ b/modules/AOW_Actions/FormulaCalculator.php
@@ -400,7 +400,17 @@ class FormulaCalculator
         }
 
         if (($params = $this->evaluateFunctionParams("date", $text, $childItems)) != null) {
-            return date($params[0], strtotime($params[1]));
+            // STIC-Custom 20240321 JBL - Unformat datetime fields to extract parts
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/??
+            // return date($params[0], strtotime($params[1]));
+            global $timedate;
+            $date = $timedate->to_db($params[1]);
+            if($date=="") {
+                return date($params[0], strtotime($params[1]));
+            } else {
+                return date($params[0], strtotime($date));
+            }
+            // END STIC-Custom
         }
 
         if (($params = $this->evaluateFunctionParams("datediff", $text, $childItems)) != null) { 

--- a/modules/AOW_Actions/FormulaCalculator.php
+++ b/modules/AOW_Actions/FormulaCalculator.php
@@ -401,15 +401,10 @@ class FormulaCalculator
 
         if (($params = $this->evaluateFunctionParams("date", $text, $childItems)) != null) {
             // STIC-Custom 20240321 JBL - Unformat datetime fields to extract parts
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/??
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/174
             // return date($params[0], strtotime($params[1]));
-            global $timedate;
-            $date = $timedate->to_db($params[1]);
-            if($date=="") {
-                return date($params[0], strtotime($params[1]));
-            } else {
-                return date($params[0], strtotime($date));
-            }
+            $date = $this->getDBFormat($params[1]);
+            return date($params[0], strtotime($date));
             // END STIC-Custom
         }
 


### PR DESCRIPTION
 - Closes #172
## Descripción
Se ha detectado que hay un error en la identificación del formato de los campos tipo "fecha y hora" de los campos custom en los flujos de trabajo.
El problema radica en la solución aplicada en el PR [#113 Incidencia - Flujos de trabajo - Formateo de hora en campos calculados que no usan funciones de fecha.](https://github.com/SinergiaTIC/SinergiaCRM/pull/113), que aplica el formato de fecha de usuario a los parámetros, pero al intentar extraer sus partes no se esperaba este formato

La solución implementada fuerza el formato de BD antes de extraer las partes de las fechas.

## Pruebas
1. En Estudio, editar el módulo Personas:
    1. Añadir un campo de tipo "Fecha y Hora" con el nombre "fecha_hora"
    2. Añadir el campo en la vista de Detalle y edición
3. Crear un Flujo de Trabajo sobre el módulo Personas que se ejecute en "Todos los registros" con ejecuciones reiteradas
    1. Sin condiciones
    3. Acción: Campos calculados
        1. Parámetros: "Fecha de nacimiento" {P0}, "Fecha de modificación" {P1} y "fecha hora" {P2}
        2. Fórmula al campo "Descripción": Escribir la siguiente fórmula:
        `[Fecha de nacimiento -> Año: {date(Y;{P0})}, Mes: {date(m;{P0})}, Día: {date(d;{P0})}] [Registro modificado -> Año: {date(Y;{P1})}, Mes: {date(m;{P1})}, Día: {date(d;{P1})}, Hora: {date(H;{P1})}, Minutos: {date(i;{P1})}, Segundos: {date(s;{P1})}][Fecha_hora -> Año: {date(Y;{P2})}, Mes: {date(m;{P2})}, Día: {date(d;{P2})}, Hora: {date(H;{P2})}, Minutos: {date(i;{P2})}, Segundos: {date(s;{P2})}]`
2. Editar una persona y asignarle una fecha de nacimiento y una "fecha hora"
4. Verificar que la descripción contiene la "fecha de nacimiento", la "fecha de modificación" y la "fecha hora" correctamente desglosadas