### PR TITLE
Hotfix - Vistas Personalizadas - Comportamiento anómalo al indicar campo "Solo lectura" y "Visible"

### DIFF
--- a/modules/stic_Custom_Views/processor/js/sticCVUtils.js
+++ b/modules/stic_Custom_Views/processor/js/sticCVUtils.js
@@ -547,7 +547,7 @@ var sticCVUtils = class sticCVUtils {
       if (first) {
         first = false;
       } else {
-        fieldContent.$readonlyLabel.append("<br>");
+        fieldContent.$readonlyLabel.append("<br />");
       }
       fieldContent.$readonlyLabel.append(line);
     });

--- a/modules/stic_Custom_Views/processor/js/sticCVUtils.js
+++ b/modules/stic_Custom_Views/processor/js/sticCVUtils.js
@@ -537,4 +537,19 @@ var sticCVUtils = class sticCVUtils {
     }
     return value;
   }
+
+  static fillReadonlyText(fieldContent) {
+    fieldContent.$readonlyLabel.empty();
+
+    var lines = fieldContent.text().split("\n");
+    var first = true;
+    lines.forEach(function(line) {
+      if (first) {
+        first = false;
+      } else {
+        fieldContent.$readonlyLabel.append("<br>");
+      }
+      fieldContent.$readonlyLabel.append(line);
+    });
+  }
 };

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -26,7 +26,12 @@
  */
 var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends sticCV_Element_Label {
   constructor(field, $fieldElement, fieldName) {
-    super(field.customView, $fieldElement.children('[field="' + fieldName + '"]'));
+    debugger;
+    var $contentElement = $fieldElement.children('[field="' + fieldName + '"]');
+    if ($contentElement.length == 0) {
+      $contentElement = $fieldElement.children(".stic-FieldContent").children('[field="' + fieldName + '"]');
+    }
+    super(field.customView, $contentElement);
 
     this.field = field;
     this.fieldName = fieldName;
@@ -56,16 +61,15 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
     this.$fieldText = this.$element.find(".sugar_field");
 
     this.$readonlyLabel = this.$element.parent().find(".stic-ReadonlyInput");
+    var classes = this.$element.attr("class").replace(/\bhidden\b/g, "").replace(/\s+/g, " ").trim();
     if (this.$readonlyLabel.length == 0 && this.$element.length > 0) {
-      var classes = this.$element.attr("class").replaceAll("hidden", "");
-
       this.$element
         .parent()
         .append(
           '<div class="' +
             classes +
             ' stic-ReadonlyInput hidden" ' +
-            'style="min-height:20px; height:30px; display:inline-flex; align-items:center; padding-left:5px; border-radius:0.25em;">' +
+            'style="min-height:20px; height:30px; display:inline-flex; align-items:center; padding-left:5px; border-radius:0.25em; width:90%">' +
             "</div>"
         );
       this.$readonlyLabel = this.$element.parent().find(".stic-ReadonlyInput");
@@ -75,6 +79,24 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
       var self = this;
       this.onChange(function() {
         self.$readonlyLabel.text(self.text());
+      });
+    }
+
+    // Move $element and $readonlyLabel inside new $element div
+    this.$elementEditor = this.$element;
+    this.$element = $fieldElement.find(".stic-FieldContent");
+    if (this.$element.length == 0 && this.$elementEditor.length > 0) {
+      this.$element = $('<div class="' + classes + ' stic-FieldContent" ' + "></div>");
+      this.$elementEditor.after(this.$element);
+      this.$element.append(this.$readonlyLabel);
+      this.$element.append(this.$elementEditor);
+
+      // Remove "col-" classes
+      this.$elementEditor.removeClass(function(index, className) {
+        return (className.match(/\bcol-\S+/g) || []).join(" ");
+      });
+      this.$readonlyLabel.removeClass(function(index, className) {
+        return (className.match(/\bcol-\S+/g) || []).join(" ");
       });
     }
   }
@@ -165,7 +187,7 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
           return false;
         }
         var readonly = sticCVUtils.isTrue(action.value);
