### PR TITLE
Hotfix - Incripciones - Resetear campos calculados despues de duplicar masivamente inscripciones

### DIFF
--- a/modules/stic_Registrations/LogicHooksCode.php
+++ b/modules/stic_Registrations/LogicHooksCode.php
@@ -42,6 +42,12 @@ class stic_RegistrationsLogicHooks {
             $bean->name = $subjectName . ' - ' . $eventName;
         }
 
+        // If is a new record (cloned), reset calculated fields
+        if (!isset($bean->fetched_row)) {
+            $bean->attended_hours = null;
+            $bean->attendance_percentage = null;
+        }
+
     }
 
     public function after_save(&$bean, $event, $arguments) {


### PR DESCRIPTION
## Descripción
- solves #295 

Para resolver el issue se añade de forma directa el reseteo (a null) del valor de los campos `attended_hours` y `attendance_percentage` cuando se trata de un nuevo registro.

## Pruebas
- Duplicar masivamente inscripciones que tengan valor en los campos _attended_hours_ y _attendance_percentage_ , asociandoles en la misma operación a un evento que no tenga sesiones (y por tanto asistencias) asociadas.
- Verificar que las inscripciones creadas tienen vacío los campos indicados.
