### PR TITLE
Hotfix - Registro horario y Calendario laboral - Evitar el uso de sugar_die() cuando no es un caso de error

### DIFF
--- a/modules/stic_Time_Tracker/controller.php
+++ b/modules/stic_Time_Tracker/controller.php
@@ -34,7 +34,7 @@ class stic_Time_TrackerController extends SugarController {
     {
         // Check if the user has started any time registration today
         $GLOBALS['log']->debug('Line '.__LINE__.': '.__METHOD__.':  Checking time tracker registration status.');
-        global $timedate, $current_user;
+        global $current_user;
         
         // Check if time tracker module is active
         include_once 'modules/MySettings/TabController.php';

--- a/modules/stic_Time_Tracker/controller.php
+++ b/modules/stic_Time_Tracker/controller.php
@@ -53,10 +53,12 @@ class stic_Time_TrackerController extends SugarController {
         );
         
         // return the json result
+        ob_clean();
         $json = json_encode($data);
         header('Content-Type: application/json');
         echo $json;
-        sugar_die('');
+        ob_flush();
+        die();
     }
 
     /**
@@ -75,16 +77,18 @@ class stic_Time_TrackerController extends SugarController {
 
         // Get record data
         $recordName = stic_Time_Tracker::getLastTodayTimeTrackerRecord($current_user->id)['name'];
-
-        // return the json result
         $data = array(
             'date' => $currentUserNow,
             'recordName' => $recordName,
         );
+        
+        // return the json result
+        ob_clean();
         $json = json_encode($data);
         header('Content-Type: application/json');
         echo $json;
-        sugar_die('');
+        ob_flush();
+        die();
     }
 
     /**
@@ -122,6 +126,5 @@ class stic_Time_TrackerController extends SugarController {
             '.$data['description']; 
         }
         $bean->save(false);
-        sugar_die('');
     }
 }

--- a/modules/stic_Work_Calendar/controller.php
+++ b/modules/stic_Work_Calendar/controller.php
@@ -59,9 +59,11 @@ class stic_Work_CalendarController extends SugarController
             }
 
             require_once 'modules/stic_Work_Calendar/Utils.php';
+            ob_clean();
             echo(stic_Work_CalendarUtils::existsRecordsWithIncompatibleType($id, $startDate, $endDate, $type, $assignedUserId));
+            ob_flush();
         }
-        sugar_die('');    
+        die('');    
     }
 
 


### PR DESCRIPTION
- closes #264 

## Description

Tanto en código stic como en código de suitecrm se utiliza **die()** para finalizar la ejecución de un código que ha cumplido su misión, como es el caso de los métodos de Registro horario cuyo objetivo es devolver información al navegador.

**sugar_die()** se usa para matar la ejecución de procesos que han fallado y, entre otras cosas, pinta el mensaje en el log para que se sepa del error.

Además, se aprovecha el PR para introducir el uso de los métodos ob_clean() y ob_flush() para limpiar el buffer de salida antes y después de enviar el contenido el buffer al navegador 

## Pruebas
1. Acceder al CRM y comprobar que la acción que pinta el botón de Registro horario ya no muestra logs en suitecrm.log
2. Pulsar en el botón y comprobar que la acción que dibuja el cuadro de dialogo ya no muestra logs en suitecrm.log
3. Pulsar en el botón de aceptar del cuadro de dialogo y comprobar que la acción de crear o modificar un registro horario ya no muestra logs en suitecrm.log
4. Crear un registro de Calendario laboral de tipo Vacaciones. Duplicarlo y comprobar que el método que informa del error de validación de que existen tipos incompatibles ya no muestra logs en suitecrm.log. 