### PR TITLE
Hotfix - Campañas - Auditar los cambios al pulsar en el enlace de baja de una campaña de email

### DIFF
--- a/modules/Campaigns/RemoveMe.php
+++ b/modules/Campaigns/RemoveMe.php
@@ -88,13 +88,46 @@ if (!empty($_REQUEST['identifier'])) {
         $id = $db->quote($id);
 
         //no opt out for users.
-        if (preg_match('/^[0-9A-Za-z\-]*$/', $id) && $module != 'Users') {
+        if (preg_match('/^[0-9A-Za-z\-]*$/', $id) && $module != 'Users') 
+        {
             //record this activity in the campaing log table..
             $query = "UPDATE email_addresses SET email_addresses.opt_out = 1 WHERE EXISTS(SELECT 1 FROM email_addr_bean_rel ear WHERE ear.bean_id = '$id' AND ear.deleted=0 AND email_addresses.id = ear.email_address_id)";
             $status=$db->query($query);
             if ($status) {
                 echo "*";
             }
+
+        	// STIC-Custom 202410617 MHP - Audit in email_addresses_audit table the unsubscription action through the campaign email 
+            // 
+
+            // SELECT the email_address_id from the emails related to the user who is unsubscribing
+            $query = "SELECT email_address_id FROM email_addr_bean_rel WHERE bean_id = '$id';";
+            $result = $db->query($query);
+            
+            while ($row = $db->fetchByAssoc($result)) {
+                $emailAddressesID[] = "'" . $row['email_address_id'] . "'" ;
+            }
+            $emailsContidion = implode(", ", $emailAddressesID);
+
+            $query = "SELECT id, opt_out FROM `email_addresses` WHERE `id` IN ($emailsContidion);"; 
+            $result = $db->query($query);
+
+            // Retrieve the opt-out value for each email and, if the value has changed, insert the audit log
+            while ($row = $db->fetchByAssoc($result)) 
+            {
+                if ($row['opt_out'] != '1') {
+                    $newId = create_guid();
+                    $emailAddressId = $row['id'];
+                    $query = "INSERT INTO email_addresses_audit
+                             (id, parent_id, date_created, created_by, field_name, data_type, before_value_string, after_value_string, before_value_text, after_value_text) VALUES
+                             ('$newId', '$emailAddressId', UTC_TIMESTAMP(), '1', 'opt_out','bool','0','1',NULL,NULL)";
+                    $result2 = $db->query($query);
+                    if ($result2) {
+                        $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ": Error inserting the corresponding record with parent_id = $id into the email_addresses_audit table");
+                    }                
+                }
+            }            
+            // END STIC-Custom            
         }
     }
     //Print Confirmation Message.


### PR DESCRIPTION
## Descripción
Se observa que si un usuario tiene varias direcciones de correo, al pulsar el enlace de baja de una campaña de tipo correo electrónico, el CRM configura como _Rehusado_ todas las cuentas de correo relacionadas con la persona o interesado y no solo la cuenta desde la que pulsó en el enlace de baja. 

Comentándolo en el área de desarrollo, este comportamiento es razonable ya que la persona o interesado ha indicado que no quiere recibir más correos de campañas de email, por lo que la solución al PR tiene en cuenta esto y creará un registro por cada una de las direcciones de email en la tabla _email_addresses_audit_



## Cómo reproducir el problema
1. Crear una persona o un interesado con un email o con varios emails.
2. Crear una campaña de email y enviar un email al interesado o a la persona. 
3. Pulsar en el enlace de baja y comprobar que el cambio ha sido auditado en la tabla de _email_addresses_audit_


