### PR TITLE
Hotfix - Vistas Personalizadas - Error al aplicar acciones en ciertas instancias

### DIFF
--- a/modules/stic_Custom_Views/processor/js/sticCVUtils.js
+++ b/modules/stic_Custom_Views/processor/js/sticCVUtils.js
@@ -537,7 +537,7 @@ var sticCVUtils = class sticCVUtils {
   }
 
   static isTrue(value) {
-    return value === true || value === "1" || value === 1;
+    return value === true || value === "1" || value === 1 || value === "yes" || value === "true";
   }
 
   static normalizeToCompare(value) {


### PR DESCRIPTION
## Descripción
En ciertas instancias el json que recibe el motor javascript de Vistas Personalizadas recibe como valor booleano la cadena `"yes"` en vez de `true` o `1`. Esto producía que dicho valor se entendiera como `false` y por tanto, las acciones que esperan un booleano como valor, nunca se aplicaban

## Pruebas
1. Editar un registro del módulo Persona
2. Abrir las "Herramientas para desarrolladores" (Ctr+May+I) del navegador
3. En la Consola, escribir:
```js
var cv = sticCustomizeView.editview();
cv.field("assigned_user_name").readonly("yes");
```
4. Verificar que el campo "Asignado a" se ha convertido en campo "solo lectura"