### PR TITLE
Hotfix - SinergiaDA - Corrección en nombre de fichero de errores de rebuild

### DIFF
--- a/SticInclude/SinergiaDARebuild.php
+++ b/SticInclude/SinergiaDARebuild.php
@@ -63,7 +63,7 @@ class SinergiaDARebuild
                 $msg .= $match . "<br>";
             }
 
-            unlink('sdaRebuildError');
+            unlink('sdaRebuildError.txt');
             
             // Return 'ok' or the error message
             if (empty($msg)) {


### PR DESCRIPTION
Se corrige el nombre del fichero que se borra, al ejecutar rebuild y encontrar errores, puesto que le falta la extensión, lo que provoca que no se borre el fichero generado al encontrar errores.

Como probarlo:
-  Crear en la raiz de la instancia un fichero llamado _sdaRebuildError.txt_, con cualquier contenido y comprobar que tras ejecutar rebuild, si no se producen errores, el fichero es borrado.