### PR TITLE
Hotfix - General - Usar el delimitador de decimales configurado en campos FLOAT

### DIFF
--- a/include/SugarFields/Fields/Float/SugarFieldFloat.php
+++ b/include/SugarFields/Fields/Float/SugarFieldFloat.php
@@ -76,15 +76,10 @@ class SugarFieldFloat extends SugarFieldInt
         $focus,
         ImportFieldSanitize $settings
         ) {
-        $value = str_replace($settings->num_grp_sep, "", $value);
-        $dec_sep = $settings->dec_sep;
-        if ($dec_sep != '.') {
-            $value = str_replace($dec_sep, ".", $value);
+        if (isset($vardef['len'])) {
+            // check for field length
+            $value = sugar_substr($value, $vardef['len']);
         }
-        if (!is_numeric($value)) {
-            return false;
-        }
-        
         return $value;
     }
 }

--- a/include/SugarFields/Fields/Float/SugarFieldFloat.php
+++ b/include/SugarFields/Fields/Float/SugarFieldFloat.php
@@ -76,10 +76,21 @@ class SugarFieldFloat extends SugarFieldInt
         $focus,
         ImportFieldSanitize $settings
         ) {
+        // STIC-Custom 20240814 MHP - https://github.com/SinergiaTIC/SinergiaCRM/pull/338
+        // Apply the solution that is applied with the Decimal type fields, which is the one implemented in SugarFieldBase
+        // $value = str_replace($settings->num_grp_sep, "", $value);
+        // $dec_sep = $settings->dec_sep;
+        // if ($dec_sep != '.') {
+        //    $value = str_replace($dec_sep, ".", $value);
+        // }
+        // if (!is_numeric($value)) {
+        //    return false;
+        // }
         if (isset($vardef['len'])) {
             // check for field length
             $value = sugar_substr($value, $vardef['len']);
         }
+        // STIC-Custom
         return $value;
     }
 }

--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -121,7 +121,7 @@ class templateParser
                         ENT_COMPAT, 'UTF-8');
                 // STIC-custom 20210922 - Parse decimal symbol in templates according to configuration
                 // STIC#390
