### PR TITLE
Hotfix - Formularios Web - Pérdida del EntryPoint si algún campo contiene doble comilla

### DIFF
--- a/modules/stic_Web_Forms/Assistant/AssistantController.php
+++ b/modules/stic_Web_Forms/Assistant/AssistantController.php
@@ -256,6 +256,10 @@ class stic_Web_FormsAssistantController extends stic_Web_FormsController
     
     	// Treat the persistence field
     	if (! empty($this->persistentData)) {
+			// Ensure $this->persistentData is correct
+			if(strpos($this->persistentData, '"') !== false) {
+				$this->persistentData = htmlentities($this->persistentData);
+			}
     		$this->persistentData = json_decode(html_entity_decode($this->persistentData),true);
     	} 
     	else {


### PR DESCRIPTION
- Closes #249 

### Descripción y análisis
Ver issue #249
En la generación de formularios web stic (inscripción a evento, por ejemplo), si se escoge un evento cuyo nombre contenga doble comilla (` " `), al generar el formulario, no aparece el EntryPoint, provocando que el formulario no funcione:
En vez de generar:
```html
<form action="https://<INSTANCIA>/index.php?entryPoint=stic_Web_Forms_save" name="WebToLeadForm" method="POST" id="WebToLeadForm" >
```
Genera erróneamente:
```html
<form action="" name="WebToLeadForm" method="POST" id="WebToLeadForm" > 
```
### Solución propuesta
El error estaba en una discrepancia entre cómo se reciben los datos entre  el último paso y los demás del asistente de creación de formularios: en los primeros pasos los datos habían pasado por la función `htmlentities` y en el último no.
Esto es debido a una excepción en el `config.php` para este último paso del asistente:
https://github.com/SinergiaTIC/SinergiaCRM/blob/e4492cab3fdd7f41f926e0b5ff18d206b1b8ecbb/config.php#L548-L554

Esta excepción solucionaba antiguas incidencias.

La solución propuesta mira si los datos recibidos han pasado por la función `htmlentities` antes de decodificarlos.
**Observación**: Los datos que se reciben es una cadena json, con los parámetros y valores entre comillas. Si han pasado por la función `htmlentities` tienen este formato: `{&quot;EVENT_NAME&quot;:&quot;Evento &quot;Prueba&quot;&quot;}` y si no, este: `{"EVENT_NAME":"Evento "Prueba""}`

### Pruebas
1. Crear o editar un evento con alguna doble comilla (`"`) en su nombre
2. Crear un formulario de inscripción a eventos
    1. Seleccionar el evento con el nombre con comillas
3. Verificar que en el código del formulario generado tiene definida la `action` del `<form>`
