### PR TITLE
Hotfix - Calendario de recursos - Evitar la regeneración de ficheros de idioma de aplicación

### DIFF
--- a/modules/ResourceCalendar/language/ca_ES.lang.php
+++ b/modules/ResourceCalendar/language/ca_ES.lang.php
@@ -42,4 +42,6 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-$mod_strings = array();
+$mod_strings = array(
+    'LBL_ID' => 'ID',
+);

--- a/modules/ResourceCalendar/language/en_us.lang.php
+++ b/modules/ResourceCalendar/language/en_us.lang.php
@@ -42,4 +42,6 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-$mod_strings = array();
+$mod_strings = array(
+    'LBL_ID' => 'ID',
+);

--- a/modules/ResourceCalendar/language/es_ES.lang.php
+++ b/modules/ResourceCalendar/language/es_ES.lang.php
@@ -42,4 +42,6 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-$mod_strings = array();
+$mod_strings = array(
+    'LBL_ID' => 'ID',
+);

--- a/modules/ResourceCalendar/language/gl_ES.lang.php
+++ b/modules/ResourceCalendar/language/gl_ES.lang.php
@@ -42,4 +42,6 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-$mod_strings = array();
+$mod_strings = array(
+    'LBL_ID' => 'ID',
+);


### PR DESCRIPTION
Cuando el módulo de Calendario de recursos (ResourceCalendar) está activado, se detecta que el sistema regenera continuamente los ficheros de idioma de aplicación custom/application/Ext/Language/*.ext.php. Esto es debido a que los ficheros de idioma del módulo tienen el array `$mod_strings` vacío.

En este PR añadimos la etiqueta "LBL_ID" para cada fichero de idioma del módulo ResourceCalendar para evitar este comportamiento.

Se informará a SA de este comportamiento. Valorar hacerlo a través del Issue ya existente: https://github.com/salesagility/SuiteCRM/issues/5195

**Pruebas:**
- Activar el módulo de ResourceCalendar
- Comprobar que al hacer logout-login o cualquier otra acción del CRM, los ficheros de idioma de aplicación no se regeneran.

