### PR TITLE
Hotfix - Encuestas - Mostrar logo correcto en encuestas cerradas

### DIFF
--- a/modules/Surveys/Entry/Survey.php
+++ b/modules/Surveys/Entry/Survey.php
@@ -362,6 +362,12 @@ function displayDateField($question)
 
 function displayClosedPage($survey)
 {
+    // STIC-Custom 20240402 - JBL - Show logo in closed surveys
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/93
+    $themeObject = SugarThemeRegistry::current();
+    $companyLogoURL = $themeObject->getImageURL('company_logo.png');
+    // END STIC-Custom
+
     ?>
     <!DOCTYPE html>
     <html lang="en">
@@ -378,7 +384,11 @@ function displayClosedPage($survey)
     <div class="container">
         <div class="row">
             <div class="col-md-offset-3 col-md-6">
-                <img height=100 src="modules/Surveys/Entry/survey_logo.jpg"/>
+                <!-- STIC-Custom 20240402 - JBL - Show logo in closed surveys -->
+                <!-- https://github.com/SinergiaTIC/SinergiaCRM/pull/93 -->
+                <!-- <img height=100 src="modules/Surveys/Entry/survey_logo.jpg"/> -->
+                <img src="<?php echo $companyLogoURL ?>"/>
+                <!-- END STIC-Custom -->
             </div>
         </div>
         <div class="row well">

--- a/modules/Surveys/Entry/Survey.php
+++ b/modules/Surveys/Entry/Survey.php
@@ -363,7 +363,7 @@ function displayDateField($question)
 function displayClosedPage($survey)
 {
     // STIC-Custom 20240402 - JBL - Show logo in closed surveys
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/93
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/184
     $themeObject = SugarThemeRegistry::current();
     $companyLogoURL = $themeObject->getImageURL('company_logo.png');
     // END STIC-Custom
@@ -385,7 +385,7 @@ function displayClosedPage($survey)
         <div class="row">
             <div class="col-md-offset-3 col-md-6">
                 <!-- STIC-Custom 20240402 - JBL - Show logo in closed surveys -->
-                <!-- https://github.com/SinergiaTIC/SinergiaCRM/pull/93 -->
+                <!-- https://github.com/SinergiaTIC/SinergiaCRM/pull/184 -->
                 <!-- <img height=100 src="modules/Surveys/Entry/survey_logo.jpg"/> -->
                 <img src="<?php echo $companyLogoURL ?>"/>
                 <!-- END STIC-Custom -->


### PR DESCRIPTION
- Closes #183 

## Descripción
Las encuestas, en estado "Cerrado" no mostraban la imagen del logo, tal y como ocurre en las encuestas en estado "público"

## Solución propuesta
La función `displayClosedPage` de `modules/Surveys/Entry/Survey.php` muestra la página de la encuesta si ésta está cerrada. 
La imagen que muestra no es la misma que la mostrada al renderizar la encuesta en estado "público"

Este PR cambia el origen de la imágen mostrada por la misma que se muestra en el caso de una encuesta pública. También se elimina la limitación del tamaño de la imagen, mostrándola igual que en una encuesta pública

## Pruebas
1. Crear una encuesta de prueba, con el estado "Público"
2. Abrir el enlace de la encuesta en una pestaña nueva
3. Verificar que el logo se visualiza correctamente
4. Cambiar el estado de la encuesta a "Cerrado"
5. Actualizar la pestaña con la encuesta
6. Verificar que se visualiza el logo de la misma forma que en la encuesta "Pública"