### PR TITLE
Hotfix - SinergiaDA - Evitar errores con campos llamados "email1" y otras mejoras

### DIFF
--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -936,8 +936,16 @@ class ExternalReporting
         $token = md5($token);
         $this->info .= "<li>Token md5: $token";
 
-        // Specify the URL to fetch content from.
-        $url = $sugar_config['stic_sinergiada_public']['url'] ?? "https://{$this->baseHostname}.sinergiada.org/edapi/updatemodel/update?tks=$token";
+        // Builds the URL to be called to execute the updateModel method in SinergiaDA,
+        // depending on whether a specific URL has been indicated or if a standard location will be used.
+        if($sugar_config['stic_sinergiada_public']['url'] ?? null ){
+            $url = "{$sugar_config['stic_sinergiada_public']['url']}/edapi/updatemodel/update?tks=$token";
+        }else{
+            $url = "https://{$this->baseHostname}.sinergiada.org/edapi/updatemodel/update?tks=$token";
+        }
+        
+        
+        
         $link = "<a href='$url' target='_blank'>$url</a>";
         $link2 = addslashes("Retry <a href='$url' target='_blank'>&#9842;</a>");
 

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -593,7 +593,7 @@ class ExternalReporting
                     case 'ColorPicker':
                     case 'email':
                         $fieldV['alias'] = $fieldV['name'];
