### PR TITLE
Improvement - General - Deshabilitar carga de UI por Ajax 

### DIFF
--- a/config.php
+++ b/config.php
@@ -585,4 +585,9 @@ $sugar_config = array(
     // https://github.com/SinergiaTIC/SinergiaCRM/pull/3
     'stic_security_groups_rules_enabled' => false,
     // END STIC
+
+    // STIC-Custom 20240538 JBL - Disable AjaxUI calls
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    'disableAjaxUI' => true,
+    // END STIC
 );

--- a/config.php
+++ b/config.php
@@ -586,7 +586,7 @@ $sugar_config = array(
     'stic_security_groups_rules_enabled' => false,
     // END STIC
 
-    // STIC-Custom 20240538 JBL - Disable AjaxUI calls
+    // STIC-Custom 20240528 JBL - Disable AjaxUI calls
     // https://github.com/SinergiaTIC/SinergiaCRM/pull/253
     'disableAjaxUI' => true,
     // END STIC

--- a/config.php
+++ b/config.php
@@ -587,7 +587,7 @@ $sugar_config = array(
     // END STIC
 
     // STIC-Custom 20240538 JBL - Disable AjaxUI calls
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/253
     'disableAjaxUI' => true,
     // END STIC
 );


### PR DESCRIPTION
## Descripción
Mediante este PR se deshabilitan las llamadas Ajax para la carga de la interfaz de SinergiaCRM.

## Motivación
Deshabilitando las llamadas de AjaxUI:
- La navegación entre módulos y la carga de las páginas no se ve afectada (parece hasta más rápida)
- Las urls son más descriptivas
- Se evitan dobles recargas para aquellos usuarios que entren en más de una instancia a la vez
- La recarga automática de recursos por incremento de versión es más rápida
- Se evita la necesidad de generar código extra y complejo al modificar los tpl de cabecera
- No se ha observado ningún comportamiento anómalo en las instancias con esta configuración
Discusión sobre este punto en el foro de SuiteCRM: https://community.suitecrm.com/t/disabling-ajaxui/66943

## Pruebas
1. Navegar por la instancia
2. Verificar que las url en el navegador no tienen la cadena `&action=ajaxui#ajaxUILoc=`
3. Comprobar que la instancia funciona correctamente
