### PR TITLE
Hotfix - Formularios Web - Eliminar información no necesaria en formularios generados

### DIFF
--- a/modules/stic_Web_Forms/Assistant/Donation/DonationController.php
+++ b/modules/stic_Web_Forms/Assistant/Donation/DonationController.php
@@ -218,7 +218,6 @@ class DonationController extends stic_Web_FormsAssistantController {
             'email_template_id' => $this->persistentData['EMAIL_TEMPLATE_ID'],
             'relation_type' => $this->persistentData['RELATION_TYPE'],
             'include_recaptcha' => ($this->persistentData['include_recaptcha'] ? 1 : 0),
-            'recaptcha_configs' => ($this->persistentData['recaptcha_configs']),
             'recaptcha_configKeys' => ($this->persistentData['recaptcha_configKeys']),
             'recaptcha_selected' => ($this->persistentData['recaptcha_selected']),
         ));

--- a/modules/stic_Web_Forms/Assistant/EventInscription/EventInscriptionController.php
+++ b/modules/stic_Web_Forms/Assistant/EventInscription/EventInscriptionController.php
@@ -340,7 +340,6 @@ class EventInscriptionController extends stic_Web_FormsAssistantController {
             'account_name_optional' => ($this->persistentData['account_name_optional'] ? 1 : 0),
             'email_template_id' => $this->persistentData['EMAIL_TEMPLATE_ID'],
             'include_recaptcha' => ($this->persistentData['include_recaptcha'] ? 1 : 0),
-            'recaptcha_configs' => ($this->persistentData['recaptcha_configs']),
             'recaptcha_configKeys' => ($this->persistentData['recaptcha_configKeys']),
             'recaptcha_selected' => ($this->persistentData['recaptcha_selected']),
         ));


### PR DESCRIPTION
## Descripción
Se ha observado que en los formularios Stic, se incluye un campo oculto llamado "defParams" que contiene información no necesaria en los formularios generados

## Solución propuesta
Se ha eliminado información no necesaria relativa a reCAPTCHA incluída en el campo "defParams"

## Pruebas
1. Configurar reCAPTCHA para formularios: https://wikisuite.sinergiacrm.org/index.php?title=Google_reCAPTCHA
2. Crear un formulario web de Captación de Fondos con reCAPTCHA
3. Verificar que el formulario funciona correctamente
4. Crear un formulario web de Inscripción a Eventos con reCAPTCHA
5. Verificar que el formulario funciona correctamente
6. En código, verificar los cambios, evaluando especialmente que la variable `$defParams` no contiene información no relevante (esta variable se materializará en un campo oculto del formulario)