### PR TITLE
Hotfix - Incorpora - Corregir transformación de lista desplegable Nacionalidad

### DIFF
--- a/modules/stic_Incorpora/utils/TransformedLists.php
+++ b/modules/stic_Incorpora/utils/TransformedLists.php
@@ -87,7 +87,7 @@ $stic_genders_list = array(
 
 $stic_incorpora_nationality_list = array (
     'extranjero' => 'extranjero',
-    'nacional' => 'nacional',
+    'espanola' => 'nacional',
     '**not_listed**' => 'extranjero',
 );
 


### PR DESCRIPTION
Se ha detectado que al subir una persona del CRM a Incorpora, el campo de Nacionalidad siempre se mapea como "extranjero", aunque se haya seleccionado el ítem de "Nacional". 

En este PR se corrige la transformación para que transforme correctamente el ítem de "nacional" a "espanola", que es el que acepta Incorpora en su sistema.

Pruebas
- No se pueden realizar pruebas directamente en Incorpora ya que no tenemos acceso a Producción. Y el servidor de PRE lo retiraron hace unos meses. La entidad probadora verificará que funcione correctamente.