### PR TITLE
Hotfix - Economía - Formato correcto de fecha al guardar desde interfaz o código

### DIFF
--- a/SticInclude/Utils.php
+++ b/SticInclude/Utils.php
@@ -623,44 +623,51 @@ EOQ;
 
     /**
      * Formats date and datetime strings into the standard database format.
-     * Cloned from the getDBFormat function in modules/AOW_Actions/FormulaCalculator.php
+     * This function is based on the getDBFormat function found in modules/AOW_Actions/FormulaCalculator.php.
+     * It ensures that both date and datetime strings are standardized for database storage, accommodating both
+     * the database's default format and user-specific formats.
      *
-     * @param string $date String representing a date or datetime.
-     * @return string|null Formatted string suitable for database storage, or null if the input is invalid.
+     * @param string $date String representing a date. This can be in the format expected by the database or a SuiteCRM user-defined format.
+     *                     It attempts to standardize dates (Y-m-d) and datetimes (Y-m-d H:i:s) for database insertion.
+     * @return string|null Returns a formatted string suitable for database storage if the input is valid. If the input date
+     *                     cannot be processed or is invalid, it returns null. 
      */
     public static function formatDateForDatabase($date)
     {
-        $formatDate = 'Y-m-d';
-        $validDate = DateTime::createFromFormat($formatDate, $date);
-        $formatDateTime = 'Y-m-d H:i:s';
-        $validDateTime = DateTime::createFromFormat($formatDateTime, $date);
+        $originalDate=$date;
+        $formatDate = 'Y-m-d'; // Defines the standard date format for comparison and formatting.
+        $validDate = DateTime::createFromFormat($formatDate, $date); // Attempts to create a DateTime object based on the standard date format.
 
-        // If the string matches the date format without time, return it unchanged.
+        if (!$validDate) {
+            // If the initial attempt fails, it tries to create a DateTime object with a datetime format.
+            $validDate = DateTime::createFromFormat('Y-m-d H:i:s', $date);
+            if ($validDate) {
+                // If successful, formats the DateTime object to the standard date format.
+                $date = $validDate->format('Y-m-d');
+            }
+        }
+
+        // Checks if the string matches the date format without time, returning it unchanged if it does.
         if ($validDate && $validDate->format($formatDate) === $date) {
             return $date;
-        }
-        // If the string matches the datetime format, adjust the timezone.
-        else if ($validDateTime && $validDateTime->format($formatDateTime) === $date) {
-            global $timedate, $current_user;
-            $date = $timedate->fromDb($date);
-            $date = $timedate->tzUser($date, $current_user);
-            return $date->format('Y-m-d H:i:s');
-        }
-        // If the input does not match either format, attempt to format based on user type.
-        else {
+        } else {
             global $current_user, $timedate;
-            // Determine if the string includes a time component.
+            // Determines if the string includes a time component by checking for a space character.
             if (strpos($date, " ") !== false) {
                 $type = 'datetime';
             } else {
                 $type = 'date';
             }
-            // Convert from user's format to database format.
+            // Converts the date from the user's format to the database format, leveraging the user's settings.
             $date = $timedate->fromUserType($date, $type, $current_user);
             if ($date) {
-                return $date->asDb(false);
+                // If conversion is successful, returns the date as a string in database format.
+                return $date->asDbDate(false);
             }
+            // Returns null if the date cannot be formatted to the database's expectations, indicating an invalid input.
+            $GLOBALS['log']->fatal('Line '.__LINE__.': '.__METHOD__.': '."The date [$originalDate] is invalid or uses an unsupported format.");
             return null;
         }
     }
+
 }

