### PR TITLE
Hotfix - Registro horario - Error JS en página de Login

### DIFF
--- a/custom/modules/Calendar/Calendar.php
+++ b/custom/modules/Calendar/Calendar.php
@@ -502,6 +502,7 @@ class CustomCalendar extends Calendar
 
     /**
      * STIC-Custom 20240222 MHP - Includes/excludes the stic_Work_Calendar records from the activities array according to filters values.
+     * https://github.com/SinergiaTIC/SinergiaCRM/pull/114
      * 
      * Current existing filters:
      * - stic_work_calendar_type

--- a/custom/themes/SuiteP/modules/Calendar/tpls/settings.tpl
+++ b/custom/themes/SuiteP/modules/Calendar/tpls/settings.tpl
@@ -94,7 +94,8 @@ $(function() {
 									</tr>
 									<tr>
 										<td scope="row" valign="top" width="55%">
-											<!-- STIC-Custom 20240222 MHP - Add information icon and informational popup -->	
+											<!-- STIC-Custom 20240222 MHP - Add information icon and informational popup 
+												 https://github.com/SinergiaTIC/SinergiaCRM/pull/114 -->     	
 											<!-- {$MOD.LBL_SETTINGS_DISPLAY_SHARED_CALENDAR_SEPARATE} -->
 											{$MOD.LBL_SETTINGS_DISPLAY_SHARED_CALENDAR_SEPARATE} 
 											<i class="inline-help glyphicon glyphicon-info-sign"></i>
@@ -210,7 +211,8 @@ $(function() {
 										<th>Module</th><th>Body</th><th>Border</th><th>Text</th>
 									</tr>
 									{foreach from=$activity key=name item=def}
-										<!-- STIC-Custom 20240222 MHP - The work calendar records are colored depending on whether they are work type or not. -->	
+										<!-- STIC-Custom 20240222 MHP - The work calendar records are colored depending on whether they are work type or not. 
+										     https://github.com/SinergiaTIC/SinergiaCRM/pull/114 -->	
                                         {if $name != 'stic_Work_Calendar'}
 											<tr>
 												<td>{$def.label}</td>

--- a/custom/themes/SuiteP/tpls/_head.tpl
+++ b/custom/themes/SuiteP/tpls/_head.tpl
@@ -93,7 +93,8 @@
     <script type="text/javascript" src='{sugar_getjspath file="themes/SuiteP/js/jscolor.js"}'></script>
     <script type="text/javascript" src='{sugar_getjspath file="cache/include/javascript/sugar_field_grp.js"}'></script>
     <script type="text/javascript" src='{sugar_getjspath file="vendor/tinymce/tinymce/tinymce.min.js"}'></script>
-    {* STIC-Custom 20240222 MHP - Add CSS and JS for efficient registration button handling *}     
+    {* STIC-Custom 20240222 MHP - Add CSS and JS for efficient registration button handling 
+       https://github.com/SinergiaTIC/SinergiaCRM/pull/114 *}     
     <link href="modules/stic_Time_Tracker/menuButton/SticTimeTrackerButtonInMainMenu.css" rel="stylesheet" type="text/css"/>    
     <script type="text/javascript" src='{sugar_getjspath file="modules/stic_Time_Tracker/menuButton/SticTimeTrackerButtonInMainMenu.js"}'></script>
     {literal}

--- a/custom/themes/SuiteP/tpls/_head.tpl
+++ b/custom/themes/SuiteP/tpls/_head.tpl
@@ -102,7 +102,10 @@
             // If used, updates the button color based on whether or not there is an active time record for today
             $(document).ready(function() 
             {
-                checkTimeTrackerButtonStatus();
+                // Check that it is not the login view
+                if (!window.location.href.includes('action=Login') && !window.location.href.includes('module=Users')) {
+                    checkTimeTrackerButtonStatus();
+                }
             });
         </script>
     {/literal}

--- a/custom/themes/SuiteP/tpls/_headerModuleList.tpl
+++ b/custom/themes/SuiteP/tpls/_headerModuleList.tpl
@@ -593,7 +593,8 @@
                         </form>
                     </div>
                 </li>
-                {* STIC-Custom 20240222 MHP - Adding efficient registration button *}
+                {* STIC-Custom 20240222 MHP - Adding efficient registration button 
+                   https://github.com/SinergiaTIC/SinergiaCRM/pull/114 *}
                 <li class="time_tracker_button_row no-show-time-tracker-button">
                     <button class="time_tracker_button btn suitepicon suitepicon-module-tasks"
                         onclick="showTimeTrackerConfirmBox();"></button>
@@ -732,7 +733,8 @@
                             </div>
                         </form>
                     </li>
-                    {* STIC-Custom 20240222 MHP - Adding efficient registration button *}
+                    {* STIC-Custom 20240222 MHP - Adding efficient registration button 
+                       https://github.com/SinergiaTIC/SinergiaCRM/pull/114     *}
                     <li class="time_tracker_button_row no-show-time-tracker-button">
                         <button class="time_tracker_button btn suitepicon suitepicon-module-tasks"
                             onclick="showTimeTrackerConfirmBox();"></button>
@@ -854,7 +856,8 @@
                                 </div>
                             </form>
                         </li>
-                        {* STIC-Custom 20240222 MHP - Adding efficient registration button *}
+                        {* STIC-Custom 20240222 MHP - Adding efficient registration button 
+                           https://github.com/SinergiaTIC/SinergiaCRM/pull/114 *}
                         <li class="time_tracker_button_row no-show-time-tracker-button">
                             <button class="time_tracker_button btn suitepicon suitepicon-module-tasks"
                                 onclick="showTimeTrackerConfirmBox();"></button>
@@ -893,7 +896,8 @@
                         </ul>
                     </div>
             </nav>
-            {* STIC-Custom 20240222 MHP - Add registration button dialog *}
+            {* STIC-Custom 20240222 MHP - Add registration button dialog 
+               https://github.com/SinergiaTIC/SinergiaCRM/pull/114 *}
             <div id="time-tracker-dialog-box"></div>
             {* END STIC-Custom *}
             <!--End Responsive Top Navigation Menu -->


### PR DESCRIPTION

## Descripción
Se detecta que en la página de login del CRM se produce un error JS relacionado con el botón de registro horario. 

`SticTimeTrackerButtonInMainMenu.js?v=ZWwyFYVMVtOoy_EHWuepyA:36 Failed to get time tracker button status. Could not find out if there is a time record started for today and for the logged in employee: SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON`

Este PR resuelve la incidencia comprobando, antes de consultar si tiene que pintar o no dicho botón, que no se esté en la página de Login. 


[FYI] Además, se detecta que algunos comentarios relacionados con el PR principal que implemento esta funcionalidad no tenían indicado el ID de dicho PR, por lo que he aprovechado este PR para indicarlo. 


## Pruebas
1. Acceder a la página de login y comprobar que ya no se muestra el error JS
2. Acceder al CRM y comprobar que el botón se muestra correctamente una vez logueado (tener en cuenta las condiciones para que se muestre el botón: Módulo activado y checkbox de Registro horario en el perfil del usuario activado)