### PR TITLE
Improvement - Formularios Web - Inclusión de nombre y apellidos del pagador en el envío a Redsys

### DIFF
--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
@@ -418,6 +418,8 @@ class PaymentController extends WebFormDataController {
             $merchant_titular = $_REQUEST['Accounts___name'];
         }
         if (!empty($merchant_titular)) {
+            // Limit to length 16
+            $merchant_titular = substr($merchant_titular, 0, 16);
             $tpvSys->setParameter("DS_MERCHANT_TITULAR", $merchant_titular);
         }
 

--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
@@ -408,14 +408,16 @@ class PaymentController extends WebFormDataController {
         $tpvSys->setParameter("DS_MERCHANT_CONSUMERLANGUAGE", PaymentBO::getTPVLanguage($this->getLanguage()));
 
         // Set the Titular name to the TPV (DS_MERCHANT_TITULAR)
+        include_once 'SticInclude/Utils.php';
         $merchant_titular = "";
-        if (isset($_REQUEST['Contacts___last_name']) && !empty($_REQUEST['Contacts___last_name'])) {
-            $merchant_titular = $_REQUEST['Contacts___last_name'];
-            if (isset($_REQUEST['Contacts___first_name']) && !empty($_REQUEST['Contacts___first_name'])) {
-                $merchant_titular .= ", " . $_REQUEST['Contacts___first_name'];
+        $relatedContactBean = SticUtils::getRelatedBeanObject($PCBean, 'stic_payment_commitments_contacts');
+        if($relatedContactBean) {
+            $merchant_titular = $relatedContactBean->full_name;
+        } else {
+            $relatedAccountBean = SticUtils::getRelatedBeanObject($PCBean, 'stic_payment_commitments_accounts');
+            if($relatedAccountBean) {
+                $merchant_titular = $relatedAccountBean->name;
             }
-        } elseif (isset($_REQUEST['Accounts___name']) && !empty($_REQUEST['Accounts___name'])) {
-            $merchant_titular = $_REQUEST['Accounts___name'];
         }
         if (!empty($merchant_titular)) {
             // Limit to length 16

--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
@@ -421,7 +421,7 @@ class PaymentController extends WebFormDataController {
         }
         if (!empty($merchant_titular)) {
             // Limit to length 16
-            $merchant_titular = substr($merchant_titular, 0, 16);
+            $merchant_titular = substr($merchant_titular, 0, 60);
             $tpvSys->setParameter("DS_MERCHANT_TITULAR", $merchant_titular);
         }
 

--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
@@ -407,6 +407,20 @@ class PaymentController extends WebFormDataController {
         $tpvSys->setParameter("DS_MERCHANT_URLOK", $okURL);
         $tpvSys->setParameter("DS_MERCHANT_CONSUMERLANGUAGE", PaymentBO::getTPVLanguage($this->getLanguage()));
 
+        // Set the Titular name to the TPV (DS_MERCHANT_TITULAR)
+        $merchant_titular = "";
+        if (isset($_REQUEST['Contacts___last_name']) && !empty($_REQUEST['Contacts___last_name'])) {
+            $merchant_titular = $_REQUEST['Contacts___last_name'];
+            if (isset($_REQUEST['Contacts___first_name']) && !empty($_REQUEST['Contacts___first_name'])) {
+                $merchant_titular .= ", " . $_REQUEST['Contacts___first_name'];
+            }
+        } elseif (isset($_REQUEST['Accounts___name']) && !empty($_REQUEST['Accounts___name'])) {
+            $merchant_titular = $_REQUEST['Accounts___name'];
+        }
+        if (!empty($merchant_titular)) {
+            $tpvSys->setParameter("DS_MERCHANT_TITULAR", $merchant_titular);
+        }
+
         // Configuration data
         $version = $settings["TPV_VERSION"];
         $kc = $settings["TPV_PASSWORD"];


### PR DESCRIPTION
- Closes #212

## Descripción
La funcionalidad actual del TPV Redsys en SinergiaCRM no envía el parámetro DS_MERCHANT_TITULAR con el nombre completo de la persona que realiza el pago en formularios de donaciones o inscripciones. Esto dificulta la identificación clara de los pagadores en el sistema del TPV de la entidad.

## Solución implementada
Se realiza el envío del parámetro DS_MERCHANT_TITULAR con los datos que el pagador ha introducido en el formulario: "Apellidos, Nombre" (Persona) o "Nombre" (Organización)

## Pruebas
1. Configurar correctamente los settings necesarios para TPV de Redsys
2. Crear un formulario de captación de fondos para Persona 
3. Mediante el formulario, realizar un donativo 
4. Introducir los datos de pago en la pantalla de RedSys
5. Verificar que en la pantalla de confirmación del pago de RedSys aparece el nombre y apellidos en "Nombre del titular"
6. Repetir el proceso para un formulario de captación de fondos para Organización