### PR TITLE
Hotfix - Emails - Mostrar notas adjuntas en el subpanel de Datos Adjuntos del email

### DIFF
--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -2646,6 +2646,16 @@ class Email extends Basic
             $note->file_mime_type = $note->file->mime_type;
             $note_id = $note->save();
 
+            // STIC-Custom 20240827 MHP - 
+            // Create relationship between Email and Note
+            global $db;
+            $query = "INSERT INTO emails_beans (id, email_id, bean_id, bean_module, deleted) 
+                      VALUES (UUID(), '{$this->id}', '{$note->id}', 'Notes', '0')";
+            if ($db->query($query)) {
+                $GLOBALS['log']->fatal("Line ".__LINE__.": ".__METHOD__.":  Error creating relationship between email ({$this->id}) and attached note ({$note->id})");
+            }
+            // END STIC-Custom
+            
             $this->saved_attachments[] = $note;
 
             $note->id = $note_id;

--- a/modules/Emails/Email.php
+++ b/modules/Emails/Email.php
@@ -2646,7 +2646,7 @@ class Email extends Basic
             $note->file_mime_type = $note->file->mime_type;
             $note_id = $note->save();
 
-            // STIC-Custom 20240827 MHP - 
+            // STIC-Custom 20240827 MHP - https://github.com/SinergiaTIC/SinergiaCRM/pull/377
             // Create relationship between Email and Note
             global $db;
             $query = "INSERT INTO emails_beans (id, email_id, bean_id, bean_module, deleted) 
@@ -2655,7 +2655,7 @@ class Email extends Basic
                 $GLOBALS['log']->fatal("Line ".__LINE__.": ".__METHOD__.":  Error creating relationship between email ({$this->id}) and attached note ({$note->id})");
             }
             // END STIC-Custom
-            
+
             $this->saved_attachments[] = $note;
 
             $note->id = $note_id;
@@ -2686,6 +2686,16 @@ class Email extends Basic
                 $docNote->parent_type = 'Emails';
                 $docNote->file_mime_type = $docRev->file_mime_type;
                 $docId = $docNote = $docNote->save();
+
+                // STIC-Custom 20240827 MHP - https://github.com/SinergiaTIC/SinergiaCRM/pull/377
+                // // Create relationship between email and note created from attached document
+                global $db;
+                $query = "INSERT INTO emails_beans (id, email_id, bean_id, bean_module, deleted) 
+                        VALUES (UUID(), '{$this->id}', '{$docNote}', 'Notes', '0')";
+                if ($db->query($query)) {
+                    $GLOBALS['log']->fatal("Line ".__LINE__.": ".__METHOD__.":  Error creating relationship between email ({$this->id}) and attached note ({$docNote})");
+                }
+                // END STIC-Custom
 
                 $noteFile->duplicate_file($docRev->id, $docId, $docRev->filename);
             }


### PR DESCRIPTION
- Closes #35 

## Descripción

**Pendiente de valorar la solución propuesta**

Además de lo indicado en el issue, se detecta que tampoco se crea la relación entre el email y la nota que genera el CRM cuando se adjunta un registro del módulo de Documentos al correo electrónico.

También se observa que:

- Existe una relación N-M entre Emails y Notas (en Estudio: emails_notes_rel) que es la que genera el subpanel de _Datos Adjuntos_ y que no se usa para relacionar la nota con el Email. Esta relación la modificamos en este PR https://github.com/SinergiaTIC/SinergiaCRM-SuiteCRM/pull/1081

- Para relacionar la nota con el email se utiliza un campo (parent_type) de tipo _Posible relacionado con_ . 
 
Durante la implementación del PR se intentó crear el registro vía beans en el mismo punto donde ahora está el INSERT:
```
$note->load_relationship('notes');
$note->notes->add($this->id);
```
pero daba error al encontrar el lado derecho de la relación. 

Se optó por no investigar dicho error e implementarlo vía SQL ya que si creábamos los registros en la tabla de BBDD de la relación aparecían las notas en el subpanel de Datos Adjuntos. 


## Pruebas

1. Acceder al módulo de Emails y enviar un email con uno o más ficheros y documentos adjuntos
2. Acceder al email enviado y comprobar que se muestran todas las notas generadas