--- a/SticUpdates/Migrations/20230802_feature_payments_prevision.sql
+++ b/SticUpdates/Migrations/20230802_feature_payments_prevision.sql
@@ -1,5 +1,4 @@
--- Active: 1632214630318@@localhost@2002@sinergiacrm
--- Update the expected_payments_detail and pending_annualized_fee fields in all active payment commitments
+-- Re-Update the expected_payments_detail and pending_annualized_fee fields in all active payment commitments
 UPDATE
     stic_payment_commitments AS t1
     JOIN (

--- a/modules/stic_Payments/stic_Payments.php
+++ b/modules/stic_Payments/stic_Payments.php
@@ -133,7 +133,7 @@ class stic_Payments extends Basic
         parent::save();
 
 
-        if ($PCBean) {
+        if ($PCBean && $userDate) {
         
             // Recalculate the field paid_annualized_fee if applicable.
             require_once 'SticInclude/Utils.php';

--- a/modules/stic_Payments/stic_Payments.php
+++ b/modules/stic_Payments/stic_Payments.php
@@ -99,7 +99,10 @@ class stic_Payments extends Basic
 
         if ($PCBean) {
             global $timedate, $current_user;
-            $userDate = $timedate->fromUserDate($this->payment_date, false, $current_user);
+            
+            // Get userDate object from user format or from database format 
+            $userDate = $timedate->fromDBDate(SticUtils::formatDateForDatabase($this->payment_date));
+            
             // Create name if empty
             if (empty($this->name)) {
                 if ($userDate) {
@@ -121,7 +124,7 @@ class stic_Payments extends Basic
             }
         }
 
-        // Since the value of `fetched_row` is reset in the case of audited fields, 
+        // Since the value of `fetched_row` is reset in the case of audited fields,
         // we will save its contents in a variable to be used after running the `Save` method.
         $tempFetchedRow = $this->fetched_row;
 
@@ -131,11 +134,11 @@ class stic_Payments extends Basic
 
 
         if ($PCBean) {
-        
+
             // Recalculate the field paid_annualized_fee if applicable.
             require_once 'SticInclude/Utils.php';
-           
-            // Check if the status, amount, or payment_date fields have changed or if it is a new record.            
+
+            // Check if the status, amount, or payment_date fields have changed or if it is a new record.
             if (
                 $this->status != $tempFetchedRow['status']
                 || SticUtils::unformatDecimal($this->amount) != SticUtils::unformatDecimal($tempFetchedRow['amount'])

--- a/modules/stic_Payments/stic_Payments.php
+++ b/modules/stic_Payments/stic_Payments.php
@@ -124,7 +124,7 @@ class stic_Payments extends Basic
             }
         }
 
-        // Since the value of `fetched_row` is reset in the case of audited fields,
+        // Since the value of `fetched_row` is reset in the case of audited fields, 
         // we will save its contents in a variable to be used after running the `Save` method.
         $tempFetchedRow = $this->fetched_row;
 
@@ -134,11 +134,11 @@ class stic_Payments extends Basic
 
 
         if ($PCBean) {
-
+        
             // Recalculate the field paid_annualized_fee if applicable.
             require_once 'SticInclude/Utils.php';
-
-            // Check if the status, amount, or payment_date fields have changed or if it is a new record.
+           
+            // Check if the status, amount, or payment_date fields have changed or if it is a new record.            
             if (
                 $this->status != $tempFetchedRow['status']
                 || SticUtils::unformatDecimal($this->amount) != SticUtils::unformatDecimal($tempFetchedRow['amount'])

--- a/modules/stic_Payments/stic_Payments.php
+++ b/modules/stic_Payments/stic_Payments.php
@@ -108,7 +108,7 @@ class stic_Payments extends Basic
                 if ($userDate) {
                     $this->name = $PCBean->name . ' - ' . $userDate->asDBDate();
                 } else {
-                    // The payment is created from the pop-up view where the format of the date type fields is from the database
+                    // The payment is created in any context where the format of the date-type fields is bad formed.
                     $this->name = $PCBean->name . ' - ' . $this->payment_date;
                 }
             }

--- a/modules/stic_Payments/stic_Payments.php
+++ b/modules/stic_Payments/stic_Payments.php
@@ -98,7 +98,7 @@ class stic_Payments extends Basic
         }
 
         if ($PCBean) {
-            global $timedate, $current_user;
+            global $timedate;
             
             // Get userDate object from user format or from database format 
             $userDate = $timedate->fromDBDate(SticUtils::formatDateForDatabase($this->payment_date));
@@ -136,8 +136,6 @@ class stic_Payments extends Basic
         if ($PCBean && $userDate) {
         
             // Recalculate the field paid_annualized_fee if applicable.
-            require_once 'SticInclude/Utils.php';
-           
             // Check if the status, amount, or payment_date fields have changed or if it is a new record.            
             if (
                 $this->status != $tempFetchedRow['status']


### PR DESCRIPTION
## Problema Detectado

Se ha detectado un problema en el que los pagos creados a través de un Logic Hook (LH) daban error. Este problema surge a partir de los cambios realizados en el PR [SinergiaCRM pull #5](https://github.com/SinergiaTIC/SinergiaCRM/pull/5), específicamente en el archivo `modules/stic_Payments/stic_Payments.php`. La llamada a la función `"$userDate = $timedate->fromUserDate($this->payment_date, false, $current_user);"` se adelantó en el flujo de ejecución. Cuando el guardado del pago proviene de un LH, la fecha de pago ya viene en formato de base de datos, por lo que la función `asDbDate()` no retorna el valor esperado.

## Solución Implementada

- Se ha creado la función `formatDateForDatabase`, clonada de la función `getDBFormat` del archivo `modules/AOW_Actions/FormulaCalculator.php`. De esta manera, se obtiene la fecha en formato de base de datos antes de utilizarla para crear el objeto `$userDate`. Esto asegura que la función trabajará correctamente, independientemente de si la fecha viene en el formato de base de datos (probable si proviene de un Logic Hook o de un flujo de trabajo) o en el formato personalizado del usuario. Esta nueva función se ha añadido en `SticUtils.php`, ya que la función original no podía utilizarse al estar definida como privada, además de tener un propósito más generalista.
- Se ha reintroducido el script que regenera el cálculo de la previsión de pagos para ejecutarlo nuevamente con la instalación de este PR. Así se corrigen los posibles efectos adversos que hayan ocurrido por no haber aplicado correctamente el arreglo desde que se detectó el error.

## Pruebas a realizar
- Crear pagos desde un LH o desde flujo de trabajo y verificar que el pago se crea correctamente y no se produce el error. 
Se puede usar el siguiente código en un fichero _modules/stic_Payments/crearPago.php_ e invocarlo en el navegador mediante _<host>/index.php?module=stic_Payments&action=crearPago_:
```php
<?php
$pBean=BeanFactory::newBean('stic_Payments');
$pBean->amount=10;
$pBean->stic_paymebfe2itments_ida='<id-de-un-compromiso-de-pago-existente>';
$pBean->payment_date='2024-03-25';
$pBean->save();
SugarApplication::redirect("index.php?module=stic_Payments&action=DetailView&record={$pBean->id}");
```
- Crear pagos mediante la interfaz en diferentes situaciones y verificar que no se produce el error:
  - Mediante el subpanel pagos
  - Creando un compromiso de pago
  - Mediante un formulario de inscripciones a eventos
  - Mediante un formulario de donaciones
  - etc...
  


