### PR TITLE
Hotfix - Vistas Personalizadas - Error en ocultación de campos en vista Detalle

### DIFF
--- a/modules/stic_Custom_Views/processor/js/sticCVUtils.js
+++ b/modules/stic_Custom_Views/processor/js/sticCVUtils.js
@@ -482,11 +482,18 @@ var sticCVUtils = class sticCVUtils {
     return field;
   }
   static getRequiredStatus(field) {
-    var validateFields = validate[field.customView.formName];
-    for (var i = 0; i < validateFields.length; i++) {
-      // Array(name, type, required, msg);
-      if (validateFields[i][0] == field.name) {
-        return validateFields[i][2];
+    if (
+      field.customView &&
+      field.customView.formName &&
+      validate[field.customView.formName] &&
+      validate[field.customView.formName].length
+    ) {
+      var validateFields = validate[field.customView.formName];
+      for (var i = 0; i < validateFields.length; i++) {
+        // Array(name, type, required, msg);
+        if (validateFields[i][0] == field.name) {
+          return validateFields[i][2];
+        }
       }
     }
     return false;

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -207,7 +207,6 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
   }
 
   checkCondition_value(condition) {
-    debugger;
     switch (condition.operator) {
       case "Not_Equal_To":
         condition.operator = "Equal_To";


### PR DESCRIPTION
- Closes #232

### Descripción
Este PR soluciona la incidencia descrita en el Issue: La ocultación de múltiples campos en la vista Detalle no funcionaba correctamente.

### Solución 
Se producía un error de javascript al intentar verificar si el campo a ocultar es un campo requerido en la vista de detalle.
En la vista de detalle no existe información de los campos requeridos y la verificación fallaba, provocando que la aplicación de la siguiente acción de las Vistas Personalizadas no se ejecutase.
La solución implementa verifica que exista información sobre los campos que son requeridos en la vista actual, antes de comprobar si el campo a ocultar es requerido

### Pruebas
1. Crear una Vista Personalizada sobre el módulo Personas, en Vista de Detalle
2. Añadir dos acciones de ocultación de dos campos distintos (sin condiciones)
3. Abrir las herrramientas para desarrolladores del navegador, para ver la consola
4. En el módulo Personas, visualizar los detalles de una Persona
5. Verificar que en la Consola no se produce ningún error javascript
6. Verificar que los dos campos a ocultar se ocultan correctamente

