### PR TITLE
Hotfix - Notificaciones - Mostrar panel notificaciones aunque se personalice la vista de edición

### DIFF
--- a/custom/modules/Campaigns/SticUtils.js
+++ b/custom/modules/Campaigns/SticUtils.js
@@ -125,6 +125,7 @@ function getCampaingType() {
 function type_change() {
   var typeValue = getCampaingType();
 
+  debugger;
   updateViewNewsLetterType(typeValue == "NewsLetter");
   updateViewNotificationType(typeValue == "Notification");
   mail_change();
@@ -180,8 +181,12 @@ function ConvertItems(id) {
 function updateViewNewsLetterType(isNewsLetter) {
   if (isNewsLetter) {
     $('[data-field="frequency"]').show();
+    $('#freq_label').show();
+    $('#freq_field').show();
   } else {
     $('[data-field="frequency"]').hide();
+    $('#freq_label').hide();
+    $('#freq_field').hide();
   }
 }
 

--- a/custom/modules/Campaigns/SticUtils.js
+++ b/custom/modules/Campaigns/SticUtils.js
@@ -100,14 +100,21 @@ $(document).ready(function() {
       $("#notification_template_id").on("change paste keyup", template_change);
     }
 
-    var observer = new MutationObserver(function(mutations) {
-      mutations.forEach(function(mutation) {
-        if (mutation.attributeName === 'style') {
-          type_change();
-        }
+    // Check Notification panel exists
+    const targetElement = $(".panel-body[data-id='LBL_NOTIFICATION_INFORMATION_PANEL']").parent()[0];
+    if (targetElement) {
+      var observer = new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutation) {
+          if (mutation.attributeName === 'style') {
+            type_change();
+          }
+        });
       });
-    });
-    observer.observe($(".panel-body[data-id='LBL_NOTIFICATION_INFORMATION_PANEL']").parent()[0], { attributes: true, attributeFilter: ['style'] });
+  
+      observer.observe(targetElement, { attributes: true, attributeFilter: ['style'] });
+    } else {
+        console.log("Notification panel does not exists in DOM.");
+    }
 
     type_change();
     template_change();
@@ -125,7 +132,6 @@ function getCampaingType() {
 function type_change() {
   var typeValue = getCampaingType();
 
-  debugger;
   updateViewNewsLetterType(typeValue == "NewsLetter");
   updateViewNotificationType(typeValue == "Notification");
   mail_change();

--- a/custom/modules/Campaigns/views/view.edit.php
+++ b/custom/modules/Campaigns/views/view.edit.php
@@ -35,6 +35,7 @@ class CustomCampaignsViewEdit extends ViewEdit
         parent::__construct();
         $this->useForSubpanel = false;
         $this->useModuleQuickCreateTemplate = true;
+        $this->moduleName = 'Campaigns';
     }
 
     public function preDisplay()
@@ -47,7 +48,8 @@ class CustomCampaignsViewEdit extends ViewEdit
         include_once "custom/modules/Campaigns/SticUtils.php";
         CampaignsUtils::fillDynamicListsForNotifications();
 
-        $this->ev->defs['panels']['templateMeta']['tabdefs']['LBL_NOTIFICATION_INFORMATION_PANEL'] =array (
+        // Adding the Notification panel dinamically.
+        $this->ev->defs['panels']['templateMeta']['tabdefs']['LBL_NOTIFICATION_INFORMATION_PANEL'] = array(
             'newTab' => false,
             'panelDefault' => 'expanded',
         );
@@ -55,45 +57,51 @@ class CustomCampaignsViewEdit extends ViewEdit
         $this->ev->defs['panels']['LBL_NOTIFICATION_INFORMATION_PANEL'] = array(
             0 => array(
                 0 => array(
-                  'name' => 'notification_prospect_list_ids',
-                  'label' => 'LBL_NOTIFICATION_PROSPECT_LIST_ID',
+                    'name' => 'parent_name',
+                    'label' => 'LBL_PARENT_NAME',
                 ),
-                1 => array(
-                  'name' => 'notification_template_id',
-                  'label' => 'LBL_NOTIFICATION_TEMPLATE_ID',
-                ),
-              ),
-              1 => array(
+            ),
+            1 => array(
                 0 => array(
-                  'name' => 'notification_outbound_email_id',
-                  'label' => 'LBL_NOTIFICATION_OUTBOUND_EMAIL_ID',
+                    'name' => 'notification_prospect_list_ids',
+                    'label' => 'LBL_NOTIFICATION_PROSPECT_LIST_ID',
                 ),
                 1 => array(
-                  'name' => 'notification_inbound_email_id',
-                  'label' => 'LBL_NOTIFICATION_INBOUND_EMAIL_ID',
+                    'name' => 'notification_template_id',
+                    'label' => 'LBL_NOTIFICATION_TEMPLATE_ID',
                 ),
-              ),
-              2 => array(
+            ),
+            2 => array(
                 0 => array(
-                  'name' => 'notification_from_name',
-                  'label' => 'LBL_NOTIFICATION_FROM_NAME',
+                    'name' => 'notification_outbound_email_id',
+                    'label' => 'LBL_NOTIFICATION_OUTBOUND_EMAIL_ID',
                 ),
                 1 => array(
-                  'name' => 'notification_from_addr',
-                  'label' => 'LBL_NOTIFICATION_FROM_ADDR',
+                    'name' => 'notification_inbound_email_id',
+                    'label' => 'LBL_NOTIFICATION_INBOUND_EMAIL_ID',
                 ),
-              ),
-              3 => array(
+            ),
+            3 => array(
                 0 => array(
-                  'name' => 'notification_reply_to_name',
-                  'label' => 'LBL_NOTIFICATION_REPLY_TO_NAME',
+                    'name' => 'notification_from_name',
+                    'label' => 'LBL_NOTIFICATION_FROM_NAME',
                 ),
                 1 => array(
-                  'name' => 'notification_reply_to_addr',
-                  'label' => 'LBL_NOTIFICATION_REPLY_TO_ADDR',
+                    'name' => 'notification_from_addr',
+                    'label' => 'LBL_NOTIFICATION_FROM_ADDR',
                 ),
-              ),
-            );
+            ),
+            4 => array(
+                0 => array(
+                    'name' => 'notification_reply_to_name',
+                    'label' => 'LBL_NOTIFICATION_REPLY_TO_NAME',
+                ),
+                1 => array(
+                    'name' => 'notification_reply_to_addr',
+                    'label' => 'LBL_NOTIFICATION_REPLY_TO_ADDR',
+                ),
+            ),
+        );
     }
 
     public function display()

--- a/custom/modules/Campaigns/views/view.edit.php
+++ b/custom/modules/Campaigns/views/view.edit.php
@@ -58,8 +58,9 @@ class CustomCampaignsViewEdit extends ViewEdit
             0 => array(
                 0 => array(
                     'name' => 'parent_name',
-                    'label' => 'LBL_PARENT_NAME',
+                    'label' => 'LBL_FLEX_RELATE',
                 ),
+                1 => '',
             ),
             1 => array(
                 0 => array(

--- a/custom/modules/Campaigns/views/view.edit.php
+++ b/custom/modules/Campaigns/views/view.edit.php
@@ -46,6 +46,54 @@ class CustomCampaignsViewEdit extends ViewEdit
         // Write here you custom code
         include_once "custom/modules/Campaigns/SticUtils.php";
         CampaignsUtils::fillDynamicListsForNotifications();
+
+        $this->ev->defs['panels']['templateMeta']['tabdefs']['LBL_NOTIFICATION_INFORMATION_PANEL'] =array (
+            'newTab' => false,
+            'panelDefault' => 'expanded',
+        );
+
+        $this->ev->defs['panels']['LBL_NOTIFICATION_INFORMATION_PANEL'] = array(
+            0 => array(
+                0 => array(
+                  'name' => 'notification_prospect_list_ids',
+                  'label' => 'LBL_NOTIFICATION_PROSPECT_LIST_ID',
+                ),
+                1 => array(
+                  'name' => 'notification_template_id',
+                  'label' => 'LBL_NOTIFICATION_TEMPLATE_ID',
+                ),
+              ),
+              1 => array(
+                0 => array(
+                  'name' => 'notification_outbound_email_id',
+                  'label' => 'LBL_NOTIFICATION_OUTBOUND_EMAIL_ID',
+                ),
+                1 => array(
+                  'name' => 'notification_inbound_email_id',
+                  'label' => 'LBL_NOTIFICATION_INBOUND_EMAIL_ID',
+                ),
+              ),
+              2 => array(
+                0 => array(
+                  'name' => 'notification_from_name',
+                  'label' => 'LBL_NOTIFICATION_FROM_NAME',
+                ),
+                1 => array(
+                  'name' => 'notification_from_addr',
+                  'label' => 'LBL_NOTIFICATION_FROM_ADDR',
+                ),
+              ),
+              3 => array(
+                0 => array(
+                  'name' => 'notification_reply_to_name',
+                  'label' => 'LBL_NOTIFICATION_REPLY_TO_NAME',
+                ),
+                1 => array(
+                  'name' => 'notification_reply_to_addr',
+                  'label' => 'LBL_NOTIFICATION_REPLY_TO_ADDR',
+                ),
+              ),
+            );
     }
 
     public function display()

--- a/modules/Campaigns/metadata/editviewdefs.php
+++ b/modules/Campaigns/metadata/editviewdefs.php
@@ -249,57 +249,51 @@ $viewdefs['Campaigns']['EditView'] = array (
         'field' => '30',
       ),
     ),
-    // STIC-Custom - JBL - 20240515 - Notify new Opportunities: New Campaign type (Notification)
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/44
-    // 'javascript' => '<script type="text/javascript" src="include/javascript/popup_parent_helper.js?v=igGzALk_bn-xeyTYyoHxog"></script>
-    // <script type="text/javascript">
-    // function type_change() {ldelim}
-    // 	type = document.getElementsByName(\'campaign_type\');
-    // 	if(type[0].value==\'NewsLetter\') {ldelim}
-    // 		document.getElementById(\'freq_label\').style.display = \'\';
-    // 		document.getElementById(\'freq_field\').style.display = \'\';
-    // 	 {rdelim} else {ldelim}
-    // 		document.getElementById(\'freq_label\').style.display = \'none\';
-    // 		document.getElementById(\'freq_field\').style.display = \'none\';
-    // 	 {rdelim}
-    //  {rdelim}
-    // type_change();
+    'javascript' => '<script type="text/javascript" src="include/javascript/popup_parent_helper.js?v=igGzALk_bn-xeyTYyoHxog"></script>
+<script type="text/javascript">
+function type_change() {ldelim}
+	type = document.getElementsByName(\'campaign_type\');
+	if(type[0].value==\'NewsLetter\') {ldelim}
+		document.getElementById(\'freq_label\').style.display = \'\';
+		document.getElementById(\'freq_field\').style.display = \'\';
+	 {rdelim} else {ldelim}
+		document.getElementById(\'freq_label\').style.display = \'none\';
+		document.getElementById(\'freq_field\').style.display = \'none\';
+	 {rdelim}
+ {rdelim}
+type_change();
 
-    // function ConvertItems(id)  {ldelim}
-    // 	var items = new Array();
+function ConvertItems(id)  {ldelim}
+	var items = new Array();
 
-    // 	//get the items that are to be converted
-    // 	expected_revenue = document.getElementById(\'expected_revenue\');
-    // 	budget = document.getElementById(\'budget\');
-    // 	actual_cost = document.getElementById(\'actual_cost\');
-    // 	expected_cost = document.getElementById(\'expected_cost\');
+	//get the items that are to be converted
+	expected_revenue = document.getElementById(\'expected_revenue\');
+	budget = document.getElementById(\'budget\');
+	actual_cost = document.getElementById(\'actual_cost\');
+	expected_cost = document.getElementById(\'expected_cost\');
 
-    // 	//unformat the values of the items to be converted
-    // 	expected_revenue.value = unformatNumber(expected_revenue.value, num_grp_sep, dec_sep);
-    // 	expected_cost.value = unformatNumber(expected_cost.value, num_grp_sep, dec_sep);
-    // 	budget.value = unformatNumber(budget.value, num_grp_sep, dec_sep);
-    // 	actual_cost.value = unformatNumber(actual_cost.value, num_grp_sep, dec_sep);
+	//unformat the values of the items to be converted
+	expected_revenue.value = unformatNumber(expected_revenue.value, num_grp_sep, dec_sep);
+	expected_cost.value = unformatNumber(expected_cost.value, num_grp_sep, dec_sep);
+	budget.value = unformatNumber(budget.value, num_grp_sep, dec_sep);
+	actual_cost.value = unformatNumber(actual_cost.value, num_grp_sep, dec_sep);
 
-    // 	//add the items to an array
-    // 	items[items.length] = expected_revenue;
-    // 	items[items.length] = budget;
-    // 	items[items.length] = expected_cost;
-    // 	items[items.length] = actual_cost;
+	//add the items to an array
+	items[items.length] = expected_revenue;
+	items[items.length] = budget;
+	items[items.length] = expected_cost;
+	items[items.length] = actual_cost;
 
-    // 	//call function that will convert currency
-    // 	ConvertRate(id, items);
+	//call function that will convert currency
+	ConvertRate(id, items);
 
-    // 	//Add formatting back to items
-    // 	expected_revenue.value = formatNumber(expected_revenue.value, num_grp_sep, dec_sep);
-    // 	expected_cost.value = formatNumber(expected_cost.value, num_grp_sep, dec_sep);
-    // 	budget.value = formatNumber(budget.value, num_grp_sep, dec_sep);
-    // 	actual_cost.value = formatNumber(actual_cost.value, num_grp_sep, dec_sep);
-    //  {rdelim}
-    // </script>',
-    'javascript' => '{sugar_getscript file="include/javascript/popup_parent_helper.js"}
-                     {sugar_getscript file="SticInclude/js/Utils.js"}
-                     {sugar_getscript file="custom/modules/Campaigns/SticUtils.js"}',
-    // END STIC-Custom JBL
+	//Add formatting back to items
+	expected_revenue.value = formatNumber(expected_revenue.value, num_grp_sep, dec_sep);
+	expected_cost.value = formatNumber(expected_cost.value, num_grp_sep, dec_sep);
+	budget.value = formatNumber(budget.value, num_grp_sep, dec_sep);
+	actual_cost.value = formatNumber(actual_cost.value, num_grp_sep, dec_sep);
+ {rdelim}
+</script>',
     'useTabs' => true,
     'tabDefs' => 
     array (
@@ -308,14 +302,6 @@ $viewdefs['Campaigns']['EditView'] = array (
         'newTab' => true,
         'panelDefault' => 'expanded',
       ),
-      // STIC-Custom - JBL - 20240620 - Notify new Opportunities: New Campaign type (Notification)
-      // https://github.com/SinergiaTIC/SinergiaCRM/pull/44
-      // 'LBL_NOTIFICATION_INFORMATION_PANEL' =>
-      // array (
-      //   'newTab' => false,
-      //   'panelDefault' => 'expanded',
-      // ),
-      // END STIC-Custom JBL
       'LBL_NAVIGATION_MENU_GEN2' => 
       array (
         'newTab' => true,
@@ -379,18 +365,10 @@ $viewdefs['Campaigns']['EditView'] = array (
         0 => 
         array (
           'name' => 'frequency',
-          // STIC-Custom - JBL - 20240611 - Notify new Opportunities: New Campaign type (Notification)
-          // https://github.com/SinergiaTIC/SinergiaCRM/pull/44
-          // 'customCode' => '<div style=\'none\' id=\'freq_field\'>{html_options name="frequency" options=$fields.frequency.options selected=$fields.frequency.value}</div></TD>',
-          // 'customLabel' => '<div style=\'none\' id=\'freq_label\'>{$MOD.LBL_CAMPAIGN_FREQUENCY}</div>',
-          // END STIC-Custom JBL
+          'customCode' => '<div style=\'none\' id=\'freq_field\'>{html_options name="frequency" options=$fields.frequency.options selected=$fields.frequency.value}</div></TD>',
+          'customLabel' => '<div style=\'none\' id=\'freq_label\'>{$MOD.LBL_CAMPAIGN_FREQUENCY}</div>',
         ),
-        // STIC-Custom - JBL - 20240611 - New Campaign type (Notification)
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/44
-        1 => array (
-          'name' => 'parent_name',
-        ),
-        // END STIC-Custom JBL
+        1 => '',
       ),
       4 => 
       array (
@@ -399,62 +377,12 @@ $viewdefs['Campaigns']['EditView'] = array (
           'name' => 'content',
           'displayParams' => 
           array (
-            // STIC-Custom - JBL - 20240620 - Notify new Opportunities: New Campaign type (Notification)
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/44
-            // 'rows' => 8,
-            'rows' => 2,
-            // END STIC-Custom JBL
+            'rows' => 8,
             'cols' => 80,
           ),
         ),
       ),
     ),
-    // STIC-Custom - JBL - 20240620 - Notify new Opportunities: New Campaign type (Notification)
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/44
-    // 'LBL_NOTIFICATION_INFORMATION_PANEL' =>
-    // array (
-    //   0 => array(
-    //     0 => array(
-    //       'name' => 'notification_prospect_list_ids',
-    //       'label' => 'LBL_NOTIFICATION_PROSPECT_LIST_ID',
-    //     ),
-    //     1 => array(
-    //       'name' => 'notification_template_id',
-    //       'label' => 'LBL_NOTIFICATION_TEMPLATE_ID',
-    //     ),
-    //   ),
-    //   1 => array(
-    //     0 => array(
-    //       'name' => 'notification_outbound_email_id',
-    //       'label' => 'LBL_NOTIFICATION_OUTBOUND_EMAIL_ID',
-    //     ),
-    //     1 => array(
-    //       'name' => 'notification_inbound_email_id',
-    //       'label' => 'LBL_NOTIFICATION_INBOUND_EMAIL_ID',
-    //     ),
-    //   ),
-    //   2 => array(
-    //     0 => array(
-    //       'name' => 'notification_from_name',
-    //       'label' => 'LBL_NOTIFICATION_FROM_NAME',
-    //     ),
-    //     1 => array(
-    //       'name' => 'notification_from_addr',
-    //       'label' => 'LBL_NOTIFICATION_FROM_ADDR',
-    //     ),
-    //   ),
-    //   3 => array(
-    //     0 => array(
-    //       'name' => 'notification_reply_to_name',
-    //       'label' => 'LBL_NOTIFICATION_REPLY_TO_NAME',
-    //     ),
-    //     1 => array(
-    //       'name' => 'notification_reply_to_addr',
-    //       'label' => 'LBL_NOTIFICATION_REPLY_TO_ADDR',
-    //     ),
-    //   ),
-    // ),
-    // END STIC-Custom JBL
     'LBL_NAVIGATION_MENU_GEN2' => 
     array (
       0 => 

--- a/modules/Campaigns/metadata/editviewdefs.php
+++ b/modules/Campaigns/metadata/editviewdefs.php
@@ -310,11 +310,11 @@ $viewdefs['Campaigns']['EditView'] = array (
       ),
       // STIC-Custom - JBL - 20240620 - Notify new Opportunities: New Campaign type (Notification)
       // https://github.com/SinergiaTIC/SinergiaCRM/pull/44
-      'LBL_NOTIFICATION_INFORMATION_PANEL' =>
-      array (
-        'newTab' => false,
-        'panelDefault' => 'expanded',
-      ),
+      // 'LBL_NOTIFICATION_INFORMATION_PANEL' =>
+      // array (
+      //   'newTab' => false,
+      //   'panelDefault' => 'expanded',
+      // ),
       // END STIC-Custom JBL
       'LBL_NAVIGATION_MENU_GEN2' => 
       array (
@@ -411,49 +411,49 @@ $viewdefs['Campaigns']['EditView'] = array (
     ),
     // STIC-Custom - JBL - 20240620 - Notify new Opportunities: New Campaign type (Notification)
     // https://github.com/SinergiaTIC/SinergiaCRM/pull/44
-    'LBL_NOTIFICATION_INFORMATION_PANEL' =>
-    array (
-      0 => array(
-        0 => array(
-          'name' => 'notification_prospect_list_ids',
-          'label' => 'LBL_NOTIFICATION_PROSPECT_LIST_ID',
-        ),
-        1 => array(
-          'name' => 'notification_template_id',
-          'label' => 'LBL_NOTIFICATION_TEMPLATE_ID',
-        ),
-      ),
-      1 => array(
-        0 => array(
-          'name' => 'notification_outbound_email_id',
-          'label' => 'LBL_NOTIFICATION_OUTBOUND_EMAIL_ID',
-        ),
-        1 => array(
-          'name' => 'notification_inbound_email_id',
-          'label' => 'LBL_NOTIFICATION_INBOUND_EMAIL_ID',
-        ),
-      ),
-      2 => array(
-        0 => array(
-          'name' => 'notification_from_name',
-          'label' => 'LBL_NOTIFICATION_FROM_NAME',
-        ),
-        1 => array(
-          'name' => 'notification_from_addr',
-          'label' => 'LBL_NOTIFICATION_FROM_ADDR',
-        ),
-      ),
-      3 => array(
-        0 => array(
-          'name' => 'notification_reply_to_name',
-          'label' => 'LBL_NOTIFICATION_REPLY_TO_NAME',
-        ),
-        1 => array(
-          'name' => 'notification_reply_to_addr',
-          'label' => 'LBL_NOTIFICATION_REPLY_TO_ADDR',
-        ),
-      ),
-    ),
+    // 'LBL_NOTIFICATION_INFORMATION_PANEL' =>
+    // array (
+    //   0 => array(
+    //     0 => array(
+    //       'name' => 'notification_prospect_list_ids',
+    //       'label' => 'LBL_NOTIFICATION_PROSPECT_LIST_ID',
+    //     ),
+    //     1 => array(
+    //       'name' => 'notification_template_id',
+    //       'label' => 'LBL_NOTIFICATION_TEMPLATE_ID',
+    //     ),
+    //   ),
+    //   1 => array(
+    //     0 => array(
+    //       'name' => 'notification_outbound_email_id',
+    //       'label' => 'LBL_NOTIFICATION_OUTBOUND_EMAIL_ID',
+    //     ),
+    //     1 => array(
+    //       'name' => 'notification_inbound_email_id',
+    //       'label' => 'LBL_NOTIFICATION_INBOUND_EMAIL_ID',
+    //     ),
+    //   ),
+    //   2 => array(
+    //     0 => array(
+    //       'name' => 'notification_from_name',
+    //       'label' => 'LBL_NOTIFICATION_FROM_NAME',
+    //     ),
+    //     1 => array(
+    //       'name' => 'notification_from_addr',
+    //       'label' => 'LBL_NOTIFICATION_FROM_ADDR',
+    //     ),
+    //   ),
+    //   3 => array(
+    //     0 => array(
+    //       'name' => 'notification_reply_to_name',
+    //       'label' => 'LBL_NOTIFICATION_REPLY_TO_NAME',
+    //     ),
+    //     1 => array(
+    //       'name' => 'notification_reply_to_addr',
+    //       'label' => 'LBL_NOTIFICATION_REPLY_TO_ADDR',
+    //     ),
+    //   ),
+    // ),
     // END STIC-Custom JBL
     'LBL_NAVIGATION_MENU_GEN2' => 
     array (


### PR DESCRIPTION
## Descripción
Este PR soluciona ciertos errores en las Notificaciones: 
1. Se producía un error en la carga de fichero js de idioma para el módulo Campaigns
2. Si se había personalizado la vista de edición de Campañas, no aparecía el panel de Notificaciones y no era posible crear notificaciones

## Pruebas
1. Abrir Estudio -> Campañas -> Vista de Edición
2. Verificar que No aparece el panel "Notificaciones"
3. Acceder a Campañas -> Crear una campaña (Clásica)
4. Verificar que aparece el panel Notificaciones al cambiar el tipo a "Notificación"
5. Verificar que aparece el campo "frecuencia" al cambiar el tipos a "Boletín de Noticias"
6. Verificar que no hay errores de consola
