### PR TITLE
Hotfix - Acciones de validación - Error al comprobar las fechas para enviar el email a los administradores

### DIFF
--- a/modules/stic_Validation_Actions/DataAnalyzer/DataAnalyzer.php
+++ b/modules/stic_Validation_Actions/DataAnalyzer/DataAnalyzer.php
@@ -115,7 +115,9 @@ class stic_DataAnalyzer
         }
 
         // Send email only if there are validation results on the same day
-        $query = "SELECT count(*) as num_results FROM `stic_validation_results` WHERE deleted = 0 AND DATE_FORMAT(date_modified,'%Y-%m-%d') LIKE UTC_DATE();";
+        global $current_user;
+        $tzone = $current_user->getPreference('timezone') ?? $sugar_config['default_timezone'] ?? date_default_timezone_get();        
+        $query = "SELECT count(*) as num_results FROM `stic_validation_results` WHERE deleted = 0 AND DATE_FORMAT(CONVERT_TZ(date_modified, '+00:00', '" . $tzone ."'),'%Y-%m-%d') LIKE CURDATE();";
         $result = $db->query($query);
         $row = $db->fetchByAssoc($result);
         if (isset($row['num_results']) && intval($row['num_results']) > 0) {


### PR DESCRIPTION
## Descripción

Se detecta que la comprobación que realiza el CRM para saber si tiene que enviar el email a los administradores genera falsos positivos por estar realizando la comprobación con fechas en UTC. 

En esta comprobación se consulta si hay algún resultado de validación con fecha igual a la fecha en que se ejecuta el planificador. En instancias de entidad donde el cron se ejecuta entre las doce de la noche y el margen que ofrece la zona horaria definida en el usuario administrador, en el caso de España la 1:00 o las 2:00 dependiendo del horario de verano o invierno, al comparar con la fecha en UTC se está comprobando sí hay algún resultado de validación con fecha del día anterior, de forma que si había algún resultado creado por alguna ejecución del cron a lo largo del día anterior, se enviaba erroneamente el email a los administradores. 

Además, como en el link que se añade al cuerpo del email lleva la fecha según la zona horaria del usuario administrador, se daban casos en los que el link te llevaba al día actual aunque no hubiera resultados de validación para ese día. 

## Pruebas
1. Crear o modificar un registro para que contenga un error que sea detectado por alguna tarea de validación
2. Configurar el planificador que se relaciona con la acción de validación que detecta el error del punto anterior
3. Lanzar el cron y comprobar que se envía el correo electrónico y que el enlace que contiene lista el error en el día adecuado. 