### PR TITLE
Hotfix - Formularios web - Stripe: Eliminación de métodos de pago erróneos en producción

### DIFF
--- a/modules/stic_Web_Forms/Assistant/Donation/DonationController.php
+++ b/modules/stic_Web_Forms/Assistant/Donation/DonationController.php
@@ -255,7 +255,7 @@ class DonationController extends stic_Web_FormsAssistantController {
             ),
             array(
                 'NAME' => 'stripe_payment_method_types',
-                'VALUE' => 'card,paypal,sepa_debit,sofort',
+                'VALUE' => 'card,sepa_debit',
             ),
             array(
                 'NAME' => 'assigned_user_id',


### PR DESCRIPTION
- Closes #190 

## Descripción
Tal y como se describe en el Issue #190, al crear un formulario de captación de fondos con Stripe, los métodos de pago que se incluyen en el campo oculto '`stripe_payment_method_types`' incluyen Paypal. Esto no da problemas en el entorno de pruebas, pero en el entorno de producción, si no tienen configurado Paypal da errores: no se accede a la plataforma de pagos, se deriva a una página en blanco.

## Solución propuesta
Se ha optado por la solución 1 propuesta en el Issue #190: Modificar los valores del campo oculto y actualizar la wiki.
Se han eliminado los métodos de pago por defecto `paypal` y `sofort`

## Pruebas
(Por código)
- Desde el módulo de Campañas, crear un Formulario de captación de fondos:
   - Indiferente si es de personas u Organizaciones
   - En los parámetros del formulario, marcar: "Permitir pagos recurrentes con Stripe:" "Sí"
- Descargar el formulario y: 
    - Abrir formulario html generado con un editor de texto
    - Buscar el campo oculto `name="stripe_payment_method_types"`
    - Verificar que su valor es exáctamente: `"card,sepa_debit"`

