### PR TITLE
Hotfix - Vistas Personalizadas - Visualización correcta de campos requeridos

### DIFF
--- a/modules/stic_Custom_Views/processor/js/sticCVUtils.js
+++ b/modules/stic_Custom_Views/processor/js/sticCVUtils.js
@@ -450,16 +450,25 @@ var sticCVUtils = class sticCVUtils {
     var oldRequired = sticCVUtils.getRequiredStatus(field);
 
     var customView = field.customView;
+    sticCVUtils.show(field.header.$element.find("span.required"), customView, false);
     if (required) {
       sticCVUtils.addClass(field.header.$element, customView, "conditional-required");
-      sticCVUtils.show(field.header.$element.find("span.required"), customView, false);
       removeFromValidate(customView.formName, field.name);
+      var fieldName = field.header.text();
+      if (fieldName === null || fieldName === undefined || fieldName.trim() === "") {
+        fieldName = SUGAR.language.get("app_strings", "ERR_MISSING_REQUIRED_FIELDS");
+      } else {
+        fieldName = fieldName.trim();
+        if (fieldName.endsWith(":")) {
+          fieldName = fieldName.slice(0, -1);
+        }
+      }
       addToValidate(
         customView.formName,
         field.name,
         field.content.type,
         true,
-        SUGAR.language.get("app_strings", "ERR_MISSING_REQUIRED_FIELDS")
+        fieldName
       );
       if (!oldRequired) {
         customView.addUndoFunction(function() {


### PR DESCRIPTION
- Closes #288

## Descripción
Este PR soluciona dos incidencias:
1. Issue #288: Si se crea una Vista Personalizada que aplique sobre un campo definido como obligado en estudio y la Vista personalizada lo cambia a "No obligado", se seguía mostrando el indicador de campo obligado (asterísco rojo), aunque realmente ya no era obligado (permitia guardar sin informar el campo)
2. En los campos que se marcan como "obligados" por Vistas Personalizadas, al guardar sin informar el campo, aparecía el texto "`Falta campo requerido: Falta campo requerido`" en vez de: `"Falta campo requerido: <ETIQUETA DEL CAMPO>"`

## Pruebas
1. Crear una Vista Personalizada sobre un módulo y su Vista de Edición. Por ejemplo: Personas
2. Crear una Personalización que haga no obligado un campo obligado definido en estudio. Por ejemplo: Apellidos
3. Crear una Personalización que haga obligado un campo no obligado. Por ejemplo: Nombre
4. Editar un registro del módulo (Personas)
5. Verificar que el campo definido como no obligado (Apellidos) aparece sin marca de campo obligado
6. Vaciar el campo definido como no obligado (Apellidos) y el definido como obligado (Nombre) y guardar el registro
7. Verificar que no permite guardar únicamente por el campo vacío obligado por VP (Nombre)
8. Verificar que el texto del error es `Falta campo requerido: <ETIQUETA DEL CAMPO>`