### PR TITLE
Hotfix - Plantillas PDF - No aplicar configuración TinyMCE en vista de edición

### DIFF
--- a/include/SugarFields/Fields/Wysiwyg/SugarFieldWysiwyg.php
+++ b/include/SugarFields/Fields/Wysiwyg/SugarFieldWysiwyg.php
@@ -63,9 +63,17 @@ class SugarFieldWysiwyg extends SugarFieldBase {
         $config = [];
         $config['height'] = 250;
         $config['menubar'] = false;
-        $config['plugins']  = 'code, table, link, image, wordcount';
+        // STIC-Custom 20240722 MHP - Do not apply the configuration if we are in PDF Templates
+        // 
+        // $config['plugins']  = 'code, table, link, image, wordcount';
+        // $config['selector'] = "#{$form_name} "."#".$vardef['name'];
+        // $config['toolbar1'] = 'fontselect | fontsizeselect | bold italic underline | forecolor backcolor | styleselect | outdent indent | link image | code table';        
         $config['selector'] = "#{$form_name} "."#".$vardef['name'];
-        $config['toolbar1'] = 'fontselect | fontsizeselect | bold italic underline | forecolor backcolor | styleselect | outdent indent | link image | code table';
+        if ($vardef["custom_module"] != "AOS_PDF_Templates") {
+            $config['plugins']  = 'code, table, link, image, wordcount';
+            $config['toolbar1'] = 'fontselect | fontsizeselect | bold italic underline | forecolor backcolor | styleselect | outdent indent | link image | code table';
+        }
+        // END STIC-Custom        
 
         $jsConfig = json_encode($config);
         $initiate = '<script type="text/javascript"> tinyMCE.init('.$jsConfig.')</script>';


### PR DESCRIPTION
- closes #70 

## Description
El PR soluciona la incidencia explicada en el issue no aplicando la configuración definida en el fichero **include/SugarFields/Fields/Wysiwyg/SugarFieldWysiwyg.php** para campos WYSIWYG ya que en el módulo de Plantillas PDF ya está precargada otra configuración de TinyMCE. 


## Pruebas
1. Ir a Administración -> Estudio -> Plantillas PDF
2. Crear un campo del tipo WYSIWYG
3. Editar la Vista de Edición y añadir el nuevo campo WYSIWYG
4. Ir a Plantillas PDF -> Crear plantilla PDF
5. El editor WYSIWYG del nuevo campo debe ser cargado y no producir errores en la consola del navegador. 