### PR TITLE
Hotfix - Calendario laboral - Mostrar el resumen por usuario de todos los seleccionados

### DIFF
--- a/modules/stic_Work_Calendar/tpls/workCalendarAssistantSummary.tpl
+++ b/modules/stic_Work_Calendar/tpls/workCalendarAssistantSummary.tpl
@@ -151,7 +151,9 @@
                 renderRecordsNotCreated(currentUserId, pageNumber, pageSize);
                 renderPagination(currentUserId, pageNumber, pageSize, data[currentUserId].numRecordsNotCreated);
             } else {
-               document.getElementById('listContainer').style.display='none';
+                if (document.getElementById('listContainer')) {
+                    document.getElementById('listContainer').style.display='none';
+                }
             }
         }
 


### PR DESCRIPTION
- Closes #331 

## Descripción
En este PR se comprueba si existe el contenedor con los registros no creados de un usuario antes de intentar ocultarlo. La incidencia la generaba que si el primer usuario no tenía registros no creados daba un fallo al intentar acceder a la propiedad style de un elemento que aún no había sido creado. 

## Pruebas
1. Eliminar todos los registros de calendario laboral
2. Ir a la vista de lista de Empleados, seleccionar múltiples registros y pulsar en la opción de menú de **Generar Calendario Laboral**
3. Comprobar que en el resumen aparecen todos los empleados seleccionados.
4. Realizar alguna prueba más para asegurarnos que ya no se produce el error. 