### PR TITLE
Hotfix - Validación de importación - No crear registros relacionados al validar

### DIFF
--- a/modules/stic_Import_Validation/Importer.php
+++ b/modules/stic_Import_Validation/Importer.php
@@ -554,15 +554,16 @@ class Importer
 
             case 'relate':
             case 'parent':
-                $returnValue = $this->ifs->relate($rowValue, $fieldDef, $focus, empty($defaultRowValue));
-                if (!$returnValue && !empty($defaultRowValue)) {
-                    $returnValue = $this->ifs->relate($defaultRowValue, $fieldDef, $focus);
-                }
-                // Bug 33623 - Set the id value found from the above method call as an importColumn
-                if ($returnValue !== false) {
-                    $this->importColumns[] = $fieldDef['id_name'];
-                }
-                return $rowValue;
+                // Prevent the related record from being created
+                // $returnValue = $this->ifs->relate($rowValue, $fieldDef, $focus, empty($defaultRowValue));
+                // if (!$returnValue && !empty($defaultRowValue)) {
+                //     $returnValue = $this->ifs->relate($defaultRowValue, $fieldDef, $focus);
+                // }
+                // // Bug 33623 - Set the id value found from the above method call as an importColumn
+                // if ($returnValue !== false) {
+                //     $this->importColumns[] = $fieldDef['id_name'];
+                // }
+                // return $rowValue;
                 break;
             case 'teamset':
                 $this->ifs->teamset($rowValue, $fieldDef, $focus);


### PR DESCRIPTION
Este PR soluciona el siguiente issue encontrado en el proceso de validación de un fichero de importación. 

Se detecta que si el fichero de carga de datos contiene registros con campos de tipo relate, aunque el registro principal no se crea, si el registro relacionado no existe en el CRM, este sí se crea. Este caso es un error ya que en el proceso de validación no debería crearse ningún registro. 

Ejemplo 1: Al validar los registros de Personas, para las personas que tienen indicada una Organización, se detecta que el validador ha creado los registros de las organizaciones no existentes en el CRM. 

Ejemplo 2: Al validar los registros de Relaciones con Personas, para las relaciones que tienen indicado un Proyecto, el validador ha creado los registros de los proyectos no existentes en el CRM. 

**Pruebas**
1. Crear un fichero de datos donde indicar un valor no existente en el CRM para un campo de tipo relate. Por ejemplo, el campo Organización en Persona: [PersonaConOrganizacion.csv](https://github.com/SinergiaTIC/SinergiaCRM/files/15026544/PersonaConOrganizacion.csv)

2. Validar la importación del fichero y comprobar que no se ha creado un registro para el campo relacionado. 

3. Comprobar que el proceso de validación sigue funcionando correctamente. Validación de campos simples:
3.1 Probar a importar diferentes tipos de campos con valores erróneos que generen los diferentes tipos de error. Se puede partir y ampliar el siguiente [fichero](https://drive.google.com/file/d/1jX-gefiUAuceHbxAWe7xVh7HJ92G8_lc/view?usp=drive_link) de importación. Comprobar si se crea el error correspondiente en la columna de errores.

4. Validación e importación multimódulo
4.1 Comprobar la validación y la importación de diferentes archivos de importación que contengan información con datos de diferentes módulos. Fichero de ejemplo: [Personas - Relaciones - CdPs](https://drive.google.com/file/d/15VgYt4pt-p0PmMC3ZMIvjA-6WuIzl82f/view?usp=drive_link)
