### PR TITLE
Hotfix - Incorpora - Sincronización desde selección masiva

### DIFF
--- a/modules/stic_Incorpora/controller.php
+++ b/modules/stic_Incorpora/controller.php
@@ -87,7 +87,7 @@ class stic_IncorporaController extends SugarController
         $where = '';
         if (isset($_REQUEST['select_entire_list']) && $_REQUEST['select_entire_list'] == '1' && isset($_REQUEST['current_query_by_page'])) {
             require_once 'include/export_utils.php';
-            $retArray = generateSearchWhere($moduleTable, $_REQUEST['current_query_by_page']);
+            $retArray = generateSearchWhere($bean->module_name, $_REQUEST['current_query_by_page']);
             $where = '';
             if (!empty($retArray['where'])) {
                 $where = " AND " . $retArray['where'];

--- a/modules/stic_Incorpora/controller.php
+++ b/modules/stic_Incorpora/controller.php
@@ -76,8 +76,8 @@ class stic_IncorporaController extends SugarController
                 break;
 
             default:
-                $tableQuery = 'FROM ' . $moduleTable . ' JOIN ' . $moduleTable . '_cstm c ON id=c.id_c';
-                $incIdFieldSql = 'c.inc_id_c';
+                $tableQuery = 'FROM ' . $moduleTable . ' JOIN ' . $moduleTable . '_cstm ON id=' . $moduleTable . '_cstm.id_c';
+                $incIdFieldSql = $moduleTable . '_cstm.inc_id_c';
                 $incIdField = 'inc_id_c';
                 break;
         }


### PR DESCRIPTION
## Descripción
Al implementar la funcionalidad de envío masivo de mensajes se detectó que la sincronización masiva de Incorpora (de la cual se partió para desarrollar la funcionalidad de mensajes) no funcionaba correctamente.
En concreto se detectó que se utilizaba el nombre de la tabla en lugar de el nombre del módulo al llamar a la función _generateSearchWhere_.

## Pruebas
1. En el listado de personas realizar un filtro del listado y seleccionar todos los registros (no sólo la página)
2. Acceder a acciones masivas y seleccionar Sincronizar con Incorpora
3. Comprobar que el número de Personas coincide con el número de personas seleccionadas previamente