-                        if ($fieldV['name'] == 'email1') {
+                        if ($fieldV['name'] == 'email1' && $fieldV['type'] == 'varchar' && $fieldV['source'] == 'non-db') {
                             // Special field for main email
                             $fieldSrc = "ea.email_address AS {$fieldV['name']}";
 
@@ -671,7 +671,8 @@ class ExternalReporting
 
                 if (isset($fieldSrc)) {
                     // Add to the array of normal base and custom fields
-                    if ($fieldV['source'] == 'custom_fields' || ($fieldV['source'] == 'custom_fields' && $fieldV['name'] == 'email1')) {
+                    // We give special treatment to fields named email1 to prevent them from being seen as custom fields, to avoid errors seen
+                    if ($fieldV['source'] == 'custom_fields' || ($fieldV['name'] == 'email1' && $fieldV['source'] == 'non-db' && $fieldV['type'] == 'varchar')) {
                         $fieldList['custom'][$fieldK] = $fieldSrc;
                         $addColumnToMetadata = 1;
                     } else if ($fieldV['source'] == 'non-db' && $fieldV['name'] != 'full_name') {

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -671,11 +671,10 @@ class ExternalReporting
 
                 if (isset($fieldSrc)) {
                     // Add to the array of normal base and custom fields
-                    // We give special treatment to fields named email1 to prevent them from being seen as custom fields, to avoid errors seen
-                    if ($fieldV['source'] == 'custom_fields' || ($fieldV['name'] == 'email1' && $fieldV['source'] == 'non-db' && $fieldV['type'] == 'varchar')) {
+                    if ($fieldV['source'] == 'custom_fields') {
                         $fieldList['custom'][$fieldK] = $fieldSrc;
                         $addColumnToMetadata = 1;
-                    } else if ($fieldV['source'] == 'non-db' && $fieldV['name'] != 'full_name') {
+                    } else if ($fieldV['source'] == 'non-db' && $fieldV['name'] != 'full_name' && $fieldV['name'] != 'email1') {
                         // This source is not processed, so we are moving them away
                         $fieldList['non-db'][$fieldK] = $fieldSrc;
                         $addColumnToMetadata = 0;

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -671,7 +671,7 @@ class ExternalReporting
 
                 if (isset($fieldSrc)) {
                     // Add to the array of normal base and custom fields
-                    if ($fieldV['source'] == 'custom_fields' || $fieldV['name'] == 'email1') {
+                    if ($fieldV['source'] == 'custom_fields' || ($fieldV['source'] == 'custom_fields' && $fieldV['name'] == 'email1')) {
                         $fieldList['custom'][$fieldK] = $fieldSrc;
                         $addColumnToMetadata = 1;
                     } else if ($fieldV['source'] == 'non-db' && $fieldV['name'] != 'full_name') {

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1016,9 +1016,7 @@ class ExternalReporting
         $tableLabel = empty($tableLabel) ? '-' : $tableLabel;
         // **Retrieve relationship information:**
         $rel = $db->fetchOne("select * from relationships where relationship_name='{$field['link']}'");
-        if ($tableName == 'stic_events') {
-            echo '';
-        }
+        
         // **Check if necessary information is present for standard join:**
         if (!empty($rel['join_table']) && !empty($rel['join_key_lhs']) && !empty($rel['join_key_rhs'])) {
             // Standard join using join table

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -392,9 +392,9 @@ class ExternalReporting
                                     continue 2;
                                 }
 
+                                // Build and obtain the translated value from the other side of the relationship so it can be properly displayed in SinergiaDA
                                 $joinModuleRelLabel = 'LBL_' . strtoupper($fieldV['link']) . '_FROM_' . strtoupper($moduleName) . '_TITLE';
                                 $joinLabel = translate($joinModuleRelLabel, $fieldV['module']);
-
                                 $joinLabel = empty($joinLabel) || $joinLabel == $joinModuleRelLabel ? $txModuleName : $joinLabel;
 
                                 $res = $this->createRelateLeftJoin($fieldV, $tableName, $joinLabel);


### PR DESCRIPTION
## Cambio 1
Se ha observado que la presencia de un campo denominado `email1` en cualquier módulo es interpretada erróneamente como si fuera el campo de email primario presente en los módulos de tipo Persona u Organizaciones. Esto provoca un error al generar la relación con la tabla custom del módulo (`_cstm`) cuando esta no existe.

En este PR se refinan las condiciones para tratar los campos de tipo email, incluso en el improbable caso (pero ya visto) de que haya un campo de tipo texto llamado `email1`.

**Pruebas a realizar**
- En el constructor de módulos, crear un módulo de tipo básico y añadir un campo de texto llamado **email1**.
- Comprobar que no da error al ejecutar la reconstrucción de SinergiaDA.


## Cambio 2
Al ejecutar la reconstrucción de fuentes de datos (rebuild), se llama al método updateModel usando una dirección preconstruida que supone que la instancia está en el dominio sinergiada.org y que el nombre del subdominio es compartido entre la instancia de SinergiaDA y la de Sinergia. Como esto no es así necesariamente, se ha modificado el código, de manera que se utilice el valor de la variable `$sugar_config['stic_sinergiada_public']['url']` si está definida, para construir la URL en la que se invocará el método updateModel.

**Pruebas a realizar**
- Asignar el valor de una instancia específica de SinergiaDA en la variable  `$sugar_config['stic_sinergiada_public']['url']` , en el fichero config_override.php 
```php
$sugar_config['stic_sinergiada_public']['url'] = 'https://ejemplosbase.sinergiada.org', 
```
Verificar que tras llamar al método update model usando `https://<sinergiacrm_host>/index.php?module=Administration&action=createReportingMySQLViews&debug=1&update_model=1&print_debug=1&rebuild_filter=all` es invocado el método update model en la url indicada.

Debe aparecer un mensaje similar a este al final de la página:
```
Token source: ???????????????????????????
Token md5: 3d04cf8c785906a1a5d9cc2ff6418495
URL: https://ejemplosbase.sinergiada.org/edapi/updatemodel/update?tks=3d04cf8c785906a1a5d9cc2ff6418495
Response: {"status":"ok"}
```


## Cambio 3
Se ha modificado el sistema de construcción de etiquetas para las relaciones que se muestran en SinergiaDA, ahora incluimos las etiquetas de la relación vistas desde ambos lados, de manera que en el campo _label_ de la tabla _sda_def_relationships_ guardamos una cadena que contiene ambos valores separados por `|`:
`Organización destinataria|Compromisos de pago en los que la organización es destinataria`
`Persona externa participante|Seguimientos`
...
Esto permite a SDA mostrar la etiqueta correcta dependiendo cuál sea el módulo para el que se están mostrando las relaciones.

**Pruebas a realizar**
Tras ejecutar el rebuild, verificar que el campo _label_ de la tabla _sda_def_relationships_ contiene los valores adecuados en el formato indicado

