### PR TITLE
Hotfix - Registro horario -  Error en código javascript si el módulo está desactivado

### DIFF
--- a/modules/stic_Time_Tracker/menuButton/SticTimeTrackerButtonInMainMenu.js
+++ b/modules/stic_Time_Tracker/menuButton/SticTimeTrackerButtonInMainMenu.js
@@ -27,8 +27,8 @@ function checkTimeTrackerButtonStatus()
                     }
                 });        
             } else {
-                buttonRow.each(function(index, element) {
-                    buttonRow.classList.add('no-show-time-tracker-button');
+                buttonRow.forEach(function(element) {
+                    element.classList.add('no-show-time-tracker-button');
                 }); 
             }
         })


### PR DESCRIPTION
## Description
Se detecta el siguiente error en JS cuando el módulo de Registro horario no está activado:

> SticTimeTrackerButtonInMainMenu.js?v=WbitCcKyY2lRZyTn2YTmzQ:36 Failed to get time tracker button status. Could not find out if there is a time record started for today and for the logged in employee: TypeError: buttonRow.each is not a function
>     at SticTimeTrackerButtonInMainMenu.js?v=WbitCcKyY2lRZyTn2YTmzQ:30:27
> 

## Pruebas
1. Comprobar que el módulo de Registro horario está desactivado y, si no es así, desactivarlo. 
2. Abrir el inspector del navegador y comprobar que no se muestra el error 
