### PR TITLE
Improvement -  SinergiaDA - Varios cambios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ codeception.yml
 
 # Ignore application concatenated files
 /custom/application/Ext/*
+
+# Ignore SDA check rebuild errors
+sdaRebuildError.txt

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1201,7 +1201,6 @@ class ExternalReporting
         // 2) eda_def_groups
         $sqlMetadata[] = "CREATE or REPLACE VIEW `sda_def_groups` AS
                                   SELECT CONCAT('SDA_',name) as name FROM securitygroups WHERE deleted=0
-                                  UNION SELECT CONCAT('SDA_OWN_',user_name) FROM sda_def_users where active=1   -- auto group for owners
                                   UNION SELECT 'EDA_ADMIN'
                                   UNION SELECT 'NO_SINERGIACRM_USERS'
                                   ;";
@@ -1222,12 +1221,8 @@ class ExternalReporting
                                 AND u.deleted = 0
                                 AND su.deleted = 0
                                 AND s.deleted = 0
-
-                            -- Each user belongs to a group with their name that allows them to view records of which they are the owner                            UNION 
-                            UNION SELECT user_name, CONCAT('SDA_OWN_',user_name) FROM sda_def_users where active=1  
-
-                            -- Administrator users should always belong to the EDA_ADMIN group.
                             UNION
+                            -- Administrator users should always belong to the EDA_ADMIN group.
                             SELECT
                                 user_name,
                                 'EDA_ADMIN'

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -622,12 +622,6 @@ class ExternalReporting
                         $edaPrecision = $fieldV['type'] == 'currency' ? 2 : 0;
                         $edaPrecision = $fieldV['precision'] ? $fieldV['precision'] : $edaPrecision;
                         break;
-                    case 'id':
-                        // set id as numeric to allow counts and distinct counts
-                        $edaType = 'numeric';
-                        $edaPrecision = 0;
-                        $edaAggregations = 'count,count_distinct,none';
-                        break;
                     case 'date':
                     case 'datetime':
                     case 'datetimecombo':

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -377,13 +377,6 @@ class ExternalReporting
 
                             if (isset($fieldV['link']) && !empty($fieldV['link']) && $fieldV['name'] != 'assigned_user_name') {
 
-                                //*********************** */
-                                // Es una relación 1:n normal,
-                                if ($fieldV['module'] == $moduleName) {
-                                    // The standar relationships between the same module are directly excluded, because they cannot be represented in EDA
-                                    continue 2;
-                                }
-
                                 // Build and obtain the translated value from the other side of the relationship so it can be properly displayed in SinergiaDA
                                 $joinModuleRelLabel = 'LBL_' . strtoupper($fieldV['link']) . '_FROM_' . strtoupper($moduleName) . '_TITLE';
                                 $joinLabel = translate($joinModuleRelLabel, $fieldV['module']);

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1201,6 +1201,7 @@ class ExternalReporting
         // 2) eda_def_groups
         $sqlMetadata[] = "CREATE or REPLACE VIEW `sda_def_groups` AS
                                   SELECT CONCAT('SDA_',name) as name FROM securitygroups WHERE deleted=0
+                                  UNION SELECT CONCAT('SDA_OWN_',user_name) FROM sda_def_users where active=1   -- auto group for owners
                                   UNION SELECT 'EDA_ADMIN'
                                   UNION SELECT 'NO_SINERGIACRM_USERS'
                                   ;";
@@ -1221,8 +1222,12 @@ class ExternalReporting
                                 AND u.deleted = 0
                                 AND su.deleted = 0
                                 AND s.deleted = 0
-                            UNION
+
+                            -- Each user belongs to a group with their name that allows them to view records of which they are the owner                            UNION 
+                            UNION SELECT user_name, CONCAT('SDA_OWN_',user_name) FROM sda_def_users where active=1  
+
                             -- Administrator users should always belong to the EDA_ADMIN group.
+                            UNION
                             SELECT
                                 user_name,
                                 'EDA_ADMIN'

--- a/SticInclude/SinergiaDARebuild.php
+++ b/SticInclude/SinergiaDARebuild.php
@@ -63,10 +63,13 @@ class SinergiaDARebuild
                 $msg .= $match . "<br>";
             }
 
+            unlink('sdaRebuildError');
+            
             // Return 'ok' or the error message
             if (empty($msg)) {
                 return 'ok';
             } else {
+                file_put_contents('sdaRebuildError', $msg);
                 return $msg;
             }
             die();

--- a/SticInclude/SinergiaDARebuild.php
+++ b/SticInclude/SinergiaDARebuild.php
@@ -69,7 +69,7 @@ class SinergiaDARebuild
             if (empty($msg)) {
                 return 'ok';
             } else {
-                file_put_contents('sdaRebuildError', $msg);
+                sugar_file_put_contents('sdaRebuildError.txt', $msg);
                 return $msg;
             }
             die();


### PR DESCRIPTION
## 1. _Se deshace el forzado de tipo para los campos id_

En el pasado, se forzaba a tipo numérico los campos de _id_, para que pudieran usarse agregaciones de tipo count, count distinct, etc. Ahora esto no es necesario, ya que estas agregaciones se pueden usar en SinergiaDA de manera natural con los campos de tipo texto. Además, ahora permite que en caso necesario, el valor del id se muestre correctamente, al no estar forzado el tipo de datos.

### Pruebas:

- Verificar que en la tabla sda_def_columns, los campos de tipo id son de tipo text e incluyen las agregaciones _count_ y _count distinct_
- Verificar que los informes que incluyen campos de tipo id se muestran correctamente y sin alterar el resultado de los informes.

## 2. _Creación de fichero especial si se produce algún error al ejecutar rebuild_

Para poder monitorizar si se ha producido un error al ejecutar el método rebuild, si esto sucede se crea un fichero en la raiz de la instancia, llamado _sdaRebuildError_ que contiene el/los mensaje de error provocados. Si la ejecución funciona correctamente, se borra el mensaje.

### Pruebas:

- Provocar un error, por ejemplo eliminando o renombrando una columna de la tabla de algún módulo, y **sin reparar** ejecutar el rebuild. El proceso fallará y se creará el fichero en la raiz de la instancia.

## 3. _Habilitar autorelaciones entre módulos_. 

Hasta el momento las autorelaciones entre un mismo módulo estaban deshabilitadas, de modo que cuando se detectaban se pasaba automáticamente al siguiente campo omitiendo cualquier acción. En este PR se modifica el comportamiento para que estas relaciones sean normalmente procesadas.

### Pruebas:
- Crear una auto relación en cualquier módulo del tipo 1:1 o 1:n y verificar que tras ejecutar _rebuild_, la relación aparece correctamente registrada en la tabla _sda_def_relationships_
