### PR TITLE
Hotfix - Reuniones - "Run Email Reminder Notifications" no se ejecuta al eliminar una persona

### DIFF
--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -241,8 +241,8 @@ class Reminder extends Basic
 
                 // STIC-Custom 20240926 ART - “Run Email Reminder Notifications” does not run when deleting a person
                 // https://github.com/SinergiaTIC/SinergiaCRM/pull/406
+                // Avoid sending the reminder to any guest if the guest does not already exist in the CRM, as it causes an error that prevents the “Run Email Reminder Notifications” task from finishing correctly
 
-                // The task generated a blocking error that prevented the task from moving forward
                 // Prevent a deleted contact, user, etc. from being deleted in order for the task to run
                 if($personBean != false) {
                 // END STIC-Custom

--- a/modules/Reminders/Reminder.php
+++ b/modules/Reminders/Reminder.php
@@ -216,9 +216,9 @@ class Reminder extends Basic
             foreach ($reminders as $reminderId => $reminder) {
                 $recipients = self::getEmailReminderInviteesRecipients($reminderId, $checkDecline);
                 $eventBean = BeanFactory::getBean($reminder->related_event_module, $reminder->related_event_module_id);
-                
+
                 // STIC-Custom 20240926 ART - “Run Email Reminder Notifications” does not run when deleting a person
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/406
 
                 // Current date added to compare with meeting start date to avoid sending past reminders
                 $dateNow = date('d/m/Y H:i');
@@ -249,7 +249,7 @@ class Reminder extends Basic
                 // The original email reminders check the accept_status field in related users/leads/contacts etc. and filtered these users who not decline this event.
 
                 // STIC-Custom 20240926 ART - “Run Email Reminder Notifications” does not run when deleting a person
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/406
 
                 // Prevent a deleted contact, user, etc. from being deleted in order for the task to run
                 if($personBean != false) {


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/395

### Desarrollo del issue
Se ha comprobado que al crear una reunión con recordatorios, tanto emergente como por correo, y se elimina una persona/usuario antes de que se ejecute la tarea programada "Run Email Reminder Notifications", falla la ejecución, haciendo que se quede estancada la tarea y desde ese momento, no se enviará ningún recordatorio. 
Además, si lleva mucho tiempo estancada la tarea, las reuniones con fechas pasadas, se envían.

### Solución implementada
1. Se ha añadido una condición de que si lleva mucho tiempo la tarea estancada y ya ha pasado el recordatorio (fecha de inicio de la reunión, ejemplo: 16/06/2022 9:00), no se mande ningún recordatorio a los asistentes de la reunión pasada.
2. Se ha añadido una condición de que si la persona queda eliminada, no se intente mandar un correo y continúe la ejecución dicha tarea.

### Pruebas
**Persona eliminada**
1. Configurar correctamente la cuenta de correo.
2. Crear una reunión, añadiendo un recordatorio de correo a los asistentes.
3. Guardar y enviar invitaciones.
4. Eliminar la persona/usuario antes de ejecutar la tarea programada "Run Email Reminder Notifications".
8. Ver en la reunión que aparece la persona como "UNKNOWN".
5. Ejecutar la tarea "Run Email Reminder Notifications".
6. Comprobar que llega el correo electrónico del recordatorio a los invitados, menos a la persona eliminada, y al creador de la reunión.
7. Además, comprobar que la tarea ha sido ejecutada correctamente.

**Reunión pasada**
1. Configurar correctamente la cuenta de correo.
2. Crear una reunión pasada, añadiendo un recordatorio de correo a los asistentes.
3. Guardar y enviar invitaciones.
5. Ejecutar la tarea "Run Email Reminder Notifications".
6. Comprobar que no llega el correo electrónico del recordatorio, a ninguno de los invitados ni el creador de la reunión.
7. Además, comprobar que la tarea ha sido ejecutada correctamente.