### PR TITLE
Enhancement - SinergiaDA - Algunas mejoras

### DIFF
--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1772,10 +1772,7 @@ class ExternalReporting
                             $userGroupsRes = $db->query("SELECT distinct(name) as 'group' FROM sda_def_user_groups ug WHERE user_name='{$u['user_name']}';");
 
                             while ($userGroups = $db->fetchByAssoc($userGroupsRes, false)) {
-                                if ($u['user_name'] == 'u1') {
-                                    echo '';
-                                }
-
+                                
                                 $crmGroupName = explode('SDA_', $userGroups['group'])[1];
 
                                 // Verify whether or not the group or user has access to the module for their roles

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -466,7 +466,7 @@ class ExternalReporting
                                 $indexesToCreate[] = "{$fieldV['id_name']}";
 
                                 //Add relate record name
-                                if (in_array($fieldV['module'], ['Contacts', 'Leads']) || Beanfactory::newBean($fieldV['module'])->field_defs['last_name']) {
+                                if (in_array($fieldV['module'], ['Contacts', 'Leads']) || (Beanfactory::newBean($fieldV['module'])->field_defs['last_name']) && $fieldV['module'] != 'Users') {
                                     $relatedName = " concat_ws(' ', {$leftJoinAlias}.first_name, {$leftJoinAlias}.last_name) ";
                                 } elseif ($fieldV['module'] == 'Users') {
                                     $relatedName = "{$leftJoinAlias}.user_name";
@@ -1792,7 +1792,7 @@ class ExternalReporting
                                         'global' => 0,
                                     ];
 
-                                    // Additionally we insert a record that allows each user's access to the records in which coinicide
+                                    // Additionally we insert a record that allows each user's access to the records in which match
                                     // the user_name with the assigned_user_name field content in each module in which the user has group permission
                                     $userModuleAccessMode["{$u['user_name']}_{$aclSource}_{$userGroups['group']}_private_{$currentTable}"] = [
                                         'user_name' => $u['user_name'],

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -466,11 +466,13 @@ class ExternalReporting
                                 $indexesToCreate[] = "{$fieldV['id_name']}";
 
                                 //Add relate record name 
-                                if (in_array($fieldV['module'], ['Contacts', 'Leads'])) {
+                                if (in_array($fieldV['module'], ['Contacts', 'Leads']) || Beanfactory::newBean($fieldV['module'])->field_defs['last_name']) {
                                     $relatedName = " concat_ws(' ', {$leftJoinAlias}.first_name, {$leftJoinAlias}.last_name) ";
                                 } elseif ($fieldV['module'] == 'Users') {
                                     $relatedName = "{$leftJoinAlias}.user_name";
-                                } else { $relatedName = "{$leftJoinAlias}.name";}
+                                } else { 
+                                    $relatedName = "{$leftJoinAlias}.name";
+                                }
 
                                 $fieldSrc .= " IFNULL($relatedName,'') AS {$fieldV['name']}";
 

--- a/modules/stic_Accounts_Relationships/SDAVardefs.php
+++ b/modules/stic_Accounts_Relationships/SDAVardefs.php
@@ -50,8 +50,8 @@ $SDAVirtualFields = array(
         'precision' => 0,
         'hidden' => 0,
         'expression' => "CASE
-            WHEN (start_date IS NULL OR start_date <= LAST_DAY(CONCAT(YEAR(CURDATE()),'-12-31')))
-            AND (end_date IS NULL OR end_date >= CONCAT(YEAR(CURDATE()),'-01-01'))
+            WHEN (m.start_date IS NULL OR m.start_date <= LAST_DAY(CONCAT(YEAR(CURDATE()),'-12-31')))
+            AND (m.end_date IS NULL OR m.end_date >= CONCAT(YEAR(CURDATE()),'-01-01'))
             THEN '1'
             ELSE '0'
         END",
@@ -63,8 +63,8 @@ $SDAVirtualFields = array(
         'precision' => 0,
         'hidden' => 0,
         'expression' => "CASE
-            WHEN (start_date IS NULL OR start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-1,'-12-31')))
-            AND (end_date IS NULL OR end_date >= CONCAT(YEAR(CURDATE())-1,'-01-01'))
+            WHEN (m.start_date IS NULL OR m.start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-1,'-12-31')))
+            AND (m.end_date IS NULL OR m.end_date >= CONCAT(YEAR(CURDATE())-1,'-01-01'))
             THEN '1'
             ELSE '0'
         END",
@@ -76,8 +76,8 @@ $SDAVirtualFields = array(
         'precision' => 0,
         'hidden' => 0,
         'expression' => "CASE
-            WHEN (start_date IS NULL OR start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-2,'-12-31')))
-            AND (end_date IS NULL OR end_date >= CONCAT(YEAR(CURDATE())-2,'-01-01'))
+            WHEN (m.start_date IS NULL OR m.start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-2,'-12-31')))
+            AND (m.end_date IS NULL OR m.end_date >= CONCAT(YEAR(CURDATE())-2,'-01-01'))
             THEN '1'
             ELSE '0'
         END",
