### PR TITLE
Hotfix - Grupos de Seguridad - Índice para consultas de roles a partir de grupos de seguridad

### DIFF
--- a/metadata/securitygroups_acl_rolesMetaData.php
+++ b/metadata/securitygroups_acl_rolesMetaData.php
@@ -10,7 +10,8 @@ $dictionary['securitygroups_acl_roles'] = array(
     ),
     'indices' => array(
        array('name' =>'securitygroups_acl_rolespk', 'type' =>'primary', 'fields'=>array('id')),
-       // STIC Custom 20240917 EPS: New index to speed up the query at modules/ACLActions/ACLAction.php
+       // STIC-Custom 20240917 EPS: New index to speed up the query at modules/ACLActions/ACLAction.php
+       // https://github.com/SinergiaTIC/SinergiaCRM/pull/391
        array('name' => 'idx_SG_roles', 'type' => 'index', 'fields' => array('securitygroup_id', 'role_id')),
        // END STIC Custom
     ),


### PR DESCRIPTION
## Descripción
Durante la revisión realizada para solucionar los problemas de rendimiento de una consulta detectada en una entidad, se observa que la tabla securitygroups_acl_roles sólo tiene índice definido sobre el campo ID, ralentizando las consultas necesarias realizadas a partir del grupo de seguridad. 
Por ese motivo se añade el índice que permite obtener a partir de un grupo de seguridad el rol asociado.

## Pruebas
1. Reparar la instancia y comprobar mediante inspección de BBDD que el nuevo índice idx_SG_roles está creado sobre la tabla securitygroups_acl_roles