### PR TITLE
Hotfix - General - Evitar la regeneración innecesaria de ficheros de idioma

### DIFF
--- a/include/SugarObjects/LanguageManager.php
+++ b/include/SugarObjects/LanguageManager.php
@@ -129,7 +129,6 @@ class LanguageManager
 
         // put the item in the sugar cache.
         $key = self::getLanguageCacheKey($module, $lang);
-        $GLOBALS['log']->fatal('###EPS###' . __METHOD__ . __LINE__ , $module, $key);
         sugar_cache_put($key, $loaded_mod_strings);
     }
 

--- a/include/SugarObjects/LanguageManager.php
+++ b/include/SugarObjects/LanguageManager.php
@@ -129,6 +129,7 @@ class LanguageManager
 
         // put the item in the sugar cache.
         $key = self::getLanguageCacheKey($module, $lang);
+        $GLOBALS['log']->fatal('###EPS###' . __METHOD__ . __LINE__ , $module, $key);
         sugar_cache_put($key, $loaded_mod_strings);
     }
 
@@ -243,9 +244,13 @@ class LanguageManager
 
         //great! now that we have loaded all of our vardefs.
         //let's go save them to the cache file.
-        if (!empty($loaded_mod_strings)) {
-            LanguageManager::saveCache($module, $lang, $loaded_mod_strings);
-        }
+        // STIC Custom 20240926 EPS - Unnecessary Language regeneration
+        // We save the cache contents although it is empty, otherwise language will be regenerated on every login if the module is active
+        // if (!empty($loaded_mod_strings)) {
+        //     LanguageManager::saveCache($module, $lang, $loaded_mod_strings);
+        // }
+        LanguageManager::saveCache($module, $lang, $loaded_mod_strings);
+        // END STIC Custom
     }
 
     public static function loadModuleLanguage($module, $lang, $refresh=false)

--- a/modules/ResourceCalendar/language/ca_ES.lang.php
+++ b/modules/ResourceCalendar/language/ca_ES.lang.php
@@ -43,5 +43,4 @@ if (!defined('sugarEntry') || !sugarEntry) {
 }
 
 $mod_strings = array(
-    'LBL_ID' => 'ID',
 );

--- a/modules/ResourceCalendar/language/en_us.lang.php
+++ b/modules/ResourceCalendar/language/en_us.lang.php
@@ -43,5 +43,4 @@ if (!defined('sugarEntry') || !sugarEntry) {
 }
 
 $mod_strings = array(
-    'LBL_ID' => 'ID',
 );

--- a/modules/ResourceCalendar/language/es_ES.lang.php
+++ b/modules/ResourceCalendar/language/es_ES.lang.php
@@ -43,5 +43,4 @@ if (!defined('sugarEntry') || !sugarEntry) {
 }
 
 $mod_strings = array(
-    'LBL_ID' => 'ID',
 );

--- a/modules/ResourceCalendar/language/gl_ES.lang.php
+++ b/modules/ResourceCalendar/language/gl_ES.lang.php
@@ -43,5 +43,4 @@ if (!defined('sugarEntry') || !sugarEntry) {
 }
 
 $mod_strings = array(
-    'LBL_ID' => 'ID',
 );

--- a/modules/stic_MessagesMan/Menu.php
+++ b/modules/stic_MessagesMan/Menu.php
@@ -1,0 +1,9 @@
+<?php
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+
+
+
+$module_menu=array();

