### PR TITLE
Hotfix - Calendario laboral - Calcular correctamente el campo Día de la semana

### DIFF
--- a/modules/stic_Work_Calendar/stic_Work_Calendar.php
+++ b/modules/stic_Work_Calendar/stic_Work_Calendar.php
@@ -82,6 +82,9 @@ class stic_Work_Calendar extends Basic
         $startDate = $timedate->fromDbFormat($this->start_date, TimeDate::DB_DATETIME_FORMAT);
         $startDate = $timedate->asUser($startDate, $current_user);
 
+        // Date used to calculate weekday field
+        $startDateInTZ = $timedate->fromUser($startDate, $current_user);
+        $startDateInTZ = $startDateInTZ->format(TimeDate::DB_DATE_FORMAT);
         
         if (!in_array($this->type, self::ALL_DAY_TYPES)) 
         {
@@ -122,7 +125,7 @@ class stic_Work_Calendar extends Basic
 
         // Set weekday field
         if ($this->start_date != $this->fetched_row['start_date']) {
-            $this->weekday = date('w', strtotime($this->start_date));
+            $this->weekday = date('w', strtotime($startDateInTZ));
         }
 
         // Save the bean


### PR DESCRIPTION
- Closes #300 

## Description
El PR arregla la incidencia en el cálculo incorrecto del campo **Día de la semana** en registros que duran de Todo el día (Vacaciones, Festivo y Permiso/Excedencia)


**Cómo reproducir el problema**
1. Crear un registro de Calendario laboral de tipo Vacaciones
2. Comprobar que el día de la semana se calcula correctamente tanto en registros que duran todo el día como en los de tiempo parcial