### PR TITLE
Hotfix - Personas - Calcular Tipo de identificación en before_save

### DIFF
--- a/custom/Extension/modules/Contacts/Ext/LogicHooks/SticLogicHooksCall.php
+++ b/custom/Extension/modules/Contacts/Ext/LogicHooks/SticLogicHooksCall.php
@@ -27,4 +27,3 @@ if (!defined('sugarEntry') || !sugarEntry) {
 }
 $hook_array['before_save'][] = array(100, 'before_save', 'custom/modules/Contacts/SticLogicHooksCode.php', 'ContactsLogicHooks', 'before_save');
 $hook_array['after_save'][] = array(100, 'after_save', 'custom/modules/Contacts/SticLogicHooksCode.php', 'ContactsLogicHooks', 'after_save');
-$hook_array['after_retrieve'][] = array(100, 'after_retrieve', 'custom/modules/Contacts/SticLogicHooksCode.php', 'ContactsLogicHooks', 'after_retrieve');

--- a/custom/modules/Contacts/SticLogicHooksCode.php
+++ b/custom/modules/Contacts/SticLogicHooksCode.php
@@ -34,6 +34,22 @@ class ContactsLogicHooks {
             include_once 'modules/stic_Incorpora_Locations/Utils.php';
             stic_Incorpora_LocationsUtils::transferLocationData($bean);
         }
+
+        // In order to avoid identification number loss due to GUI JS validation, set the right identification type
+        // when this field is empty and the identification number is set.
+        if (!empty($bean->stic_identification_number_c) && (empty($bean->stic_identification_type_c) || trim($bean->stic_identification_type_c) == '')) {
+            include_once 'SticInclude/Utils.php';
+            if (!SticUtils::isValidNIForNIE($bean->stic_identification_number_c)) {
+                $bean->stic_identification_type_c = 'other';
+            } else {
+                $firstCharacter = strtoupper($bean->stic_identification_number_c[0]);
+                if (is_numeric($firstCharacter) || in_array($firstCharacter, array('K', 'L', 'M'))) {
+                    $bean->stic_identification_type_c = 'nif';
+                } else {
+                    $bean->stic_identification_type_c = 'nie';
+                }
+            };
+        }
     }
 
     public function after_save(&$bean, $event, $arguments) {
@@ -52,25 +68,6 @@ class ContactsLogicHooks {
         if ($bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c']) {
             include_once 'custom/modules/Contacts/SticUtils.php';
             ContactsUtils::generateCallFromReturnMailReason($bean);
-        }
-    }
-
-    public function after_retrieve(&$bean, $event, $arguments) {
-        // In order to avoid identification number loss due to GUI JS validation, set the right identification type
-        // when this field is empty and the identification number is set.
-        if (!empty($bean->stic_identification_number_c) && (empty($bean->stic_identification_type_c) || trim($bean->stic_identification_type_c) == '')) {
-            include_once 'SticInclude/Utils.php';
-            if (!SticUtils::isValidNIForNIE($bean->stic_identification_number_c)) {
-                $bean->stic_identification_type_c = 'other';
-            } else {
-                $firstCharacter = strtoupper($bean->stic_identification_number_c[0]);
-                if (is_numeric($firstCharacter) || in_array($firstCharacter, array('K', 'L', 'M'))) {
-                    $bean->stic_identification_type_c = 'nif';
-                } else {
-                    $bean->stic_identification_type_c = 'nie';
-                }
-            };
-            $bean->save();
         }
     }
 }


### PR DESCRIPTION
- Closes #22 

## Description

Se detecta que el INSERT que provoca el error en la base de datos se genera en la llamada al método  [_save()_ ](https://github.com/SinergiaTIC/SinergiaCRM/blob/develop/custom/modules/Contacts/SticLogicHooksCode.php#L73) realizada en la LH _after_retrieve_ del fichero _custom/modules/Contacts/SticLogicHooksCode.php_

Esto es debido a que cuando se va a guardar el bean, este tiene la propiedad _new_with_id_ a _true_ provocando que la propiedad _isUpdate_ pase a ser FALSE en vez de  TRUE en el método [save()](https://github.com/SinergiaTIC/SinergiaCRM/blob/develop/data/SugarBean.php#L2325-L2327) de SugarBean

Se observa que en la llamada al método [_save()_](https://github.com/SinergiaTIC/SinergiaCRM/blob/develop/modules/stic_Web_Forms/Catcher/WebFormDataBO.php#L318) , en el fichero _modules/stic_Web_Forms/Catcher/WebFormDataBO.php_, dicha propiedad está a _FALSE_, pero no he conseguido identificar en qué momento ni por que motivo la propiedad _new_with_id_ cambia a _TRUE_ ya que 

Se podría configurar la propiedad _new_with_id_ a _FALSE_ antes de ejecutar el método [_save()_ ](https://github.com/SinergiaTIC/SinergiaCRM/blob/develop/custom/modules/Contacts/SticLogicHooksCode.php#L73) de la LH _after_retrieve_ del fichero _custom/modules/Contacts/SticLogicHooksCode.php_ pero viendo el código de la LH, que calcula el valor de stic_identification_type_c en caso de que este campo no tenga valor y _stic_identification_number_c_ sí, la propuesta es eliminar el evento _after_retrieve_ y pasar el código a _before_save_

## How To Test This
1. Crear un FdT basado en Personas que se ejecute al guardar sobre todos los registros cuya acción sea crear una Relación con persona. 
2. Crear un formulario de donaciones o de inscripciones e indicar datos de una persona no existente para que se cree una persona nueva en el CRM y que esto haga saltar el FdT. 
3. Comprobar que el formulario ya no devuelve error y que se ha generado tanto la Persona, la Relación con Persona, el compromiso de pago y el pago.