-        this.applyAction({ action: "visible", value: !readonly });
+        sticCVUtils.show(this.$elementEditor, this.customView, !readonly);
         sticCVUtils.show(this.$readonlyLabel, this.customView, readonly);
         return this;
       case "inline":
@@ -176,6 +198,9 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
         return this;
       case "fixed_value":
         return this.value(action.value);
+      case "visible":
+        sticCVUtils.show(this.$element, this.customView, action.value);
+        return this;
     }
     return super.applyAction(action);
   }
@@ -207,7 +232,6 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
   }
 
   checkCondition_value(condition) {
-    debugger;
     switch (condition.operator) {
       case "Not_Equal_To":
         condition.operator = "Equal_To";

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -68,16 +68,18 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
           '<div class="' +
             classes +
             ' stic-ReadonlyInput hidden" ' +
-            'style="min-height:20px; height:30px; display:inline-flex; align-items:center; padding-left:5px; border-radius:0.25em; width:90%">' +
+            'style="min-height:30px; align-items:center; padding-left:5px; border-radius:0.25em; width:90%">' +
             "</div>"
         );
       this.$readonlyLabel = this.$element.parent().find(".stic-ReadonlyInput");
-      this.$readonlyLabel.text(this.text());
+      sticCVUtils.fillReadonlyText(this);
+      //this.$readonlyLabel.text(this.text());
 
       // Update label when value is changed
       var self = this;
       this.onChange(function() {
-        self.$readonlyLabel.text(self.text());
+        sticCVUtils.fillReadonlyText(self);
+        //self.$readonlyLabel.html(self.text());
       });
     }
 

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -73,13 +73,11 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
         );
       this.$readonlyLabel = this.$element.parent().find(".stic-ReadonlyInput");
       sticCVUtils.fillReadonlyText(this);
-      //this.$readonlyLabel.text(this.text());
 
       // Update label when value is changed
       var self = this;
       this.onChange(function() {
         sticCVUtils.fillReadonlyText(self);
-        //self.$readonlyLabel.html(self.text());
       });
     }
 

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -26,7 +26,6 @@
  */
 var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends sticCV_Element_Label {
   constructor(field, $fieldElement, fieldName) {
-    debugger;
     var $contentElement = $fieldElement.children('[field="' + fieldName + '"]');
     if ($contentElement.length == 0) {
       $contentElement = $fieldElement.children(".stic-FieldContent").children('[field="' + fieldName + '"]');


### PR DESCRIPTION
- Closes #217 

###  Descripción
Se ha detectado que en Vistas Personalizadas, al indicar una acción que fuerce la visibilidad de un campo que se ha marcado como "solo lectura", se muestra el editor del campo y un texto con el contenido del editor

El problema estaba en que al marcar como "solo lectura", se crea un elemento con el texto a mostrar y se ocultaba el elemento de edición del campo, y al marcarlo como Visible, se forzaba la visualización del elemento de edición

### Solución propuesta
En la estructura DOM de la vista, en el campo que se accede para modificarse por Vistas Personalizadas, se crea un elemento contenedor que incluye el elemento correspondiente al editor del campo y al correspondiente al texto mostrado en caso de "solo lectura".
Al ejecutar la acción de "solo lectura", se modificará la visibilidad del texto y el editor
Al ejecutar la acción de "visible", se modificará la visibilidad del nuevo contenedor con el texto y el editor

### Pruebas a realizar
1. Crear una Vista Personalizada del módulo Personas, en la Vista de Edición
2. Agregar una acción con: 
   - Modificación de campo - Apellidos - Solo lectura - Sí
   - Modificación de campo - Apellidos - Visible - Sí
3. Editar un registro de Persona
4. Verificar que el campo "Apellidos" se visualiza correctamente y no aparece su editor

Alternativamente:
- Crear acciones que modifiquen la visibilidad de un campo en función del valor de otro
- Crear una acción que modifique "solo lectura" del mismo campo, en función de otras condiciones
- Editar un registro del módulo afectado por la Vista Personalizada
- Realizar combinaciones para que se modifique la visibilidad y "solo lectura" del campo 
- Verificar que el comportamiento es el esperado