### PR TITLE
Hotfix - Vistas Personalizadas - Visibilidad correcta en campos de pestaña/panel al ocultar y mostrar contenedor en vista de Edición y creación rápida

### DIFF
--- a/modules/stic_Custom_Views/processor/js/sticCVUtils.js
+++ b/modules/stic_Custom_Views/processor/js/sticCVUtils.js
@@ -34,6 +34,23 @@ var sticCVUtils = class sticCVUtils {
       } else {
         sticCVUtils.addClass($(this), customView, "hidden");
       }
+      sticCVUtils.removeClass($(this), customView, "auto-hidden");
+    });
+  }
+  static show_auto($elem, customView = null, show = true) {
+    show = sticCVUtils.isTrue(show);
+    $elem.each(function() {
+      if (show) {
+        if ($(this).hasClass("auto-hidden")) {
+          sticCVUtils.removeClass($(this), customView, "hidden");
+          sticCVUtils.removeClass($(this), customView, "auto-hidden");
+        }
+      } else {
+        if (!$(this).hasClass("hidden")) {
+          sticCVUtils.addClass($(this), customView, "hidden");
+          sticCVUtils.addClass($(this), customView, "auto-hidden");
+        }
+      }
     });
   }
   static is_visible($elem) {

--- a/modules/stic_Custom_Views/processor/js/sticCVUtils.js
+++ b/modules/stic_Custom_Views/processor/js/sticCVUtils.js
@@ -30,11 +30,13 @@ var sticCVUtils = class sticCVUtils {
     show = sticCVUtils.isTrue(show);
     $elem.each(function() {
       if (show) {
-        sticCVUtils.removeClass($(this), customView, "hidden");
+        if (!$(this).hasClass("auto-hidden")) {
+          sticCVUtils.removeClass($(this), customView, "hidden");
+        }
       } else {
         sticCVUtils.addClass($(this), customView, "hidden");
+        sticCVUtils.removeClass($(this), customView, "auto-hidden");
       }
-      sticCVUtils.removeClass($(this), customView, "auto-hidden");
     });
   }
   static show_auto($elem, customView = null, show = true) {

--- a/modules/stic_Custom_Views/processor/js/sticCV_Element_Div.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Element_Div.js
@@ -67,6 +67,9 @@ var sticCV_Element_Div = class sticCV_Element_Div {
       case "visible":
         sticCVUtils.show(this.$element, this.customView, action.value);
         return this;
+      case "visible_auto":
+        sticCVUtils.show_auto(this.$element, this.customView, action.value);
+        return this;
       case "color":
         sticCVUtils.color(this.$element, this.customView, action.value);
         return this;

--- a/modules/stic_Custom_Views/processor/js/sticCV_Element_FieldContainer.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Element_FieldContainer.js
@@ -41,12 +41,10 @@ var sticCV_Element_FieldContainer = class sticCV_Element_FieldContainer extends 
   applyAction(action) {
     if (action.action == "visible") {
       var show = sticCVUtils.isTrue(action.value);
-      if (!show) {
-        if (this.customView.view == "editview" || this.customView.view == "quickcreate") {
-          for (var field of this.getFields()) {
-            // Hide fields (this make unrequired also)
-            field.hide();
-          }
+      if (this.customView.view == "editview" || this.customView.view == "quickcreate") {
+        for (var field of this.getFields()) {
+          // Automatic Hide/Show fields (this make unrequired also)
+          field.show(show, true);
         }
       }
     }

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Container.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Container.js
@@ -36,11 +36,15 @@ var sticCV_Record_Container = class sticCV_Record_Container {
     this.content = null;
   }
 
-  show(show = true) {
-    return this.applyAction({ action: "visible", value: show, element_section: "container" });
+  show(show = true, automatically = false) {
+    if (automatically) {
+      return this.applyAction({ action: "visible_auto", value: show, element_section: "container" });
+    } else {
+      return this.applyAction({ action: "visible", value: show, element_section: "container" });
+    }
   }
-  hide() {
-    return this.show(false);
+  hide(automatically = false) {
+    return this.show(false, automatically);
   }
 
   style(style) {

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field.js
@@ -58,6 +58,7 @@ var sticCV_Record_Field = class sticCV_Record_Field extends sticCV_Record_Contai
   applyAction(action) {
     switch (action.action) {
       case "visible":
+      case "visible_auto":
         if (action.element_section != "header" && action.element_section != "field_label") {
           super.applyAction(action);
           sticCVUtils.check_required_visible(this);

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -209,9 +209,6 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
         return this;
       case "fixed_value":
         return this.value(action.value);
-      case "visible":
-        sticCVUtils.show(this.$element, this.customView, action.value);
-        return this;
     }
     return super.applyAction(action);
   }


### PR DESCRIPTION
- Closes #286 

## Descripción del problema
Este PR soluciona el error descrito en el Issue #286:  Si se aplican Vistas Personalizadas sobre una Vista de Edición o Creación rápida que primero oculte un panel o pestaña y después lo muestre, se mostraba el panel o pestaña pero no los campos que contiene

## Solución propuesta
Al ocultar un contenedor de campos (panel o pestaña) también se realizaba una ocultación de todos sus campos para así gestionar su obligatoriedad (en la ocultación de un campo, se verifica si éste es obligado, se hace no obligado y se marca para tener información que debe volver a ser obligado cuando vuelva a ser visible).
Para mantener el comportamiento, se ha separado el cambio de visibilidad de un campo realizado por una acción directa del cambio realizado por la ocultación de su contenedor.
De esta forma, si se oculta un contenedor y:
- Se indica que uno de sus campos es obligado y se vuelve a mostrar el contenedor: el campo obligado sólo será obligado cuando se visualice el campo
- Se oculta uno de sus campos y se vuelve a mostrar el contenedor: el campo no se visualizará
- Se muestra uno de sus campos y se vuelve a mostrar el contenedor: el campo sólo se visualizará al mostrar el contenedor
- Se muestra uno de sus campos y se hace obligado: el campo sólo será obligado cuando se visualice

## Pruebas a realizar
Crear una Vista Personalizada que aplique al módulo Personas y la Vista de Edición con las siguientes Personalizaciones:
1. Sin Condiciones, con las acciones de:
    1. Ocultar Pestaña de "Datos Socioeconómicos"
    2. Ocultar Panel de "Datos de contacto"
2. Con Condición: "Apellido" - "Contiene" - "Valor" - "Test" y las acciones:
    1. Mostrar Pestaña de "Datos Socioeconómicos"
    2. Mostrar Panel de "Datos de contacto"
3. Sin Condiciones, con las acciones de:
   1. Campo "Tel. alternativo" - "Visible" - "No"
   2. Campo "Móvil" - "Visitble" - "Si"
   3. Campo "Móvil" - "Obligado" - "Si"
4. Crear o editar una persona
5. Verificar que no aparecen la pestaña "Datos Socioeconómicos" ni el panel "Datos de contacto"
6. Guardar el registro
7. Verificar que se ha guardado el registro sin datos en "Móvil"
8. Crear o editar una persona
9. Cambiar el apellido por "Test"
10. Verificar que aparecen la pestaña "Datos Socioeconómicos" y el panel "Datos de contacto"
11. Verificar que tanto la pestaña como el panel contienen sus campos
12. Verificar que el campo "Tel. alternativo" no aparece
13. Verificar que el campo "Móvil" aparece y es obligado
