### PR TITLE
Hotfix - General - No permitr edición en campos que no son de texto deshabilitados

### DIFF
--- a/SticInclude/js/Utils.js
+++ b/SticInclude/js/Utils.js
@@ -281,6 +281,10 @@ function setEnabledStatus(elementId, clearField) {
   } else {
     $("#" + elementId, $form)
       .prop("readonly", false);
+    $("#" + elementId, $form)
+      .prop("disabled", false);
+    $("#" + elementId, $form).parent().find("button")
+      .prop("disabled", false);
   }
   $("#" + elementId, $form)
     .closest(".edit-view-row-item")
@@ -313,6 +317,10 @@ function setDisabledStatus(elementId, clearField) {
   } else {
     $("#" + elementId, $form)
       .prop("readonly", true);
+    $("#" + elementId, $form)
+      .prop("disabled", true);
+    $("#" + elementId, $form).parent().find("button")
+      .prop("disabled", true);
   }
   $("#" + elementId, $form)
     .closest(".edit-view-row-item")


### PR DESCRIPTION
- Closes #350 

## Descripción
Tal y como se describe en el issue #350, en los campos que no son de texto y se marcan como deshabilitados mediante javascript era posible modificar su valor:
- En los campos que son de tipo selección (combobox), se permitía modificar su valor haciendo click en él, haciendo que aparezca su despleglable
- En los campos de selección de fecha, se permitía abrir el calendario accediendo al botón

Concretamente, este error se podía observar en los siguientes campos de los módulos:
- Módulo "Candidaturas", campo "Motivo de rechazo"
- Módulo "Ofertas laborales", campo "Fecha oferta cubierta (SEPE)", al clicar en el calendario
- Módulo "Inscripciones", campo "Motivo de no participación"
- Módulo "Inscripciones", campo "Motivo de rechazo"
- Módulo "Renesas", campo "Cuenta bancaria"
- Módulo "Acciones SEPE", campo "Convenio"
- Módulo "Ficheros SEPE", campo "Código convenio"

## Pruebas
Módulo "Candidaturas", campo "Motivo de rechazo":
1. Crear una nueva Candidatura
2. Con el campo "Motivo de rechazo" deshabilitado, clicar en su desplegable
3. Verificar que el campo no es modificable
4. Seleccionar "Estado": "Rechazada o cerrada"
5. Verificar que el campo "Motivo de rechazo" es modificable y funciona correctamente

Módulo "Ofertas laborales", campo "Fecha oferta cubierta (SEPE)"
1. Crear una Oferta laboral
2. Con el campo "Fecha oferta cubierta (SEPE)" deshabilitado, clicar en el botón del calendario
3. Verificar que el campo no es modificable
4. Insertar un valor en "Fecha activación (SEPE)"
5. Verificar que el campo "Fecha oferta cubierta (SEPE)" es modificable y funciona correctamente