--- a/modules/stic_MessagesMan/vardefs.php
+++ b/modules/stic_MessagesMan/vardefs.php
@@ -1,0 +1,170 @@
+<?php
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+$dictionary['stic_MessagesMan'] =
+array( 'table' => 'stic_messagesman', 'comment' => 'Messages campaign queue', 'fields' => array(
+    'date_entered' => array(
+        'name' => 'date_entered',
+        'vname' => 'LBL_DATE_ENTERED',
+        'type' => 'datetime',
+        'comment' => 'Date record created',
+        'enable_range_search' => true,
+        'options' => 'date_range_search_dom',
+    ),
+    'date_modified' => array(
+        'name' => 'date_modified',
+        'vname' => 'LBL_DATE_MODIFIED',
+        'type' => 'datetime',
+        'comment' => 'Date record last modified',
+        'enable_range_search' => true,
+        'options' => 'date_range_search_dom',
+    ),
+    'user_id' => array(
+        'name' => 'user_id',
+        'vname' => 'LBL_USER_ID',
+        'type' => 'id','len' => '36',
+        'reportable' =>false,
+        'comment' => 'User ID representing assigned-to user',
+    ),
+    'id' =>
+    array(
+        'name' => 'id',
+        'vname' => 'LBL_ID',
+        'type' => 'int',
+        'len' => '11',
+        'auto_increment'=>true,
+        'comment' => 'Unique identifier',
+    ),
+    'campaign_id' => array(
+        'name' => 'campaign_id',
+        'vname' => 'LBL_CAMPAIGN_ID',
+        'type' => 'id',
+        'reportable' =>false,
+        'comment' => 'ID of related campaign',
+    ),
+    'marketing_id' => array(
+        'name' => 'marketing_id',
+        'vname' => 'LBL_MARKETING_ID',
+        'type' => 'id',
+        'reportable' =>false,
+        'comment' => '',
+    ),
+    'list_id' => array(
+        'name' => 'list_id',
+        'vname' => 'LBL_LIST_ID',
+        'type' => 'id',
+        'reportable' =>false,
+        'len' => '36',
+        'comment' => 'Associated list',
+    ),
+    'send_date_time' => array(
+        'name' => 'send_date_time' ,
+        'vname' => 'LBL_SEND_DATE_TIME',
+        'type' => 'datetime',
+        // STIC-Custom 20220928 MHP - Add search properties
+        // STIC#873        
+        'enable_range_search' => true,
+        'options' => 'date_range_search_dom',
+        // END STIC-Custom
+    ),
+    'modified_user_id' => array(
+        'name' => 'modified_user_id',
+        'vname' => 'LBL_MODIFIED_USER_ID',
+        'type' => 'id',
+        'reportable' =>false,
+        'len' => '36',
+        'comment' => 'User ID who last modified record',
+    ),
+    'in_queue' => array(
+        'name' => 'in_queue',
+        'vname' => 'LBL_IN_QUEUE',
+        'type' => 'bool',
+        'default' => '0',
+        'comment' => 'Flag indicating if item still in queue',
+    ),
+    'in_queue_date' => array(
+        'name' => 'in_queue_date',
+        'vname' => 'LBL_IN_QUEUE_DATE',
+        'type' => 'datetime',
+        'comment' => 'Datetime in which item entered queue',
+    ),
+    'send_attempts' => array(
+        'name' => 'send_attempts',
+        'vname' => 'LBL_SEND_ATTEMPTS',
+        'type' => 'int',
+        'default' => '0',
+        'comment' => 'Number of attempts made to send this item',
+    ),
+    'deleted' => array(
+        'name' => 'deleted',
+        'vname' => 'LBL_DELETED',
+        'type' => 'bool',
+        'reportable' =>false,
+        'comment' => 'Record deletion indicator',
+                'default' => '0',
+    ),
+    'related_id' => array(
+        'name' => 'related_id',
+        'vname' => 'LBL_RELATED_ID',
+        'type' => 'id',
+        'reportable' =>false,
+        'comment' => 'ID of Sugar object to which this item is related',
+    ),
+    'related_type' => array(
+        'name' => 'related_type' ,
+        'vname' => 'LBL_RELATED_TYPE',
+        'type' => 'varchar',
+        'len' => '100',
+        'comment' => 'Descriptor of the Sugar object indicated by related_id',
+    ),
+    
+                'related_confirm_opt_in' => array(
+                    'name' => 'related_confirm_opt_in',
+                    'vname' => 'LBL_RELATED_CONFIRM_OPT_IN',
+                    'type' => 'bool',
+                    'default' => 0,
+                    'reportable' => false,
+                    'comment' => '',
+                ),
+    
+                'recipient_name' => array(
+        'name' => 'recipient_name',
+        'type' => 'varchar',
+        'len' => '255',
+        'source'=>'non-db',
+    ),
+    // 'recipient_email' => array(
+    //     'name' => 'recipient_email',
+    //     'type' => 'varchar',
+    //     'len' => '255',
+    //     'source'=>'non-db',
+    // ),
+    'recipient_phone' => array(
+        'name' => 'recipient_phone',
+        'type' => 'varchar',
+        'len' => '55',
+        'source'=>'non-db',
+    ),
+    'message_name' => array(
+        'name' => 'message_name',
+        'type' => 'varchar',
+        'len' => '255',
+        'source'=>'non-db',
+    ),
+    'campaign_name' => array(
+        'name' => 'campaign_name',
+        'vname' => 'LBL_LIST_CAMPAIGN',
+        'type' => 'varchar',
+        'len' => '50',
+        'source'=>'non-db',
+    ),
+
+), 'indices' => array(
+                    array('name' => 'stic_messagesmanpk', 'type' => 'primary', 'fields' => array('id')),
+                    array('name' => 'idx_mman_list', 'type' => 'index', 'fields' => array('list_id','user_id','deleted')),
+                    array('name' => 'idx_mman_campaign_id', 'type' => 'index', 'fields' => array('campaign_id')),
+                    array('name' => 'idx_mman_relid_reltype_id', 'type' => 'index', 'fields'=> array('related_id', 'related_type', 'campaign_id')),
+                    )
+);

