### PR TITLE
Hotfix - Validación de importación - Añadir un paréntesis

### DIFF
--- a/modules/stic_Import_Validation/Importer.php
+++ b/modules/stic_Import_Validation/Importer.php
@@ -496,7 +496,9 @@ class Importer
             if (count($fields) > 1) {
                 $query .= "
                 OR ";
-            } 
+            } else {
+                $query .= ")";
+            }
 
         } else {
             // If it has not been filtered by Email, we add WHERE to the query
@@ -515,7 +517,7 @@ class Importer
         }
         // Add the deleted = 0 clause
         $query .= "
-        AND m.deleted = 0)";
+        AND m.deleted = 0";
 
         // Get the ID of the first record that meets the query
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __FILE__ . ': Query fo getIDForBBDD(): '. $query);

--- a/modules/stic_Import_Validation/Importer.php
+++ b/modules/stic_Import_Validation/Importer.php
@@ -490,7 +490,9 @@ class Importer
             $query .= "
             JOIN email_addr_bean_rel as ea ON m.id = ea.bean_id
             JOIN email_addresses as e ON ea.email_address_id = e.id
-            WHERE (e.email_address_caps = '{$emailCap}'";
+            WHERE ( ea.deleted = 0                   
+                AND e.deleted = 0 
+                AND e.email_address_caps = '{$emailCap}'";
 
             // If, in addition to the email, there are more filters to search for duplicates, we add OR operator to the query
             if (count($fields) > 1) {

--- a/modules/stic_Import_Validation/Importer.php
+++ b/modules/stic_Import_Validation/Importer.php
@@ -515,7 +515,7 @@ class Importer
         }
         // Add the deleted = 0 clause
         $query .= "
-        AND m.deleted = 0";
+        AND m.deleted = 0)";
 
         // Get the ID of the first record that meets the query
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __FILE__ . ': Query fo getIDForBBDD(): '. $query);


### PR DESCRIPTION
## Description
Se detecta durante la validación de datos a importar que al buscar duplicados por email en registros ya existentes en la base de datos, el validador no devuelve el ID de alguno de los registros encontrados, si no que genera uno nuevo. 

Esto es debido a que la query que debería devolver el ID tiene mal cerrado un paréntesis. 


*Pruebas*
1. Crear una persona con un email
2. Exportar esa persona, abrir el fichero y dejar solo la columnas de Apellidos y Correo electrónico. 
3. Validar el fichero de importación, indicando en el paso 4 que busque duplicados por correo electrónico 
4. Abrir el fichero enriquecido y comprobar que en la columna de **Personas - ID** ha devuelto el ID de la persona del paso 1. 
5. Comprobar que al buscar duplicados con otros filtros (Nombre, apellidos, DNI, etc) sigue funcionando. 