@@ -89,8 +89,8 @@ $SDAVirtualFields = array(
         'precision' => 0,
         'hidden' => 0,
         'expression' => "CASE
-            WHEN (start_date IS NULL OR start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-3,'-12-31')))
-            AND (end_date IS NULL OR end_date >= CONCAT(YEAR(CURDATE())-3,'-01-01'))
+            WHEN (m.start_date IS NULL OR m.start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-3,'-12-31')))
+            AND (m.end_date IS NULL OR m.end_date >= CONCAT(YEAR(CURDATE())-3,'-01-01'))
             THEN '1'
             ELSE '0'
         END",
@@ -102,8 +102,8 @@ $SDAVirtualFields = array(
         'precision' => 0,
         'hidden' => 0,
         'expression' => "CASE
-            WHEN (start_date IS NULL OR start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-4,'-12-31')))
-            AND (end_date IS NULL OR end_date >= CONCAT(YEAR(CURDATE())-4,'-01-01'))
+            WHEN (m.start_date IS NULL OR m.start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-4,'-12-31')))
+            AND (m.end_date IS NULL OR m.end_date >= CONCAT(YEAR(CURDATE())-4,'-01-01'))
             THEN '1'
             ELSE '0'
         END",

--- a/modules/stic_Contacts_Relationships/SDAVardefs.php
+++ b/modules/stic_Contacts_Relationships/SDAVardefs.php
@@ -42,7 +42,7 @@
 
  */
 
-$SDAVirtualFields = array(
+ $SDAVirtualFields = array(
     'SDA_ACTIVE_CURRENT_YEAR_MINUS_0' => array(
         'label' => 'LBL_SDA_ACTIVE_CURRENT_YEAR_MINUS_0',
         'description' => 'LBL_SDA_ACTIVE_CURRENT_YEAR_MINUS_0_DESCRIPTION',
@@ -50,8 +50,8 @@ $SDAVirtualFields = array(
         'precision' => 0,
         'hidden' => 0,
         'expression' => "CASE
-            WHEN (start_date IS NULL OR start_date <= LAST_DAY(CONCAT(YEAR(CURDATE()),'-12-31')))
-            AND (end_date IS NULL OR end_date >= CONCAT(YEAR(CURDATE()),'-01-01'))
+            WHEN (m.start_date IS NULL OR m.start_date <= LAST_DAY(CONCAT(YEAR(CURDATE()),'-12-31')))
+            AND (m.end_date IS NULL OR m.end_date >= CONCAT(YEAR(CURDATE()),'-01-01'))
             THEN '1'
             ELSE '0'
         END",
@@ -63,8 +63,8 @@ $SDAVirtualFields = array(
         'precision' => 0,
         'hidden' => 0,
         'expression' => "CASE
-            WHEN (start_date IS NULL OR start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-1,'-12-31')))
-            AND (end_date IS NULL OR end_date >= CONCAT(YEAR(CURDATE())-1,'-01-01'))
+            WHEN (m.start_date IS NULL OR m.start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-1,'-12-31')))
+            AND (m.end_date IS NULL OR m.end_date >= CONCAT(YEAR(CURDATE())-1,'-01-01'))
             THEN '1'
             ELSE '0'
         END",
@@ -76,8 +76,8 @@ $SDAVirtualFields = array(
         'precision' => 0,
         'hidden' => 0,
         'expression' => "CASE
-            WHEN (start_date IS NULL OR start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-2,'-12-31')))
-            AND (end_date IS NULL OR end_date >= CONCAT(YEAR(CURDATE())-2,'-01-01'))
+            WHEN (m.start_date IS NULL OR m.start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-2,'-12-31')))
+            AND (m.end_date IS NULL OR m.end_date >= CONCAT(YEAR(CURDATE())-2,'-01-01'))
             THEN '1'
             ELSE '0'
         END",
