### PR TITLE
Hotfix - Vistas Personalizadas - Aplicación de las Personalizaciones durante la edición inline en Vista Detalle

### DIFF
--- a/modules/stic_Custom_Views/processor/js/sticCVUtils.js
+++ b/modules/stic_Custom_Views/processor/js/sticCVUtils.js
@@ -509,12 +509,19 @@ var sticCVUtils = class sticCVUtils {
     return false;
   }
 
+  static createObserverCallback($elem, callback) {
+    return function() {
+      sticCVUtils.onChange($elem.find("input"), callback);
+      callback();
+    };
+  }
+
   static onChange($elem, callback) {
     $elem.each(function() {
       $(this).on("change paste keyup", callback);
       YAHOO.util.Event.on($(this)[0], "change", callback);
       if (!$(this).is(":input")) {
-        var observer = new MutationObserver(callback);
+        var observer = new MutationObserver(sticCVUtils.createObserverCallback($(this), callback));
         observer.observe($(this)[0], { attributes: true, childList: true, subtree: true, characterData: true });
       }
     });

--- a/modules/stic_Custom_Views/processor/js/sticCVUtils.js
+++ b/modules/stic_Custom_Views/processor/js/sticCVUtils.js
@@ -286,6 +286,9 @@ var sticCVUtils = class sticCVUtils {
       if (fieldContent.type == "bool") {
         return $elem.prop("checked");
       }
+      if ($elem.length > 0 && (fieldContent.type == "multienum" || fieldContent.type == "enum")) {
+        return $elem.val().replace(new RegExp('\\^', 'g'), '');
+      }
       var text = fieldContent.text();
       if (
         value_list != undefined &&

--- a/modules/stic_Custom_Views/processor/js/sticCVUtils.js
+++ b/modules/stic_Custom_Views/processor/js/sticCVUtils.js
@@ -268,14 +268,18 @@ var sticCVUtils = class sticCVUtils {
 
   static getValue(fieldContent, value_list) {
     var $elem = fieldContent.$editor;
-    if (fieldContent.customView.view == "detailview" && fieldContent.type != "bool") {
+    if (
+      fieldContent.customView.view == "detailview" &&
+      fieldContent.type != "bool" &&
+      !fieldContent.$element.hasClass("inlineEditActive")
+    ) {
       $elem = fieldContent.$fieldText;
     }
     if ($elem.length == 0 || $elem.get(0).parentNode === null) {
       $elem = fieldContent.$element;
     }
 
-    if (fieldContent.customView.view == "detailview") {
+    if (fieldContent.customView.view == "detailview" && !fieldContent.$element.hasClass("inlineEditActive")) {
       if (fieldContent.type == "relate") {
         return $elem.attr("data-id-value") + "|" + $elem.text().trim();
       }

--- a/modules/stic_Custom_Views/processor/js/sticCVUtils.js
+++ b/modules/stic_Custom_Views/processor/js/sticCVUtils.js
@@ -274,6 +274,9 @@ var sticCVUtils = class sticCVUtils {
       !fieldContent.$element.hasClass("inlineEditActive")
     ) {
       $elem = fieldContent.$fieldText;
+      if ($elem.length > 0 && (fieldContent.type == "multienum" || fieldContent.type == "enum")) {
+        return $elem.val().replaceAll("^", "").split(",").sort().join(",");
+      }
     }
     if ($elem.length == 0 || $elem.get(0).parentNode === null) {
       $elem = fieldContent.$element;
@@ -286,16 +289,14 @@ var sticCVUtils = class sticCVUtils {
       if (fieldContent.type == "bool") {
         return $elem.prop("checked");
       }
-      if ($elem.length > 0 && (fieldContent.type == "multienum" || fieldContent.type == "enum")) {
-        return $elem.val().replace(new RegExp('\\^', 'g'), '');
-      }
       var text = fieldContent.text();
       if (
         value_list != undefined &&
         value_list != "" &&
         fieldContent.type != "date" &&
         fieldContent.type != "datetime" &&
-        fieldContent.type != "datetimecombo"
+        fieldContent.type != "datetimecombo" &&
+        fieldContent.type != "multienum"
       ) {
         return sticCVUtils.getListValueFromLabel(value_list, text);
       }
@@ -548,6 +549,19 @@ var sticCVUtils = class sticCVUtils {
       }
     });
     return res;
+  }
+
+  static getMultienumLabelFromKeys(app_list_stringsName, keyValues) {
+    var keyValueArray = keyValues.replaceAll("^", "").split(",");
+    var labelValueArray = [];
+  
+    for (var i = 0; i < keyValueArray.length; i++) {
+      var label = SUGAR.language.languages.app_list_strings[app_list_stringsName][keyValueArray[i]];
+      if(label !== undefined) {
+        labelValueArray.push(label);  
+      }
+    }
+    return labelValueArray.join(", ");
   }
 
   static isTrue(value) {

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -31,7 +31,7 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
       $contentElement = $fieldElement.children(".stic-FieldContent").children('[field="' + fieldName + '"]');
     }
     super(field.customView, $contentElement);
-    
+
     this.$element.css("height", "auto");
 
     this.field = field;
@@ -281,6 +281,9 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
     }
 
     var currentValue = sticCVUtils.normalizeToCompare(this._getValue(value_list));
+    if (currentValue === undefined) {
+      currentValue = "";
+    }
     var conditionValue = sticCVUtils.normalizeToCompare(condition.value);
     switch (condition.operator) {
       case "Equal_To":

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -292,6 +292,9 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
     if (currentValue === undefined) {
       currentValue = "";
     }
+    if(this.type == "date") {
+      currentValue = currentValue.split(" ")[0];
+    }
 
     var conditionValue = condition.value ? condition.value : "";
     if (this.type == "multienum") {
@@ -300,6 +303,9 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
       } else {
         conditionValue = conditionValue.replaceAll("^", "").split(",").sort().join(",");
       }
+    }
+    if(this.type == "date") {
+      conditionValue = conditionValue.split(" ")[0];
     }
     if (!this._isMultienumCancelledInline()) {
       conditionValue = sticCVUtils.normalizeToCompare(conditionValue);

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -245,6 +245,15 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
     return false;
   }
 
+  _isMultienumCancelledInline() {
+    return (
+      this.type == "multienum" &&
+      this.customView.view == "detailview" &&
+      !this.$element.hasClass("inlineEditActive") &&
+      this.$fieldText.length == 0
+    );
+  }
+
   checkCondition_value(condition) {
     switch (condition.operator) {
       case "Not_Equal_To":
@@ -275,16 +284,26 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
     }
 
     var value_list = condition.value_list;
-    if (this.type == "multienum") {
-      condition.value = condition.value ? condition.value : "";
-      condition.value = condition.value.replaceAll("^", "").split(",").sort().join(",");
-    }
 
-    var currentValue = sticCVUtils.normalizeToCompare(this._getValue(value_list));
+    var currentValue = this._getValue(value_list);
+    if (!this._isMultienumCancelledInline()) {
+      currentValue = sticCVUtils.normalizeToCompare(currentValue);
+    }
     if (currentValue === undefined) {
       currentValue = "";
     }
-    var conditionValue = sticCVUtils.normalizeToCompare(condition.value);
+
+    var conditionValue = condition.value ? condition.value : "";
+    if (this.type == "multienum") {
+      if (this._isMultienumCancelledInline()) {
+        conditionValue = sticCVUtils.getMultienumLabelFromKeys(value_list, conditionValue);
+      } else {
+        conditionValue = conditionValue.replaceAll("^", "").split(",").sort().join(",");
+      }
+    }
+    if (!this._isMultienumCancelledInline()) {
+      conditionValue = sticCVUtils.normalizeToCompare(conditionValue);
+    }
     switch (condition.operator) {
       case "Equal_To":
         if (this.type == "relate") {


### PR DESCRIPTION
- Closes #276 

## Descripción
Tal y como se describe en el Issue #276, el comportamiento de las Vistas Personalizadas en una Vista de Detalle durante la edición Inline de un campo era distinto al comportamiento durante la edición en la Vista de Edición:
- En la vista de Edición se aplican las personalizaciones mientras el valor de un campo cambia
- En la vista de Detalle, cuando se editaba online, la personalización únicamente cambiaba cuando el usuario aceptaba el cambio de valor

Este PR soluciona el error, tratando la edición inline del mismo modo que la edición del campo en la vista de edición.

## Pruebas
1. Crear una VP sobre un módulo cualquiera y su Vista de Detalle (Por ejemplo: Personas)
2. Añadir una Personalización con una condición y una acción. Por ejemplo: Condición: "Nombre - Contiene - Valor - Test". Acción "Campo-Nombre - Color del fondo - Rojo - Todo el campo"
3. Visualizar un registro del módulo (Personas)
5. Mediante edición inline, modificar el campo para que cumpla la condición (Nombre: Test)
6. Verificar que mientras el editor inline está activo, se aplica la acción cuando la condición se cumple
7. Opcionalmente, repetir con otro tipo de campo