### PR TITLE
Hotfix - Vistas Personalizadas - Usar hora correcta al comprobar las condiciones de las personalizaciones

### DIFF
--- a/modules/stic_Custom_Views/processor/LogicHooksCode.php
+++ b/modules/stic_Custom_Views/processor/LogicHooksCode.php
@@ -254,7 +254,7 @@ class stic_Custom_Views_ProcessorLogicHooks
             case "date":
             case "datetime":
             case "datetimecombo":
-                return $timedate->to_display_date_time($value, true, false, $current_user);
+                return $timedate->asUser($timedate->fromDbFormat($value, TimeDate::DB_DATETIME_FORMAT), $current_user);
         }
         return $value;
     }


### PR DESCRIPTION
- Closes #302 

## Descripción
Este PR corrige el error que se producía al verificar la fecha y hora para decidir si aplica o no una personalización de Vistas Personalizadas.
Si se creaba una personalización con una condición con un campo del tipo datetime, la verificación de la hora no se realizaba correctamente: Al definir la condición se especifica en la hora local, se guarda en la base de datos en hora UTC y al procesar la Vista Personalizada, se evaluaba la condición comparando la hora actual con la hora UTC.

## Pruebas
1. Crear una Vista Personalizada sobre el módulo de Sesiones - Vista de Edición
2. Definir una personalización con:
    1. Condición: Fecha inicio - Más grande o igual que - Valor - 12/07/2024 11:00
    2. Acción: Campo - Fecha inicio - Color de fondo - Rojo - Todo el campo
3. Editar una Sesión y especificar Fecha de inicio: 12/07/2024 09:00
4. Verificar que el campo no cambia de color en horas anteriores a 11:00