### PR TITLE
Hotfix - Casos - Mostrar editor texto enriquecido en el campo Resolución 

### DIFF
--- a/custom/Extension/modules/Cases/Ext/Vardefs/SticVardefs.php
+++ b/custom/Extension/modules/Cases/Ext/Vardefs/SticVardefs.php
@@ -27,5 +27,6 @@ $dictionary['Case']['fields']['contact_created_by_id']['massupdate'] = 1;
 $dictionary['Case']['fields']['contact_created_by']['massupdate'] = 1;
 $dictionary['Case']['fields']['priority']['massupdate'] = 1;
 $dictionary['Case']['fields']['internal']['massupdate'] = 1;
+$dictionary['Case']['fields']['resolution']['editor'] = 'html';
 
 $dictionary['Case']['unified_search_default_enabled'] = false;


### PR DESCRIPTION
- Closes #310 

## Descripción
Al igual que ocurre con el campo Descripción, este PR añade la propiedad **editor = 'html'** en la definición del campo Resolución. 

## Pruebas
1. Activar el módulo de Casos y acceder a la vista de creación o de edición de un registro
2. Comprobar que el campo Resolución se muestra con el editor de texto enriquecido