### PR TITLE
Hotfix - Vistas Personalizadas - No aplica personalizaciones en vista de creación rápida mostrada en PopUp

### DIFF
--- a/modules/stic_Custom_Views/processor/LogicHooksCode.php
+++ b/modules/stic_Custom_Views/processor/LogicHooksCode.php
@@ -34,7 +34,10 @@ class stic_Custom_Views_ProcessorLogicHooks
         if ($action == "subpanelcreates") {
             $view = "quickcreate";
             $module = $_POST["target_module"];
+        } else if ($action == "popup") {
+            $view = "quickcreate";
         }
+        
         $availableViews = $GLOBALS['app_list_strings']['stic_custom_views_views_list'];
         if (!array_key_exists($view, $availableViews)) {
             return "";


### PR DESCRIPTION
- Closes #206 
## Descripción del problema
Si se define una Vista Personalizada de una vista de creación rápida, esta no se aplica cuando la vista se muestra en modo PopUp, en la creación de un registro desde una venta de selección de elemento relacionado

## Solución implementada
Se especifica el tipo de vista "creación rápida" para el formulario de edición cuando la acción es "popup"

## Pruebas
1. Crear una VP de un módulo para su vista de creación rápida. Por ejemplo, para el módulo Personas: aplicar color de fondo a pestaña "Direcciones" sin condiciones
2. Verificar que se aplica la VP. En el ejemplo, acceder a la vista de detalle de una Organización, y en el subpanel de Personas, crear una persona i verificar el color de fondo de la pestaña "Direcciones"
3. En un registro que pueda contener una relación con el módulo, abrir el selector de registros para la relación y crear uno. Siguiendo el ejemplo: En el registro de una Organización, en el subpanel Personas, abrir el selector de Personas (botón seleccionar), y en el PopUp, seleccionar "+ NUEVA PERSONA" para crear una persona
4. Comprobar que en la vista de edición mostrada en el PopUp se aplica la VP