### PR TITLE
Hotfix - Calendario laboral - No asignar valor a repeat_count cuando llega a null

### DIFF
--- a/modules/stic_Work_Calendar/Utils.php
+++ b/modules/stic_Work_Calendar/Utils.php
@@ -109,7 +109,7 @@ class stic_Work_CalendarUtils
         // Get the data from the smarty template
         $repeat_type = $_REQUEST['repeat_type'] ?: 'Daily' ;
         $interval = $_REQUEST['repeat_interval'] ?: '1';
-        $count = $_REQUEST['repeat_count'] ?: '1';
+        $count = $_REQUEST['repeat_count'];
         $until = $_REQUEST['repeat_until'];
         $type = $_REQUEST['type'];
         $startDay = $_REQUEST['repeat_start_day'];


### PR DESCRIPTION
Relacionado de este PR: https://github.com/SinergiaTIC/SinergiaCRM/pull/268

## Descripción
Este PR revierte un cambio realizado en el PR #268 (incidencia 7) para no asignar un valor a la opción _repeat_count_ en caso de que esta llegue a null ya que dicho cambio no era necesario y además ha generado la siguiente incidencia: 

- Al crear registros de calendario laboral de forma periódica, si se selecciona la opción de Finalizar el día 31/12/2024 o cualquier otra fecha, solo se crea un registro. 

![image](https://github.com/SinergiaTIC/SinergiaCRM/assets/56689842/08d55726-9e96-4df0-92c5-a6dff1c48ec2)


## Pruebas
1. Crear registros de Calendario laboral de forma periódica indicando una fecha en el campo Finalizar. 
2. Comprobar que se han creado los registros correspondientes