### PR TITLE
Hotfix - Ayudas - Error en las listas de tipo y subtipo 

### DIFF
--- a/modules/stic_Grants/metadata/searchdefs.php
+++ b/modules/stic_Grants/metadata/searchdefs.php
@@ -37,7 +37,7 @@ array(
                 'label' => 'LBL_TYPE',
                 'width' => '10%',
                 'default' => true,
-                'name' => 'amount',
+                'name' => 'type',
             ),
             'subtype' => array(
                 'type' => 'dynamicenum',
@@ -45,7 +45,7 @@ array(
                 'label' => 'LBL_SUBTYPE',
                 'width' => '10%',
                 'default' => true,
-                'name' => 'amount',
+                'name' => 'subtype',
             ),
             'amount' => array(
                 'type' => 'decimal',


### PR DESCRIPTION
## Descripción
En la vista de lista del módulo de Ayudas, la búsqueda tenía seleccionados incorrectamente los listados de tipo y subtipo.

## Pruebas

1. Ir al módulo de Ayudas y realizar una búsqueda.
2. Verificar que los campos de tipo y subtipo carguen los valores apropiados:

   - Tipo: Administraciones públicas, privadas, Propia entidad, ...
   - Subtipo: Bono social eléctrico, Ingreso mínimo vital, Renta garantizada de ciudadanía, Jubilación, Discapacidad, ...