### PR TITLE
Enhacement - Registro horario - Mostrar el botón aunque el usuario no tenga permiso de acceso al módulo

### DIFF
--- a/modules/stic_Time_Tracker/controller.php
+++ b/modules/stic_Time_Tracker/controller.php
@@ -37,10 +37,18 @@ class stic_Time_TrackerController extends SugarController {
         global $current_user;
         
         // Check if time tracker module is active
-        include_once 'modules/MySettings/TabController.php';
-        $controller = new TabController();
-        $currentTabs = $controller->get_system_tabs();
-        $timeTrackerModuleActive = in_array('stic_Time_Tracker', $currentTabs) ? 1 : 0;
+        $timeTrackerModuleActive = false;
+        $administration = BeanFactory::newBean('Administration');
+        $administration->retrieveSettings('MySettings');
+        if (isset($administration->settings) && isset($administration->settings['MySettings_tab'])) {
+            $tabs = $administration->settings['MySettings_tab'];
+            //make sure serialized string is not empty
+            if (!empty($tabs)) {
+                $tabs = base64_decode($tabs);
+                $tabs = unserialize($tabs);
+                $timeTrackerModuleActive = in_array('stic_Time_Tracker', $tabs) ? 1 : 0;
+            }
+        }
 
         // Check if there is a time tracker record for the employee in today
         $data = stic_Time_Tracker::getLastTodayTimeTrackerRecord($current_user->id);


### PR DESCRIPTION
- Closes #369 

## Descripción

Este PR cambia una de las comprobaciones que realiza el CRM para mostrar el botón de fichaje eficiente de forma que ahora valida si el módulo existe en la configuración de Administración en vez de comprobar si el módulo existían en el menú de usuario.

## Pruebas
1. Crear un usuario no administrador y activar el checkbox de Registro horario.
2. Relacionar al usuario con un rol donde esté deshabilitado el permiso de acceso al módulo de Registro horario.
3. Acceder al CRM con este usuario y comprobar que se muestra el botón de registro eficiente. 
4. Acceder con un usuario administrador y deshabilitar el módulo desde **Administración / Seleccionar Pestañas de Módulos y Subpaneles**
5. Acceder al CRM con el usuario del punto 1 y comprobar que NO se muestra el botón de registro eficiente. 