### PR TITLE
Hotfix - Grupos de Seguridad - La importación de registros podía generar error cuando había reglas

### DIFF
--- a/modules/stic_Security_Groups_Rules/Utils.php
+++ b/modules/stic_Security_Groups_Rules/Utils.php
@@ -433,6 +433,7 @@ class stic_Security_Groups_RulesUtils
             }
 
             // Create an array of security groups that are not inheritable under any circumstances for the current module
+            $notInheritableGroups = array();
             if (!empty($rulesBean->non_inherit_from_security_groups)) {
                 $notInheritableGroups = unencodeMultienum($rulesBean->non_inherit_from_security_groups);
             }


### PR DESCRIPTION
- Closes #383 

## Descripción
Tal como se describe en el issue #383, bajo ciertas condiciones se genera un error de PHP que impide la importación.
El problema se originaba por el uso de un array que no se había creado. 
La solución ha sido asegurarse que el array se crea siempre, aunque sea vacío.

## Pruebas
1. Activar las reglas personalizadas en la configuración de Grupos de Seguridad
2. Definir un módulo desde el cual se heredarán grupos
3. Cerciorarse que en la instancia no hay ningún grupo definido como no heredable
4. Importar un registro que haga referencia a un registro padre (del que heredará los grupos) y que este padre tenga grupos de seguridad definidos
5. Comprobar que se importa correctamente y hereda el grupo