### PR TITLE
Hotfix - Personas - Etiqueta 'Dirección - Calle' incorrecta en la Vista Detalle

### DIFF
--- a/modules/Contacts/metadata/detailviewdefs.php
+++ b/modules/Contacts/metadata/detailviewdefs.php
@@ -697,7 +697,7 @@ array (
           array (
             'name' => 'primary_address_street',
             // STIC - ART - Incorrect tag for the address in DetailView
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/180
             // 'label' => 'LBL_PRIMARY_ADDRESS',
             'label' => 'LBL_PRIMARY_ADDRESS_STREET',
             // END STIC
@@ -706,7 +706,7 @@ array (
           array (
             'name' => 'alt_address_street',
             // STIC - ART - Incorrect tag for the address in DetailView
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/180
             // 'label' => 'LBL_ALTERNATE_ADDRESS',
             'label' => 'LBL_ALT_ADDRESS_STREET',
             // END STIC

--- a/modules/Contacts/metadata/detailviewdefs.php
+++ b/modules/Contacts/metadata/detailviewdefs.php
@@ -696,12 +696,20 @@ array (
           0 => 
           array (
             'name' => 'primary_address_street',
-            'label' => 'LBL_PRIMARY_ADDRESS',
+            // STIC - ART - Incorrect tag for the address in DetailView
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // 'label' => 'LBL_PRIMARY_ADDRESS',
+            'label' => 'LBL_PRIMARY_ADDRESS_STREET',
+            // END STIC
           ),
           1 => 
           array (
             'name' => 'alt_address_street',
-            'label' => 'LBL_ALTERNATE_ADDRESS',
+            // STIC - ART - Incorrect tag for the address in DetailView
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // 'label' => 'LBL_ALTERNATE_ADDRESS',
+            'label' => 'LBL_ALT_ADDRESS_STREET',
+            // END STIC
           ),
         ),
         2 => 


### PR DESCRIPTION
## Description
A partir de esta consulta del foro https://forums.sinergiacrm.org/viewtopic.php?p=67222, se ha cambiado la etiqueta `LBL_PRIMARY_ADDRESS` por `LBL_PRIMARY_ADDRESS_STREET`, al igual que la etiqueta `LBL_ALTERNATE_ADDRESS` por `LBL_ALT_ADDRESS_STREET`. Ya que, se mostraban dichos campos sin la palabra "Calle", mientras que en los demás campos si se especificaba.

## How To Test This
1. Ir al módulo Personas
2. Comprobar que se muestran correctamente las etiquetas del campo como: Dirección principal - Calle o Dirección alternativa - Calle. 
3. Comprobar que se muestra igual en la vista de edición.
