### PR TITLE
Improvement - Personas y Organizaciones - Incluir índice por número de identificación

### DIFF
--- a/SticInstall/sql/common/Indices.sql
+++ b/SticInstall/sql/common/Indices.sql
@@ -1,0 +1,4 @@
+-- Índices identificados para agilizar algunas consultas clave que se ejecutan sobre campos custom y que, por tanto, no pueden definirse vía vardefs.
+
+create index stic_idx_identification_number on contacts_cstm(stic_identification_number_c);
+create index stic_idx_identification_number on accounts_cstm(stic_identification_number_c);

--- a/SticUpdates/Migrations/20240930_Indices_identification_number.sql
+++ b/SticUpdates/Migrations/20240930_Indices_identification_number.sql
@@ -1,0 +1,4 @@
+-- Índices identificados para agilizar algunas consultas clave que se ejecutan sobre campos custom y que, por tanto, no pueden definirse vía vardefs.
+
+create or replace index stic_idx_identification_number on contacts_cstm(stic_identification_number_c);
+create or replace index stic_idx_identification_number on accounts_cstm(stic_identification_number_c);


### PR DESCRIPTION
- Related to #392 

## Descripción
Tal como se explica en #392 se detecta que los formularios hacen uso intensivo de la búsqueda por número de identificación para evitar duplicar personas/organizaciones en el CRM. Esa búsuqeda no tiene índice que la facilite por lo que en BBDD grandes y cuando hay aluvión de peticiones puede colapsar el sistema.

## Solución
Incluir los índices por número de identificación en Personas y Organizaciones. No se incluye en Interesados puesto que los formularios de interesados no realizan ese chequeo.
Los índices se incluyen vía SQL al no permitir SuiteCRM definir índices sobre campos custom mediante vardefs.

## Pruebas
1.- Ejecutar el fichero SQL de creación de índices
2.- Conectarse a la BBDD y comrpobar que los índices sobre el campo stic_identification_number_c se han creados en contacts_cstm y accounts_cstm