### PR TITLE
Hotfix - Campañas - Cargar información relacionada a la cuenta de entrada seleccionada

### DIFF
--- a/custom/modules/EmailMarketing/EditView.html
+++ b/custom/modules/EmailMarketing/EditView.html
@@ -279,8 +279,8 @@
     }
 
     //get values to populate from and reply boxes on change of mail box dropdown
-    // STIC-Custom 20240913 MHP - Remove spaces between {} and variable name
-    // 
+    // STIC-Custom 20240913 MHP - Remove spaces between {} and variable
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/387
     // var ie_stored_options = { IEStoredOptions };
     var ie_stored_options = {IEStoredOptions};
     // END STIC-Custom

--- a/custom/modules/EmailMarketing/EditView.html
+++ b/custom/modules/EmailMarketing/EditView.html
@@ -279,7 +279,11 @@
     }
 
     //get values to populate from and reply boxes on change of mail box dropdown
-    var ie_stored_options = { IEStoredOptions };
+    // STIC-Custom 20240913 MHP - Remove spaces between {} and variable name
+    // 
+    // var ie_stored_options = { IEStoredOptions };
+    var ie_stored_options = {IEStoredOptions};
+    // END STIC-Custom
     var from_emails = new Array({ FROM_EMAILS });
 
     function set_from_email_and_name(mailbox) {


### PR DESCRIPTION
- Closed #82 

## Descripción
El PR elimina dos espacios que impedían que se pudiese acceder a la variable con la información necesaria desde Javascript. Una vez eliminados ya funciona el mecanismo de SuiteCRM para recuperar la información del remitente y de a quien responder de cada cuenta de entrada

## Pruebas
1. Crear una cuenta de rebotes y poblar los campos **Nombre del remitente, Dirección del Remitente, Nombre de "Responder A"  y Dirección de "Responder A"** 
2. Crear una campaña clásica y crear un email de marketing desde el subpanel de la vista de detalle de la campaña.
3. Seleccionar una cuenta de rebotes y comprobar que se carga la información asociada a la cuenta de rebotes seleccionada en los campos relacionados del email de marketing 