@@ -89,8 +89,8 @@ $SDAVirtualFields = array(
         'precision' => 0,
         'hidden' => 0,
         'expression' => "CASE
-            WHEN (start_date IS NULL OR start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-3,'-12-31')))
-            AND (end_date IS NULL OR end_date >= CONCAT(YEAR(CURDATE())-3,'-01-01'))
+            WHEN (m.start_date IS NULL OR m.start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-3,'-12-31')))
+            AND (m.end_date IS NULL OR m.end_date >= CONCAT(YEAR(CURDATE())-3,'-01-01'))
             THEN '1'
             ELSE '0'
         END",
@@ -102,8 +102,8 @@ $SDAVirtualFields = array(
         'precision' => 0,
         'hidden' => 0,
         'expression' => "CASE
-            WHEN (start_date IS NULL OR start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-4,'-12-31')))
-            AND (end_date IS NULL OR end_date >= CONCAT(YEAR(CURDATE())-4,'-01-01'))
+            WHEN (m.start_date IS NULL OR m.start_date <= LAST_DAY(CONCAT(YEAR(CURDATE())-4,'-12-31')))
+            AND (m.end_date IS NULL OR m.end_date >= CONCAT(YEAR(CURDATE())-4,'-01-01'))
             THEN '1'
             ELSE '0'
         END",

--- a/modules/stic_Payment_Commitments/SDAVardefs.php
+++ b/modules/stic_Payment_Commitments/SDAVardefs.php
@@ -49,7 +49,7 @@ $SDAVirtualFields = array(
         'type' => 'numeric',
         'precision' => 2,
         'hidden' => 0,
-        'expression' => "SUBSTRING_INDEX(expected_payments_detail, '|', 1)",
+        'expression' => "SUBSTRING_INDEX(m.expected_payments_detail, '|', 1)",
     ),
     'SDA_EXPECTED_PAYMENTS_MONTH_2' => array(
         'label' => 'LBL_EXPECTED_PAYMENTS_MONTH_2',
@@ -57,7 +57,7 @@ $SDAVirtualFields = array(
         'type' => 'numeric',
         'precision' => 2,
         'hidden' => 0,
-        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(expected_payments_detail, '|', 2), '|', -1)",
+        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(m.expected_payments_detail, '|', 2), '|', -1)",
     ),
     'SDA_EXPECTED_PAYMENTS_MONTH_3' => array(
         'label' => 'LBL_EXPECTED_PAYMENTS_MONTH_3',
@@ -65,7 +65,7 @@ $SDAVirtualFields = array(
         'type' => 'numeric',
         'precision' => 2,
         'hidden' => 0,
-        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(expected_payments_detail, '|', 3), '|', -1)",
+        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(m.expected_payments_detail, '|', 3), '|', -1)",
     ),
     'SDA_EXPECTED_PAYMENTS_MONTH_4' => array(
         'label' => 'LBL_EXPECTED_PAYMENTS_MONTH_4',
@@ -73,7 +73,7 @@ $SDAVirtualFields = array(
         'type' => 'numeric',
         'precision' => 2,
         'hidden' => 0,
-        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(expected_payments_detail, '|', 4), '|', -1)",
+        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(m.expected_payments_detail, '|', 4), '|', -1)",
     ),
     'SDA_EXPECTED_PAYMENTS_MONTH_5' => array(
         'label' => 'LBL_EXPECTED_PAYMENTS_MONTH_5',
@@ -81,7 +81,7 @@ $SDAVirtualFields = array(
         'type' => 'numeric',
         'precision' => 2,
         'hidden' => 0,
-        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(expected_payments_detail, '|', 5), '|', -1)",
+        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(m.expected_payments_detail, '|', 5), '|', -1)",
     ),
     'SDA_EXPECTED_PAYMENTS_MONTH_6' => array(
         'label' => 'LBL_EXPECTED_PAYMENTS_MONTH_6',
@@ -89,7 +89,7 @@ $SDAVirtualFields = array(
         'type' => 'numeric',
         'precision' => 2,
         'hidden' => 0,
-        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(expected_payments_detail, '|', 6), '|', -1)",
+        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(m.expected_payments_detail, '|', 6), '|', -1)",
     ),
     'SDA_EXPECTED_PAYMENTS_MONTH_7' => array(
         'label' => 'LBL_EXPECTED_PAYMENTS_MONTH_7',
@@ -97,7 +97,7 @@ $SDAVirtualFields = array(
         'type' => 'numeric',
         'precision' => 2,
         'hidden' => 0,
-        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(expected_payments_detail, '|', 7), '|', -1)",
+        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(m.expected_payments_detail, '|', 7), '|', -1)",
     ),
     'SDA_EXPECTED_PAYMENTS_MONTH_8' => array(
         'label' => 'LBL_EXPECTED_PAYMENTS_MONTH_8',
@@ -105,7 +105,7 @@ $SDAVirtualFields = array(
         'type' => 'numeric',
         'precision' => 2,
         'hidden' => 0,
-        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(expected_payments_detail, '|', 8), '|', -1)",
+        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(m.expected_payments_detail, '|', 8), '|', -1)",
     ),
     'SDA_EXPECTED_PAYMENTS_MONTH_9' => array(
         'label' => 'LBL_EXPECTED_PAYMENTS_MONTH_9',
@@ -113,7 +113,7 @@ $SDAVirtualFields = array(
         'type' => 'numeric',
         'precision' => 2,
         'hidden' => 0,
-        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(expected_payments_detail, '|', 9), '|', -1)",
+        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(m.expected_payments_detail, '|', 9), '|', -1)",
     ),
     'SDA_EXPECTED_PAYMENTS_MONTH_10' => array(
         'label' => 'LBL_EXPECTED_PAYMENTS_MONTH_10',
@@ -121,7 +121,7 @@ $SDAVirtualFields = array(
         'type' => 'numeric',
         'precision' => 2,
         'hidden' => 0,
-        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(expected_payments_detail, '|', 10), '|', -1)",
+        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(m.expected_payments_detail, '|', 10), '|', -1)",
     ),
     'SDA_EXPECTED_PAYMENTS_MONTH_11' => array(
         'label' => 'LBL_EXPECTED_PAYMENTS_MONTH_11',
@@ -129,7 +129,7 @@ $SDAVirtualFields = array(
         'type' => 'numeric',
         'precision' => 2,
         'hidden' => 0,
-        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(expected_payments_detail, '|', 11), '|', -1)",
+        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(m.expected_payments_detail, '|', 11), '|', -1)",
     ),
     'SDA_EXPECTED_PAYMENTS_MONTH_12' => array(
         'label' => 'LBL_EXPECTED_PAYMENTS_MONTH_12',
@@ -137,6 +137,6 @@ $SDAVirtualFields = array(
         'type' => 'numeric',
         'precision' => 2,
         'hidden' => 0,
-        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(expected_payments_detail, '|', 12), '|', -1)",
+        'expression' => "SUBSTRING_INDEX(SUBSTRING_INDEX(m.expected_payments_detail, '|', 12), '|', -1)",
     ),
 );


