### PR TITLE
Improvement - Formularios - Permitir personalizar EntryPoint para las respuestas de PayPal

### DIFF
--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php
@@ -1079,7 +1079,7 @@ class PaymentBO extends WebFormDataBO
      * @param Array $ipnMessage IPN message content
      * @return Object payment bean
      */
-    private function getPaymentByIPNMessage($ipnMessage)
+    protected function getPaymentByIPNMessage($ipnMessage)
     {
         $paymentDate = date('Ym', strtotime($ipnMessage['payment_date']));
         $paymentIdSQL = "SELECT

--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
@@ -36,6 +36,8 @@ class PaymentController extends WebFormDataController {
 
     protected $version = 1; // Use the same logic for forms generated with different versions of the wizard
 
+    protected $paypalResponseEntryPoint = "stic_Web_Forms_paypal_response";
+
     /**
      * Controller Builder
      */
@@ -658,7 +660,7 @@ class PaymentController extends WebFormDataController {
 
         $paypal_url = $settings["PAYPAL_URL"];
         $paypal_id = $settings["PAYPAL_ID"];
-        $ipn = self::getMerchantPaypalURL();
+        $ipn = $this->getMerchantPaypalURL();
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ": Retrieving template...");
         $xtpl->assign('paypal_url', $paypal_url);
         $xtpl->assign('paypal_id', $paypal_id);
@@ -676,10 +678,10 @@ class PaymentController extends WebFormDataController {
         return $this->createResponse(self::RESPONSE_STATUS_PENDING, self::RESPONSE_TYPE_TEMPLATE, $xtpl);
     }
 
-    private static function getMerchantPaypalURL() {
+    private function getMerchantPaypalURL() {
         require_once 'modules/stic_Web_Forms/controller.php';
         $server = stic_Web_FormsController::getServerURL();
-        $url = "{$server}/index.php?entryPoint=stic_Web_Forms_paypal_response";
+        $url = "{$server}/index.php?entryPoint={$this->paypalResponseEntryPoint}";
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ": {$url}");
         return $url;
     }


### PR DESCRIPTION
- Closes #319

## Description
Tal y como se describe en el issue #319, si se desea ampliar el proceso de gestión de los pagos realizados mediante PayPal, es necesario definir un nuevo EntryPoint que ejecute el código personalizado.

Este PR aporta las mínimas modificaciones al código para que se pueda definir el nuevo EntryPoint sin tener que replicar todo el código de la clase `PaymentController`, perdiendo así las actualizaciones que se realicen en un futuro.

Tambien amplia la visibilidad de la función `getPaymentByIPNMessage` de la clase `PaymentBO` para que pueda ser ejecutada en sus posibles clases hijas

## Pruebas
- Verificar por código que los cambios son inocuos
