### PR TITLE
Hotfix - Notas - Añadir popupdefs.php para poder configurar la ventana emergente

### DIFF
--- a/modules/Notes/metadata/popupdefs.php
+++ b/modules/Notes/metadata/popupdefs.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * SugarCRM Community Edition is a customer relationship management program developed by
+ * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc.
+ *
+ * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd.
+ * Copyright (C) 2011 - 2018 SalesAgility Ltd.
+ *
+ * SinergiaCRM is a work developed by SinergiaTIC Association, based on SuiteCRM.
+ * Copyright (C) 2013 - 2023 SinergiaTIC Association
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SUGARCRM, SUGARCRM DISCLAIMS THE WARRANTY
+ * OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SugarCRM, Inc. headquarters at 10050 North Wolfe Road,
+ * SW2-130, Cupertino, CA 95014, USA. or at email address contact@sugarcrm.com.
+ *
+ * You can contact SinergiaTIC Association at email address info@sinergiacrm.org.
+ * 
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License version 3.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License version 3,
+ * these Appropriate Legal Notices must retain the display of the "Powered by
+ * SugarCRM" logo, "Supercharged by SuiteCRM" logo and “Nonprofitized by SinergiaCRM” logo. 
+ * If the display of the logos is not reasonably feasible for technical reasons, 
+ * the Appropriate Legal Notices must display the words "Powered by SugarCRM", 
+ * "Supercharged by SuiteCRM" and “Nonprofitized by SinergiaCRM”. 
+ */
+
+// STIC-Custom - MHP - 
+//
+$popupMeta = 
+array (
+  'moduleMain' => 'Notes',
+  'varName' => 'Note',
+  'orderBy' => 'notes.name',
+  'whereClauses' => 
+  array (
+    'name' => 'notes.name',
+  ),
+  'searchInputs' => 
+  array (
+    0 => 'notes_number',
+    1 => 'name',
+    2 => 'priority',
+    3 => 'status',
+  ),
+);
+// END STIC-Custom

--- a/modules/Notes/metadata/popupdefs.php
+++ b/modules/Notes/metadata/popupdefs.php
@@ -43,8 +43,8 @@
  * "Supercharged by SuiteCRM" and “Nonprofitized by SinergiaCRM”. 
  */
 
-// STIC-Custom - MHP - 
-//
+// STIC-Custom - MHP - Defines popup settings for the notes module
+// https://github.com/SinergiaTIC/SinergiaCRM/pull/402/
 $popupMeta = 
 array (
   'moduleMain' => 'Notes',


### PR DESCRIPTION
- closes #401 

## Descripción
Este PR crea el fichero popupdefs.php siguiendo la estructura de este fichero en otros módulos de Actividades como Llamadas, reuniones y tareas. 


## Pruebas
1. Ir a **Estudio / Notes / Diseños / Vista Emergente** e intentar acceder a la vista de búsqueda o de lista
2. Crear un campo relacionado con el módulo de Notas en cualquier otro módulo y añadirlo a la vista de edición
3. Crear un registro de este último módulo y pulsar en el campo de Nota para que se abra la ventana emergente
4. Comprobar que funciona la vista de lista y de búsqueda