--- a/modules/stic_Web_Forms/Catcher/WebFormDataBO.php
+++ b/modules/stic_Web_Forms/Catcher/WebFormDataBO.php
@@ -98,7 +98,7 @@ class WebFormDataBO
         }
 
         $this->app_strings = return_application_language($this->lang); // Load application tags
-        $this->mod_strings[$this->defaultModule] = return_module_language($this->lang, $this->defaultModule, true); // Load the module labels by default
+        $this->mod_strings[$this->defaultModule] = return_module_language($this->lang, $this->defaultModule, false); // Load the module labels by default
     }
 
     /**

--- a/modules/stic_Web_Forms/Catcher/WebFormDataController.php
+++ b/modules/stic_Web_Forms/Catcher/WebFormDataController.php
@@ -106,7 +106,7 @@ class WebFormDataController
         }
 
         $this->app_strings = return_application_language($this->lang); // Load application labels
-        $this->mod_strings[$this->defaultModule] = return_module_language($this->lang, $this->defaultModule, true); // Load the module labels by default
+        $this->mod_strings[$this->defaultModule] = return_module_language($this->lang, $this->defaultModule, false); // Load the module labels by default
     }
 
     /**


### PR DESCRIPTION
## Descripción
En el análisis que llevó a la apertura de los issues #392 y #393, se observó también que los ficheors de idioma eran regenerados con excesiva frecuencia sin que hubiera un motivo aparente.

Después de investigar el tema y múltiples pruebas, se han observado 2 causas posibles:
1.- Si hay algún módulo activo que no contiene literales (por ejemplo ResourceCalendar está activo en algunas instancias), no genera información en caché. Al hacer login e intentar recuperar los literales de todos los módulos no se encuentra la información de estos módulos y se fuerza la regeneración de los ficheros de idiomas (que tampoco generará información en caché) con lo que el siguiente login provocará una nueva regeneración.
2.- Los formularios, en la clase WebFormDataController, dentro de la función loadLanguage está ejecutando la sentencia `$this->mod_strings[$this->defaultModule] = return_module_language($this->lang, $this->defaultModule, true); // Load the module labels by default`, la cual provoca que se regeren siempre los ficheros de idioma.

## Solución aplicada
1.- Para el caso (1) se ha aplicado un cambio para que siempre se genere información en caché aunque sea vacía
2.- Para el caso (2) se han modificado las llamadas a _return_module_language_ para que no fuerzen el refresco de los ficheros de idiomas.

## Pruebas
### No regenera con módulo vacío
1.- Habilitar algún módulo sin literales (por ejemplo ResourceCalendar)
2.- Realizar un nuevo login
3.- Comprobar la fecha de modificación de los ficheros de idioma
`ls -la /web/custom/application/Ext/Language/`
4.- Cerrar sesión y volver a iniciar sesión pasado un minuto
5.- Comprovar que no se han regenerado los ficheros de idioma
### No regenera con formulario
1.- Crear un formulario (con documento) que ataque la instancia de prueba
2.- Comprobar la fecha de modificación de los ficheros de idioma
`ls -la /web/custom/application/Ext/Language/`
3.- Rellenar y lanzar el formulario
4.- Comprovar que no se han regenerado los ficheros de idioma
5.- Comprobar la descripción del documento adjunto en la persona para ver que se incluyen correctamente (WebFormDataBO)
6.- Modificar el formulario para provocar un error de parámetros (por ejemplo indicar un assigned_user_id incorrecto)
7.- Rellenar de nuevo el formulario
8.- Comprobar que los literales del e-mail recibido son correctos (WebFormDataController)


## Información adicional
Realizando búsuqeda con el patrón `return_module_language\([^)]*,\s*[^)]*,\s*true\)` se detecta quehay más usos dentro de SuiteCRM de la llamada a return_module_language con el refresh a true. No se abordan en este PR por el posible impacto que pueden tener.