-                } elseif ($field_def['type'] == 'decimal') {
+                } elseif ($field_def['type'] == 'decimal' || $field_def['type'] == 'float') {
                     require_once('SticInclude/Utils.php');
                     if ($_REQUEST['entryPoint'] == 'formLetter') { // If generating a PDF...
                         $value = SticUtils::formatDecimalInConfigSettings($focus->$fieldName, true); // ...get user config

--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -121,6 +121,7 @@ class templateParser
                         ENT_COMPAT, 'UTF-8');
                 // STIC-custom 20210922 - Parse decimal symbol in templates according to configuration
                 // STIC#390
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/338
                 } elseif ($field_def['type'] == 'decimal' || $field_def['type'] == 'float') {
                     require_once('SticInclude/Utils.php');
                     if ($_REQUEST['entryPoint'] == 'formLetter') { // If generating a PDF...

--- a/modules/EmailTemplates/EmailTemplateParser.php
+++ b/modules/EmailTemplates/EmailTemplateParser.php
@@ -199,7 +199,7 @@ class EmailTemplateParser
             }
             // STIC-custom 20210922 - Parse decimal symbol in templates according to configuration
             // STIC#390
-            else if (($this->module->field_name_map[$attribute]['type']) && ($this->module->field_name_map[$attribute]['type']) === 'decimal'){
+            else if (($this->module->field_name_map[$attribute]['type']) && (($this->module->field_name_map[$attribute]['type']) === 'decimal' || ($this->module->field_name_map[$attribute]['type']) === 'float')){
                 require_once('SticInclude/Utils.php');
                 $value = SticUtils::formatDecimalInConfigSettings($this->module->$attribute, false);
                 return $value;

--- a/modules/EmailTemplates/EmailTemplateParser.php
+++ b/modules/EmailTemplates/EmailTemplateParser.php
@@ -199,6 +199,7 @@ class EmailTemplateParser
             }
             // STIC-custom 20210922 - Parse decimal symbol in templates according to configuration
             // STIC#390
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/338
             else if (($this->module->field_name_map[$attribute]['type']) && (($this->module->field_name_map[$attribute]['type']) === 'decimal' || ($this->module->field_name_map[$attribute]['type']) === 'float')){
                 require_once('SticInclude/Utils.php');
                 $value = SticUtils::formatDecimalInConfigSettings($this->module->$attribute, false);

--- a/modules/KReports/KReport.php
+++ b/modules/KReports/KReport.php
@@ -670,6 +670,7 @@ class KReport extends SugarBean {
             // Following the above statement, a specific condition is added for decimal and datetimecombo types.
             // STIC#222
             // STIC#296
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/338
             if ($this->fieldNameMap[$fieldID]['type'] == 'decimal' || $this->fieldNameMap[$fieldID]['type'] == 'float' || $this->fieldNameMap[$fieldID]['type'] == 'datetimecombo') {
                $thisFieldRenderer = $this->getXtypeRenderer((!empty($fieldDetails['overridetype']) ? $fieldDetails['overridetype'] : $this->fieldNameMap [$fieldID] ['type']) , $fieldID);
             }

--- a/modules/KReports/KReport.php
+++ b/modules/KReports/KReport.php
@@ -670,7 +670,7 @@ class KReport extends SugarBean {
             // Following the above statement, a specific condition is added for decimal and datetimecombo types.
             // STIC#222
             // STIC#296
-            if ($this->fieldNameMap[$fieldID]['type'] == 'decimal' || $this->fieldNameMap[$fieldID]['type'] == 'datetimecombo') {
+            if ($this->fieldNameMap[$fieldID]['type'] == 'decimal' || $this->fieldNameMap[$fieldID]['type'] == 'float' || $this->fieldNameMap[$fieldID]['type'] == 'datetimecombo') {
                $thisFieldRenderer = $this->getXtypeRenderer((!empty($fieldDetails['overridetype']) ? $fieldDetails['overridetype'] : $this->fieldNameMap [$fieldID] ['type']) , $fieldID);
             }
             else {


### PR DESCRIPTION
Para los casos relacionados con Plantillas de Email y PDF
- SuiteCRM PR: https://github.com/salesagility/SuiteCRM/pull/10495

Queda pendiente crear el PR to SA del caso detectado en el proceso de importación


## Descripción
Se detecta que el CRM no usa correctamente el delimitador de decimales cuando opera con campos de tipo FLOAT en los siguientes casos de uso: 
1. Al importar un campo de tipo Float 
2. Al usar una plantilla de correo desde campañas o desde un flujo de trabajo
3. Al exportar una plantilla PDF

## Pruebas
Este PR corrige que no se transforme correctamente el símbolo para separar decimales de un valor decimal obtenido de base de datos al incorporarlo a una plantilla de correo o una plantilla PDF.

**Pruebas**
1. Crear un campo de tipo Float en el módulo de Personas

_**Plantillas de correo**_
2. Crear una plantilla de correo con ese campo.
3. Crear una persona y proveer un valor en ese campo 
4. Crear una campaña y un email marketing que use esa plantilla
5. Enviar el email, comprobar que el valor del campo Float es el mismo y que usa el símbolo decimal configurado en el CRM

_**Flujos de trabajo**_ (opcional, ya que no se ha corregido nada)
6. Crear un FdT cuya acción sea enviar un email y que use la plantilla creada en el paso 2.
7. Modificar la persona para que se envíe el email, comprobar que el valor del campo Float es el mismo y que usa el símbolo decimal configurado en el CRM

_**Plantillas PDF**_
8. Crear una plantilla PDF y añadir un campo de tipo decimal. Por ejemplo: Total annual donations.
9. Generar la plantilla para la persona usada anteriormente, comprobar que el valor del campo Float es el mismo y que usa el símbolo decimal configurado en el perfil del usuario logueado

_**Proceso de Importación**_
10. Exportar la Persona y editar el fichero generado para dejar solo la columna apellido (campo requerido) y la columna del campo Float. Cambiar el apellido para que cuando se importe se diferencie del otro registro. 
11. Realizar la importación y comprobar que el valor del campo Float es el mismo y que usa el símbolo decimal configurado en el perfil del usuario logueado


_**Para todos los casos de uso**_
12. Cambiar el símbolo decimal del sistema y del usuario y volver a realizar las pruebas. 