### PR TITLE
Hotfix - Administración - Mostrar editor enriquecido de HTML tras Clonar o Cancelar edición

### DIFF
--- a/modules/DynamicFields/templates/Fields/Forms/html.tpl
+++ b/modules/DynamicFields/templates/Fields/Forms/html.tpl
@@ -65,6 +65,10 @@
 <script type="text/javascript" language="Javascript">
 SUGAR.ajaxLoad = true;
 {if $hideLevel < 5}
+    // STIC-Custom 20240916 MHP - Close editor before reopening it under the same ID
+    // 
+    tinymce.execCommand('mceRemoveControl', false, 'htmlarea');
+    // END STIC-Custom
     setTimeout("tinyMCE.execCommand('mceAddControl', false, 'htmlarea');", 500);  
 	ModuleBuilder.tabPanel.get("activeTab").closeEvent.subscribe(function(){ldelim}tinyMCE.execCommand('mceRemoveControl', false, 'htmlarea');{rdelim});
 	setTimeout("document.forms.popup_form.required.value = false;YAHOO.util.Dom.getAncestorByTagName(document.forms.popup_form.required, 'tr').style.display='none';", 500);

--- a/modules/DynamicFields/templates/Fields/Forms/html.tpl
+++ b/modules/DynamicFields/templates/Fields/Forms/html.tpl
@@ -66,7 +66,7 @@
 SUGAR.ajaxLoad = true;
 {if $hideLevel < 5}
     // STIC-Custom 20240916 MHP - Close editor before reopening it under the same ID
-    // 
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/388
     tinymce.execCommand('mceRemoveControl', false, 'htmlarea');
     // END STIC-Custom
     setTimeout("tinyMCE.execCommand('mceAddControl', false, 'htmlarea');", 500);  


### PR DESCRIPTION
- Closes #81 

## Descripción
Este PR elimina la posible asociación que pueda existir entre TinyMCE y el elemento textarea con id "htmlarea" antes de volver a renderizarlo. El error se producía al intentar reutilizar la referencia al editor del textarea original y este no estar disponible por que por que al pulsar en Clonar o en Cancelar + Reabrir se crea otro elemento textarea. 

## Pruebas
1. Acceder a Estudio, crear un campo, seleccionar que sea de tipo HTML, asignarle un valor y comprobar que se muestra el editor enriquecido. 
2. Pulsar en el botón de Clonar y comprobar que se muestra el editor enriquecido. 
3. Volver a editar el campo creado en el punto 1 + pulsar en el botón de Cancelar
4. Editar el campo y comprobar que se muestra el editor enriquecido. 
5. Asignar un valor diferente al que asignamos en el primer punto +  Guardar
6. Editar de nuevo el campo y comprobar que se ha guardado el valor indicado en el punto anterior
