### PR TITLE
Improvement - Acciones de Github - Ignorando fingerprint en conexiones SSH

### DIFF
--- a/.github/workflows/Develop_CreateInstanceOnOpenedPR.yml
+++ b/.github/workflows/Develop_CreateInstanceOnOpenedPR.yml
@@ -23,13 +23,13 @@ jobs:
               with:
                 key: ${{ secrets.SSH_PRIVATE_KEY }}
                 known_hosts: unnecessary
-            - name: Adding Known Hosts Develop
-              run: ssh-keyscan -H $DEVELOP_HOST  >> ~/.ssh/known_hosts
-            - name: Adding Known Hosts Main
-              run: ssh-keyscan -H $MAIN_HOST  >> ~/.ssh/known_hosts
+            # - name: Adding Known Hosts Develop
+            #   run: ssh-keyscan -H $DEVELOP_HOST  >> ~/.ssh/known_hosts
+            # - name: Adding Known Hosts Main
+            #   run: ssh-keyscan -H $MAIN_HOST  >> ~/.ssh/known_hosts
             - name: Get Available database name
               run: 
-                DATABASE_NAME=$(ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "mysql -h 127.0.0.1 -u '${{ secrets.DEVELOP_DB_USERNAME }}' --password='${{ secrets.DEVELOP_DB_PASSWORD }}' -N -e 'select schema_name
+                DATABASE_NAME=$(ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "mysql -h 127.0.0.1 -u '${{ secrets.DEVELOP_DB_USERNAME }}' --password='${{ secrets.DEVELOP_DB_PASSWORD }}' -N -e 'select schema_name
                 from information_schema.schemata
                 where
                   SCHEMA_NAME not in (
@@ -50,11 +50,11 @@ jobs:
             - name: echo environment variables
               run: echo ${{ env }}
             # - name: Delete develop instance
-            #   run: ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "test -e /web/${{ env.BRANCH_CLEAN }}" && (echo "Directory branch exists" && ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "rm -rf /web/${{ env.BRANCH_CLEAN }} && mysql -h 127.0.0.1 -u $DEVELOP_DB_USERNAME --password=$DEVELOP_DB_PASSWORD -e 'drop database if exists ${{ env.DATABASE_NAME }}; create database ${{ env.DATABASE_NAME }};'") || echo "Branch doesn't exist in develop"
+            #   run: ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "test -e /web/${{ env.BRANCH_CLEAN }}" && (echo "Directory branch exists" && ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "rm -rf /web/${{ env.BRANCH_CLEAN }} && mysql -h 127.0.0.1 -u $DEVELOP_DB_USERNAME --password=$DEVELOP_DB_PASSWORD -e 'drop database if exists ${{ env.DATABASE_NAME }}; create database ${{ env.DATABASE_NAME }};'") || echo "Branch doesn't exist in develop"
             - name: Create Instance in develop through Main
-              run: ssh $MAIN_SSH_USERNAME@$MAIN_HOST "cd scripts/create && bash create.sh -b ${{ env.BRANCH }} -i $DEVELOP_DOMAIN_NAME -p /web/${{ env.BRANCH_CLEAN }} -db ${{ env.DATABASE_NAME }} -d -y"
+              run: ssh -o "StrictHostKeyChecking no" $MAIN_SSH_USERNAME@$MAIN_HOST "cd scripts/create && bash create.sh -b ${{ env.BRANCH }} -i $DEVELOP_DOMAIN_NAME -p /web/${{ env.BRANCH_CLEAN }} -db ${{ env.DATABASE_NAME }} -d -y"
             - name: Set Clean git branch
-              run: ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "test -e /web/${{ env.BRANCH_CLEAN }}" && (echo "Directory branch exists" && ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "cd /web/${{ env.BRANCH_CLEAN }} && git stash && git reset && git pull")
+              run: ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "test -e /web/${{ env.BRANCH_CLEAN }}" && (echo "Directory branch exists" && ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "cd /web/${{ env.BRANCH_CLEAN }} && git stash && git reset && git pull")
             - name: Get project data
               env:
                   GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/Develop_DeleteInstanceOnClosedPR.yml
+++ b/.github/workflows/Develop_DeleteInstanceOnClosedPR.yml
@@ -20,20 +20,20 @@ jobs:
               with:
                 key: ${{ secrets.SSH_PRIVATE_KEY }}
                 known_hosts: unnecessary
-            - name: Adding Known Hosts Develop
-              run: ssh-keyscan -H $DEVELOP_HOST  >> ~/.ssh/known_hosts
+            # - name: Adding Known Hosts Develop
+            #   run: ssh-keyscan -H $DEVELOP_HOST  >> ~/.ssh/known_hosts
             - name: Extract branch name
               run: echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} && echo 'BRANCH='${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} >> $GITHUB_ENV
             - name: Extract branch clean
               run: echo 'BRANCH_CLEAN='`echo ${{ env.BRANCH }} | sed -e 's/[^a-zA-Z0-9_/]//g'` >> $GITHUB_ENV
             - name: Get Develop instance database name
-              run: echo 'DATABASE_NAME='`ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST grep "db_name" /web/${{ env.BRANCH_CLEAN }}/config_override.php | sed "s/.*=.'//g" | sed "s/';.*//g"` >> $GITHUB_ENV
+              run: echo 'DATABASE_NAME='`ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST grep "db_name" /web/${{ env.BRANCH_CLEAN }}/config_override.php | sed "s/.*=.'//g" | sed "s/';.*//g"` >> $GITHUB_ENV
             - name: Set current date as env variable
               run: echo 'NOW='$(date +'%Y-%m-%d %H:%M:%S') >> $GITHUB_ENV
             - name: echo environment variables
               run: echo ${{ env }}
             - name: Delete develop instance
-              run: ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "test -e /web/${{ env.BRANCH_CLEAN }}" && (echo "Directory branch exists" && ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "rm -rf /web/${{ env.BRANCH_CLEAN }} && mysql -h 127.0.0.1 -u $DEVELOP_DB_USERNAME --password=$DEVELOP_DB_PASSWORD -e 'drop database if exists ${{ env.DATABASE_NAME }}; create database ${{ env.DATABASE_NAME }};'") || echo "Branch doesn't exist in develop"
+              run: ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "test -e /web/${{ env.BRANCH_CLEAN }}" && (echo "Directory branch exists" && ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "rm -rf /web/${{ env.BRANCH_CLEAN }} && mysql -h 127.0.0.1 -u $DEVELOP_DB_USERNAME --password=$DEVELOP_DB_PASSWORD -e 'drop database if exists ${{ env.DATABASE_NAME }}; create database ${{ env.DATABASE_NAME }};'") || echo "Branch doesn't exist in develop"
             - name: Create or Edit PR comment
               uses: thollander/actions-comment-pull-request@v1
               with:

--- a/.github/workflows/Develop_ReinstallInstanceOnUserAction.yml
+++ b/.github/workflows/Develop_ReinstallInstanceOnUserAction.yml
@@ -19,24 +19,24 @@ jobs:
               with:
                 key: ${{ secrets.SSH_PRIVATE_KEY }}
                 known_hosts: unnecessary
-            - name: Adding Known Hosts Develop
-              run: ssh-keyscan -H $DEVELOP_HOST  >> ~/.ssh/known_hosts
-            - name: Adding Known Hosts Main
-              run: ssh-keyscan -H $MAIN_HOST  >> ~/.ssh/known_hosts
+            # - name: Adding Known Hosts Develop
+            #   run: ssh-keyscan -H $DEVELOP_HOST  >> ~/.ssh/known_hosts
+            # - name: Adding Known Hosts Main
+            #   run: ssh-keyscan -H $MAIN_HOST  >> ~/.ssh/known_hosts
             - name: Extract branch clean
               run: echo 'BRANCH_CLEAN='`echo ${{ env.BRANCH }} | sed -e 's/[^a-zA-Z0-9_/]//g'` >> $GITHUB_ENV
             - name: Get Develop instance database name
-              run: echo 'DATABASE_NAME='`ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST grep "db_name" /web/${{ env.BRANCH_CLEAN }}/config_override.php | sed "s/.*=.'//g" | sed "s/';.*//g"` >> $GITHUB_ENV
+              run: echo 'DATABASE_NAME='`ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST grep "db_name" /web/${{ env.BRANCH_CLEAN }}/config_override.php | sed "s/.*=.'//g" | sed "s/';.*//g"` >> $GITHUB_ENV
             - name: Set current date as env variable
               run: echo 'NOW='$(date +'%Y-%m-%d %H:%M:%S') >> $GITHUB_ENV
             - name: echo environment variables
               run: echo ${{ env }}
             # - name: Delete develop instance
-            #   run: ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "test -e /web/${{ env.BRANCH_CLEAN }}" && (echo "Directory branch exists" && ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "rm -rf /web/${{ env.BRANCH_CLEAN }} && mysql -h 127.0.0.1 -u $DEVELOP_DB_USERNAME --password=$DEVELOP_DB_PASSWORD -e 'drop database if exists ${{ env.DATABASE_NAME }}; create database ${{ env.DATABASE_NAME }};'") || echo "Branch doesn't exist in develop"
+            #   run: ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "test -e /web/${{ env.BRANCH_CLEAN }}" && (echo "Directory branch exists" && ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "rm -rf /web/${{ env.BRANCH_CLEAN }} && mysql -h 127.0.0.1 -u $DEVELOP_DB_USERNAME --password=$DEVELOP_DB_PASSWORD -e 'drop database if exists ${{ env.DATABASE_NAME }}; create database ${{ env.DATABASE_NAME }};'") || echo "Branch doesn't exist in develop"
             - name: Create Instance in develop through Main
-              run: ssh $MAIN_SSH_USERNAME@$MAIN_HOST "cd scripts/create && bash create.sh -b ${{ env.BRANCH }} -i $DEVELOP_DOMAIN_NAME -p /web/${{ env.BRANCH_CLEAN }} -db ${{ env.DATABASE_NAME }} -d -y"
+              run: ssh -o "StrictHostKeyChecking no" $MAIN_SSH_USERNAME@$MAIN_HOST "cd scripts/create && bash create.sh -b ${{ env.BRANCH }} -i $DEVELOP_DOMAIN_NAME -p /web/${{ env.BRANCH_CLEAN }} -db ${{ env.DATABASE_NAME }} -d -y"
             - name: Set Clean git branch
-              run: ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "test -e /web/${{ env.BRANCH_CLEAN }}" && (echo "Directory branch exists" && ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "cd /web/${{ env.BRANCH_CLEAN }} && git stash && git reset && git pull")
+              run: ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "test -e /web/${{ env.BRANCH_CLEAN }}" && (echo "Directory branch exists" && ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "cd /web/${{ env.BRANCH_CLEAN }} && git stash && git reset && git pull")
             - name: Get project data
               env:
                   GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/Develop_UpdateInstanceOnPush.yml
+++ b/.github/workflows/Develop_UpdateInstanceOnPush.yml
@@ -21,26 +21,26 @@ jobs:
               with:
                 key: ${{ secrets.SSH_PRIVATE_KEY }}
                 known_hosts: unnecessary
-            - name: Adding Known Hosts Develop
-              run: ssh-keyscan -H $DEVELOP_HOST  >> ~/.ssh/known_hosts
-            - name: Adding Known Hosts Main
-              run: ssh-keyscan -H $MAIN_HOST  >> ~/.ssh/known_hosts
+            # - name: Adding Known Hosts Develop
+            #   run: ssh-keyscan -H $DEVELOP_HOST  >> ~/.ssh/known_hosts
+            # - name: Adding Known Hosts Main
+            #   run: ssh-keyscan -H $MAIN_HOST  >> ~/.ssh/known_hosts
             - name: Extract branch name
               run: echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} && echo 'BRANCH='${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} >> $GITHUB_ENV
             - name: Extract branch clean
               run: echo 'BRANCH_CLEAN='`echo ${{ env.BRANCH }} | sed -e 's/[^a-zA-Z0-9_/]//g'` >> $GITHUB_ENV
             - name: Get Develop instance database name
-              run: echo 'DATABASE_NAME='`ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST grep "db_name" /web/${{ env.BRANCH_CLEAN }}/config_override.php | sed "s/.*=.'//g" | sed "s/';.*//g"` >> $GITHUB_ENV
+              run: echo 'DATABASE_NAME='`ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST grep "db_name" /web/${{ env.BRANCH_CLEAN }}/config_override.php | sed "s/.*=.'//g" | sed "s/';.*//g"` >> $GITHUB_ENV
             - name: Set current date as env variable
               run: echo 'NOW='$(date +'%Y-%m-%d %H:%M:%S') >> $GITHUB_ENV
             - name: echo environment variables
               run: echo ${{ env }}
             - name: Update develop instance
-              run: ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "test -e /web/${{ env.BRANCH_CLEAN }}" && (echo "Directory branch exists" && ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "cd /web/${{ env.BRANCH_CLEAN }} && git stash && git pull && rm -rf /web/${{ env.BRANCH_CLEAN }}/cache") || echo "Branch doesn't exist in develop"
+              run: ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "test -e /web/${{ env.BRANCH_CLEAN }}" && (echo "Directory branch exists" && ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "cd /web/${{ env.BRANCH_CLEAN }} && git stash && git pull && rm -rf /web/${{ env.BRANCH_CLEAN }}/cache") || echo "Branch doesn't exist in develop"
             - name: Repair develop instance
-              run: ssh $MAIN_SSH_USERNAME@$MAIN_HOST "scp ~/scripts/common/SticRepair.php $DEVELOP_SSH_USERNAME@$DEVELOP_HOST:/web/${{ env.BRANCH_CLEAN }}/SticRepair.php" && 
+              run: ssh -o "StrictHostKeyChecking no" $MAIN_SSH_USERNAME@$MAIN_HOST "scp ~/scripts/common/SticRepair.php $DEVELOP_SSH_USERNAME@$DEVELOP_HOST:/web/${{ env.BRANCH_CLEAN }}/SticRepair.php" && 
                    wget -O - --no-check-certificate https://$DEVELOP_DOMAIN_NAME/${{ env.BRANCH_CLEAN }}/SticRepair.php &&
-                   ssh $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "rm -rf /web//${{ env.BRANCH_CLEAN }}/SticRepair.php"
+                   ssh -o "StrictHostKeyChecking no" $DEVELOP_SSH_USERNAME@$DEVELOP_HOST "rm -rf /web//${{ env.BRANCH_CLEAN }}/SticRepair.php"
             - name: Create or Edit PR comment
               uses: thollander/actions-comment-pull-request@v1
               with:


### PR DESCRIPTION
Hasta ahora se utilizaba el comando `ssh-keyscan -H $DEVELOP_HOST  >> ~/.ssh/known_hosts` para guardar el fingerprint del servidor de main/develop en el contener de la GH action y poder conectarse por SSH. Se ha visto que ahora esto no es suficiente para poder conectarse, seguramente por una actualización de los paquetes de OpenSSH en CDmon o en las GH action.

En este PR cambiamos el método y pasamos a utilizar el parámetro "-o "StrictHostKeyChecking no" cuando se realizan las llamadas SSH. De esta manera el cliente ya no comprueba el fingerprint del host al que se conecta.

**Pruebas:**
- Ejecutar las Acciones de GH de creación y actualización y comprobar que se ejecutan correctamente. La acción de borrado se ejecutará al cerrar el PR.