### PR TITLE
Improvement - Flujos de trabajo - Uso de índices y búsqueda corregida

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -701,7 +701,7 @@ class AOW_WorkFlow extends Basic
 
         if (!$this->multiple_runs) {
             $processed = BeanFactory::getBean('AOW_Processed');
-            $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id, 'parent_id' => $bean->id));
+            $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id, 'parent_id' => $bean->id, 'status' => 'Complete'));
 
             if ($processed->status === 'Complete') {
                 //has already run so return false
@@ -1026,7 +1026,7 @@ class AOW_WorkFlow extends Basic
         require_once('modules/AOW_Processed/AOW_Processed.php');
         $processed = BeanFactory::newBean('AOW_Processed');
         if (!$this->multiple_runs) {
-            $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id,'parent_id' => $bean->id));
+            $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id,'parent_id' => $bean->id, 'status' => 'Complete'));
 
             if ($processed->status == 'Complete') {
                 //should not have gotten this far, so return

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -701,7 +701,11 @@ class AOW_WorkFlow extends Basic
 
         if (!$this->multiple_runs) {
             $processed = BeanFactory::getBean('AOW_Processed');
+            // STIC-Custom 20240930 EPS - Uso del índice y prevención de errores si hay alguna ejecución no completada
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/411
+            // $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id, 'parent_id' => $bean->id));
             $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id, 'parent_id' => $bean->id, 'status' => 'Complete'));
+            // END STIC-Custom
 
             if ($processed->status === 'Complete') {
                 //has already run so return false
@@ -1026,7 +1030,11 @@ class AOW_WorkFlow extends Basic
         require_once('modules/AOW_Processed/AOW_Processed.php');
         $processed = BeanFactory::newBean('AOW_Processed');
         if (!$this->multiple_runs) {
+            // STIC-Custom 20240930 EPS - Uso del índice y prevención de errores si hay alguna ejecución no completada
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/411
+            // $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id,'parent_id' => $bean->id));
             $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id,'parent_id' => $bean->id, 'status' => 'Complete'));
+            // END STIC-Custom
 
             if ($processed->status == 'Complete') {
                 //should not have gotten this far, so return


### PR DESCRIPTION
- Related to #392 
## Descripción
Tal como se explica en el issue #392, se detecta que cuando se ejecuta un flujo de trabajo sobre un bean se está realizando una búsqueda que no puede utilizar correctamente ningún índice.
En concreto hay el índice aow_processed_index_workflow que utiliza los campos aow_workflow_id, status y parent_id, pero en la consulta realizada no se suministra el status, por lo que la consulta no es óptima y puede llegar a ralentizarse.
Además, revisando con calma el código se observa que la consulta ejecutada puede producir resultados erróneos. Si sobre un bean se ejecuta un flujo, éste no se completa y posteriormente se completa, puede psar que vuelva a ejecutarse sobre el mismo en el futuro a pesar de no tener activas las repeticiones múltiples.

## Solución aplicada
Se modifica la consulta realizada para que busque directament con el estado "Complete", de manera que puede utilizar plenamente el índice y resuelve el proble de repetitibilidad.

## Pruebas
1.- Definir un flujo no repetitivo sobre un módulo (Personas) al guardar
2.- Realizar una modificación para que se ejecute el flujo
3.- Comrpobar que se lanza correctamente
4.- Volver a modificar el registro
5.- Comprobar que no se ha lanzado
6.- Habilitar las repeticiones en el flujo
7.- Volver a modificar y comprobar que ahora sí se vuelve a lanzar
