### PR TITLE
Enhancement - Competencias - Rellenar el nombre con el  idioma indicado en "otros" cuando esté informado

### DIFF
--- a/modules/stic_Skills/stic_Skills.php
+++ b/modules/stic_Skills/stic_Skills.php
@@ -77,7 +77,7 @@ class stic_Skills extends Basic
         $this->fillName();
 
         if ($this->type == 'language') {
-            $this->skill=$app_list_strings['stic_skills_types_list'][$this->type];
+            $this->skill = $app_list_strings['stic_skills_types_list'][$this->type];
         }
         // Save the bean
         parent::save($check_notify);
@@ -99,15 +99,17 @@ class stic_Skills extends Basic
 
             if ($this->type === 'language') {
                 $this->name = $contactName . ' - ' .
-                    $app_list_strings['stic_skills_types_list'][$this->type] . ' - ' .
-                    $app_list_strings['stic_skills_languages_list'][$this->language];
+                    $app_list_strings['stic_skills_types_list'][$this->type] . ' - ';
+                if ($this->language === 'other') {
+                    $this->name .= $this->other;
+                } else {
+                    $this->name .= $app_list_strings['stic_skills_languages_list'][$this->language];
                 }
-            else {
+            } else {
                 $this->name = $contactName . ' - ' .
-                    $app_list_strings['stic_skills_types_list'][$this->type] . ' - ' .
-                    $this->skill;
+                $app_list_strings['stic_skills_types_list'][$this->type] . ' - ' .
+                $this->skill;
             }
-
 
         }
     }


### PR DESCRIPTION
- Closes #173 
## Descripción

Al crear una competencia no se estaba utilizando la opción "Otros" para informar el nombre cuando se seleccionaba el idioma "Otro". Si elegíamos uno de los idiomas disponibles, el nombre de la competencia se mostraba como: Ximena Aragón - Idioma - Español. Sin embargo, si el idioma no estaba en la lista predefinida, aparecería como Ximena Aragón - Idioma - Otro. Para solucionarlo, se ha modificado la función `fillName()` en el archivo `modules/stic_Skills/stic_Skills.php` para que, si el idioma es "Otro", se cargue el contenido del campo correspondiente.

## Pruebas

1. Ir a Competencias y seleccionar "Crear una competencia".
2. En el campo "Tipo", elegir "Idiomas".
3. En el campo "Idioma", seleccionar "Otros" y completar la casilla que aparece.
4. Guardar y verificar que ahora el nombre se informa con el valor ingresado en la casilla "Otros".



