### PR TITLE
Hotfix - Sesiones - Campos mal informados en sesiones periódicas de un evento

### DIFF
--- a/modules/stic_Events/Utils.php
+++ b/modules/stic_Events/Utils.php
@@ -318,16 +318,14 @@ class stic_EventsUtils
             if (isset($_REQUEST['color']) && $_REQUEST['color'] != '') {
                 $sessionBean->color = $_REQUEST['color'];
             } else {
-                $sessionBean->color;
+                $eventBean = BeanFactory::getBean('stic_Events', $sessionBean->stic_sessions_stic_eventsstic_events_ida);
+
+                $sessionBean->color = $eventBean->color;
             }
             if (isset($_REQUEST['description']) && $_REQUEST['description'] != '') {
                 $sessionBean->description = $_REQUEST['description'];
             }
-             else {
-                $eventBean = BeanFactory::getBean('stic_Events', $sessionBean->stic_sessions_stic_eventsstic_events_ida);
 
-                $sessionBean->description = $eventBean->description;
-            }
             if (isset($_REQUEST['activity_type'])) {
                 $activityType = $_REQUEST['activity_type'];
                 if (is_array($activityType)) {

--- a/modules/stic_Events/Utils.php
+++ b/modules/stic_Events/Utils.php
@@ -318,12 +318,15 @@ class stic_EventsUtils
             if (isset($_REQUEST['color']) && $_REQUEST['color'] != '') {
                 $sessionBean->color = $_REQUEST['color'];
             } else {
-                $sessionBean->color = $user;
+                $sessionBean->color;
             }
             if (isset($_REQUEST['description']) && $_REQUEST['description'] != '') {
                 $sessionBean->description = $_REQUEST['description'];
-            } else {
-                $sessionBean->description = $user;
+            }
+             else {
+                $eventBean = BeanFactory::getBean('stic_Events', $sessionBean->stic_sessions_stic_eventsstic_events_ida);
+
+                $sessionBean->description = $eventBean->description;
             }
             if (isset($_REQUEST['activity_type'])) {
                 $activityType = $_REQUEST['activity_type'];

--- a/modules/stic_Events/language/ca_ES.lang.php
+++ b/modules/stic_Events/language/ca_ES.lang.php
@@ -122,4 +122,5 @@ $mod_strings = array(
     'LBL_SESSION_ENABLE_FIELDS' => 'Mostra altres camps de Sessions',
     'LBL_SESSION_ENABLE_FIELDS_INFO' => "A banda dels camps obligatoris d'inici i final de la primera sessió i de la freqüència de repetició, podeu establir també valors per defecte per a d'altres camps.",
     'LBL_SESSION_NAME_INFO' => 'El nom de la sessió pot incloure un comptador numèric utilitzant el parámetre {{$counter}}. Exemple: si indiqueu el valor "Sessió {{$counter}}" les sessions quedaran anomenades "Sessió 1", "Sessió 2", etc.',
+    'LBL_SESSION_COLOR_EMPTY_INFO' => "Si no s'emplena el camp del color, s'agafarà el color de l'esdeveniment, si té.",
 );

--- a/modules/stic_Events/language/ca_ES.lang.php
+++ b/modules/stic_Events/language/ca_ES.lang.php
@@ -122,5 +122,5 @@ $mod_strings = array(
     'LBL_SESSION_ENABLE_FIELDS' => 'Mostra altres camps de Sessions',
     'LBL_SESSION_ENABLE_FIELDS_INFO' => "A banda dels camps obligatoris d'inici i final de la primera sessió i de la freqüència de repetició, podeu establir també valors per defecte per a d'altres camps.",
     'LBL_SESSION_NAME_INFO' => 'El nom de la sessió pot incloure un comptador numèric utilitzant el parámetre {{$counter}}. Exemple: si indiqueu el valor "Sessió {{$counter}}" les sessions quedaran anomenades "Sessió 1", "Sessió 2", etc.',
-    'LBL_SESSION_COLOR_EMPTY_INFO' => "Si no s'emplena el camp del color, s'agafarà el color de l'esdeveniment, si té.",
+    'LBL_SESSION_COLOR_EMPTY_INFO' => "Si no s'informa el camp s'assignarà a les sessions el color que consti a l'esdeveniment.",
 );

--- a/modules/stic_Events/language/en_us.lang.php
+++ b/modules/stic_Events/language/en_us.lang.php
@@ -122,5 +122,5 @@ $mod_strings = array(
     'LBL_SESSION_ENABLE_FIELDS' => 'Show other Sessions fields',
     'LBL_SESSION_ENABLE_FIELDS_INFO' => 'Apart from the mandatory first session start and end fields and repeating frequency, you can also set default values for other fields.',
     'LBL_SESSION_NAME_INFO' => 'The session name can include a numeric counter using the {{$counter}} parameter. Example: if the value "Session {{$counter}}" is specified the sessions will be named "Session 1", "Session 2", etc.',
-    'LBL_SESSION_COLOR_EMPTY_INFO' => 'If the color field is not filled in, the color of the event will be taken, if it has.',
+    'LBL_SESSION_COLOR_EMPTY_INFO' => 'If the field is not entered, the sessions will be assigned the color that appears in the event.',
 );

--- a/modules/stic_Events/language/en_us.lang.php
+++ b/modules/stic_Events/language/en_us.lang.php
@@ -122,4 +122,5 @@ $mod_strings = array(
     'LBL_SESSION_ENABLE_FIELDS' => 'Show other Sessions fields',
     'LBL_SESSION_ENABLE_FIELDS_INFO' => 'Apart from the mandatory first session start and end fields and repeating frequency, you can also set default values for other fields.',
     'LBL_SESSION_NAME_INFO' => 'The session name can include a numeric counter using the {{$counter}} parameter. Example: if the value "Session {{$counter}}" is specified the sessions will be named "Session 1", "Session 2", etc.',
+    'LBL_SESSION_COLOR_EMPTY_INFO' => 'If the color field is not filled in, the color of the event will be taken, if it has.',
 );

--- a/modules/stic_Events/language/es_ES.lang.php
+++ b/modules/stic_Events/language/es_ES.lang.php
@@ -122,4 +122,5 @@ $mod_strings = array(
     'LBL_SESSION_ENABLE_FIELDS' => 'Mostrar otros campos de Sesiones',
     'LBL_SESSION_ENABLE_FIELDS_INFO' => 'Aparte de los campos obligatorios de inicio y final de la primera sesión y de la frecuencia de repetición, es posible establecer también valores por defecto para otros campos.',
     'LBL_SESSION_NAME_INFO' => 'El nombre de la sesión puede incluir un contador numérico utilizando el parámetro {{$counter}}. Ejemplo: si se indica el valor "Sesión {{$counter}}" las sesiones se denominarán "Sesión 1", "Sesión 2", etc.',
+    'LBL_SESSION_COLOR_EMPTY_INFO' => 'Si no se rellena el campo del color, se cogerá el color del evento, si tiene.',
 );

--- a/modules/stic_Events/language/es_ES.lang.php
+++ b/modules/stic_Events/language/es_ES.lang.php
@@ -122,5 +122,5 @@ $mod_strings = array(
     'LBL_SESSION_ENABLE_FIELDS' => 'Mostrar otros campos de Sesiones',
     'LBL_SESSION_ENABLE_FIELDS_INFO' => 'Aparte de los campos obligatorios de inicio y final de la primera sesión y de la frecuencia de repetición, es posible establecer también valores por defecto para otros campos.',
     'LBL_SESSION_NAME_INFO' => 'El nombre de la sesión puede incluir un contador numérico utilizando el parámetro {{$counter}}. Ejemplo: si se indica el valor "Sesión {{$counter}}" las sesiones se denominarán "Sesión 1", "Sesión 2", etc.',
-    'LBL_SESSION_COLOR_EMPTY_INFO' => 'Si se no se informa el campo se asignará a las sesiones el color que conste en el evento.',
+    'LBL_SESSION_COLOR_EMPTY_INFO' => 'Si no se informa el campo se asignará a las sesiones el color que conste en el evento.',
 );

--- a/modules/stic_Events/language/es_ES.lang.php
+++ b/modules/stic_Events/language/es_ES.lang.php
@@ -122,5 +122,5 @@ $mod_strings = array(
     'LBL_SESSION_ENABLE_FIELDS' => 'Mostrar otros campos de Sesiones',
     'LBL_SESSION_ENABLE_FIELDS_INFO' => 'Aparte de los campos obligatorios de inicio y final de la primera sesión y de la frecuencia de repetición, es posible establecer también valores por defecto para otros campos.',
     'LBL_SESSION_NAME_INFO' => 'El nombre de la sesión puede incluir un contador numérico utilizando el parámetro {{$counter}}. Ejemplo: si se indica el valor "Sesión {{$counter}}" las sesiones se denominarán "Sesión 1", "Sesión 2", etc.',
-    'LBL_SESSION_COLOR_EMPTY_INFO' => 'Si no se rellena el campo del color, se cogerá el color del evento, si tiene.',
+    'LBL_SESSION_COLOR_EMPTY_INFO' => 'Si se no se informa el campo se asignará a las sesiones el color que conste en el evento.',
 );

--- a/modules/stic_Events/language/gl_ES.lang.php
+++ b/modules/stic_Events/language/gl_ES.lang.php
@@ -122,4 +122,5 @@ $mod_strings = array(
     'LBL_SESSION_ENABLE_FIELDS' => 'Mostrar outros campos de Sesións',
     'LBL_SESSION_ENABLE_FIELDS_INFO' => 'Aparte dos campos obrigatorios de inicio e final da primeira sesión  da frecuencia de repetición, é posible establecer tamén valores por defecto para outros campos.',
     'LBL_SESSION_NAME_INFO' => 'O nome da sesión pode incluir un contador numérico utilizando o parámetro {{$counter}}. Exemplo: se se indica ol valor "Sesión {{$counter}}", as sesións denominaranse "Sesión 1", "Sesión 2", etc.',
+    'LBL_SESSION_COLOR_EMPTY_INFO' => 'Se non se enche o campo da cor, collerá a cor do evento, se ten.',
 );

--- a/modules/stic_Events/language/gl_ES.lang.php
+++ b/modules/stic_Events/language/gl_ES.lang.php
@@ -122,5 +122,5 @@ $mod_strings = array(
     'LBL_SESSION_ENABLE_FIELDS' => 'Mostrar outros campos de Sesións',
     'LBL_SESSION_ENABLE_FIELDS_INFO' => 'Aparte dos campos obrigatorios de inicio e final da primeira sesión  da frecuencia de repetición, é posible establecer tamén valores por defecto para outros campos.',
     'LBL_SESSION_NAME_INFO' => 'O nome da sesión pode incluir un contador numérico utilizando o parámetro {{$counter}}. Exemplo: se se indica ol valor "Sesión {{$counter}}", as sesións denominaranse "Sesión 1", "Sesión 2", etc.',
-    'LBL_SESSION_COLOR_EMPTY_INFO' => 'Se non se enche o campo da cor, collerá a cor do evento, se ten.',
+    'LBL_SESSION_COLOR_EMPTY_INFO' => 'Se non se informa o campo, asignaráselles ás sesións a cor que aparece no evento.',
 );

--- a/modules/stic_Events/tpls/SessionWizard.tpl
+++ b/modules/stic_Events/tpls/SessionWizard.tpl
@@ -217,7 +217,12 @@
 				</td>
 			</tr>
 			<tr id="color_row">
-				<td width="12.5%" valign="top" scope="row">{$MOD_SESSION.LBL_COLOR}:</td>
+				<td width="12.5%" valign="top" scope="row">
+					{$MOD_SESSION.LBL_COLOR}
+					<span id="session_color_empty_info" style='position: relative;'
+						class="inline-help glyphicon glyphicon-info-sign"></span>
+					:
+				</td>
 				<td width="37.5%" valign="top">
 					<select class='sqsEnabled' name='color' id='color' value='' title=''>
 						{html_options options=$COLOR}
@@ -280,7 +285,7 @@
 
 		addQtipFunctionality('#session_enable_fields_info', 'stic_Events', 'LBL_SESSION_ENABLE_FIELDS_INFO');
 		addQtipFunctionality('#session_name_info', 'stic_Events', 'LBL_SESSION_NAME_INFO');
-
+		addQtipFunctionality('#session_color_empty_info', 'stic_Events', 'LBL_SESSION_COLOR_EMPTY_INFO');
 
 
 		buildEditableColorFieldSelectize('color');


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/103

## Description
Se ha implementado la funcionalidad al crear sesiones periódicas de un evento de que si se deja sin rellenar los datos del color, obtenga el del evento (se ha añadido un tooltip que lo informa) y se deje en blanco el campo de descripción.

## How To Test This
1. Escoger un evento con color y descripción.
2. Ir a creación de sesiones periódicas.
3. Generar sesiones periódicas sin haber introducido color ni descripción.
4. Comprobar que el campos color sea el mismo que el evento y la descripción esté vacía.