### PR DESCRIPTION
Este PR aborda las siguientes mejoras/corrección de errores:

## 1 - Cualificar los campos usados en expresiones en campos virtuales.
Se ha visto que al crear campos virtuales se pudeden producir errores si el modulos tiene relaciones con otros módulos que contienen nombres de campo iguales, por lo que se utilizad de manera predeterminada el prefijo `m` correspondiente a la tabla principal del módulo, para referirnos a los campos de manera inequivoca.

Pruebas: 
- Por inspección de código
- Verificar que tras ejecutar rebuild, los campos virtuales se han creado correctamente.


## 2 -  Contemplar el uso de módulos custom de tipo persona.
Se ha visto que se produce un error si se incluyen módulos custom de tipo Persona, si estos (como es habitual) no incluyen un campo _name_. 
Para solucionarlo se hace una evaluación expresa para verificar si el campo incluye un campo llamado _last_name_ y en ese caso tratarlo como un modulo de tipo persona.
Pruebas:
- Crear un módulo custom de tipo Persona
- Ejecutar rebuild y verificar que no se producen errores

## 3 -  Habilitar acceso de grupo a usuarios que tienen el acceso  "grupo" habilitado por un rol asignado directamente al usuario, y no a sus grupos.
Se ha visto que no se generan en SinergiaDA los permisos correspondientes de grupo, si ha recibido los permisos directamente por un rol asignado al usuario.
Pruebas:
1. Asignar a un usuario no administrador un rol que le habilite el acceso "ver" + "grupo" a cualquier módulo, 
2. Asignar al usuario a un grupo de seguridad que no tenga  ningún rol asignado.
3. Verificar que en la tabla de sda_def_permissions, se crean los permisos de acceso a los registros del grupo correctamente.

## 4 - Asegurar que las vistas incluyen siempre el campos user_name en el campos assigned_user_name y no el nombre y apellidos del usuario
Se corrige un error que hacía que el campo assigned_user_name de las vistas sda_ mostrases el nombre y apellidos del usuario, en lugar del campo user_name, lo que impedía que funcionasen los filtros de seguridad de usuario asignado.
Pruebas:
- Despues de reconstruir verificar que el campo assigned_user_name de las vistas muestran, sin excepción el valor de user_name y no el Nombre y apellidos del usuario
