### PR TITLE
Hotfix - Vistas Personalizadas - No se verifican correctamente las condiciones negadas

### DIFF
--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -210,19 +210,19 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
     switch (condition.operator) {
       case "Not_Equal_To":
         condition.operator = "Equal_To";
-        return !checkCondition_value(condition);
+        return !this.checkCondition_value(condition);
       case "Not_Contains":
         condition.operator = "Contains";
-        return !checkCondition_value(condition);
+        return !this.checkCondition_value(condition);
       case "Not_Starts_With":
         condition.operator = "Starts_With";
-        return !checkCondition_value(condition);
+        return !this.checkCondition_value(condition);
       case "Not_Ends_With":
         condition.operator = "Ends_With";
-        return !checkCondition_value(condition);
+        return !this.checkCondition_value(condition);
       case "is_not_null":
         condition.operator = "is_null";
-        return !checkCondition_value(condition);
+        return !this.checkCondition_value(condition);
     }
 
     var value_list = condition.value_list;

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -207,22 +207,33 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
   }
 
   checkCondition_value(condition) {
+    debugger;
     switch (condition.operator) {
       case "Not_Equal_To":
         condition.operator = "Equal_To";
-        return !this.checkCondition_value(condition);
+        var ret = !this.checkCondition_value(condition);
+        condition.operator = "Not_Equal_To";
+        return ret;
       case "Not_Contains":
         condition.operator = "Contains";
-        return !this.checkCondition_value(condition);
+        var ret = !this.checkCondition_value(condition);
+        condition.operator = "Not_Contains";
+        return ret;
       case "Not_Starts_With":
         condition.operator = "Starts_With";
-        return !this.checkCondition_value(condition);
+        var ret = !this.checkCondition_value(condition);
+        condition.operator = "Not_Starts_With";
+        return ret;
       case "Not_Ends_With":
         condition.operator = "Ends_With";
-        return !this.checkCondition_value(condition);
+        var ret = !this.checkCondition_value(condition);
+        condition.operator = "Not_Ends_With";
+        return ret;
       case "is_not_null":
         condition.operator = "is_null";
-        return !this.checkCondition_value(condition);
+        var ret = !this.checkCondition_value(condition);
+        condition.operator = "is_not_null";
+        return ret;
     }
 
     var value_list = condition.value_list;
@@ -311,7 +322,9 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
     switch (condition.operator) {
       case "Not_Equal_To":
         condition.operator = "Equal_To";
-        return !checkCondition_date(condition);
+        var ret = !this.checkCondition_value(condition);
+        condition.operator = "Not_Equal_To";
+        return ret;
     }
 
     var value_list = condition.value_list;


### PR DESCRIPTION
- Closes #213
## Descripción
Tal y como se describe en el issue #213:
Se observa un error en la verificación de las condiciones negadas en Vistas Personalizadas. Esto incluye: "Not_Equal_To", "Not_Contains", "Not_Starts_With", "Not_Ends_With" e "is_not_null"

## Motivo del error
El error estaba en el código javascript que evalúa las condiciones negadas: en vez de `!checkCondition_value(condition)`, debería haber `!this.checkCondition_value(condition)`
También existía otro error en la evaluación de las condiciones negadas: Se evaluaban correctamente al entrar en la vista, pero al modificar el valor a evaluar, la condición que se evaluaba no era la negada, ya que la primera evaluación cambiaba el operador de la condición. Este error se ha solucionado recuperando el operador original una vez evaluada la negación.

## Pruebas
1. Crear una Vista Personalizada con una condición de las incluídas en la desccripción
2. Verificar que la Vista Personalizada se aplica correctamente 
3. Verificar que en la Consola del Navegador no aparece ningún error

