### PR TITLE
Hotfix - Pagos agregados - Errores en cálculo de pagos agregados con pagos no remesados del año anterior  

### DIFF
--- a/modules/stic_Payments/AggregatePayments.php
+++ b/modules/stic_Payments/AggregatePayments.php
@@ -59,6 +59,7 @@ WHERE
     sp.deleted = 0
     AND u.deleted = 0
     AND MONTH(sp.payment_date) = MONTH(NOW())
+    AND YEAR(sp.payment_date) = YEAR(NOW())
     AND sp.payment_type = 'aggregated_services'
     AND sp.status != 'paid'
     ORDER BY sp.name ASC";
@@ -134,6 +135,7 @@ WHERE
     AND sp.deleted = 0
     AND sa.deleted = 0
     AND MONTH(sp.payment_date) = MONTH(NOW())
+    AND YEAR(sp.payment_date) = YEAR(NOW())
     AND sa.start_date < DATE_FORMAT(curdate(),'%Y-%m-01')
     AND CASE
             WHEN spc.periodicity = 'monthly' THEN sa.start_date >= subdate(DATE_FORMAT(curdate(),'%Y-%m-01'), INTERVAL 1 MONTH)
@@ -226,6 +228,7 @@ WHERE
     AND sp.deleted = 0
     AND sa.deleted = 0
     AND MONTH(sp.payment_date) = MONTH(NOW())
+    AND YEAR(sp.payment_date) = YEAR(NOW())
     AND sa.start_date < subdate(curdate(), (day(curdate())-1))
     AND CASE
             WHEN spc.periodicity = 'monthly' THEN sa.start_date >= subdate(subdate(curdate(), (day(curdate())-1)), INTERVAL 1 MONTH)

--- a/modules/stic_Payments/AggregatePayments.php
+++ b/modules/stic_Payments/AggregatePayments.php
@@ -166,8 +166,7 @@ WHERE
             spx.id = spsac.stic_payments_stic_attendancesstic_payments_ida
         WHERE
             spsac.deleted = 0)
-    GROUP BY spspcc.stic_paymebfe2itments_ida
-    ORDER BY sa.name ASC";
+        ORDER BY sa.name ASC";
 
 $res = $db->query($warningAttendanceQuery);
 


### PR DESCRIPTION
- Closes #415 

## Descripción
Tal y como se describe en #415: Se ha observado que el cálculo de los pagos agregados no funciona correctamente en el caso que existan pagos "pendientes de remesar" del mismo mes pero de años anteriores. Tampoco funciona correctamente si existe más de un pago de "servicios agregados" asociado a un mismo compromiso de pago:
- El importe de los pagos se actualizaba en todos los pagos del mes en curso y en los de años anteriores
- Las asistencias se asignaban a un único pago, pudiendo ser de otro año

## Solución propuesta
Se han modificado las consultas para obtener los pagos para que:
1. Tenga en cuenta el año actual
2. Únicamente obtenga un pago por cada compromiso de pago

Para ello, en la primera consulta se obtienen los ids de los pagos a procesar y en las siguientes consultas se usan esos mismos ids en el filtro.

## Pruebas
Crear el entorno para que el cálculo de pagos agregados encuentre más de un pago de servicios agregados pendientes del mes actual correspondientes al mismo compromiso de pago, y pagos del mismo mes pero de otro año:
 
1. Crear un evento con fecha inicio el mes anterior y estado "Activo".
2. Crear una incripción al evento
4. Crear un algunas sesiones al evento con fecha del mes anterior
5. Crear asistencias a las sesiones, con importe
6. Duplicar el evento del paso 1 y modificar el año de inicio por el año pasado
7. Crear alguna sesión y una asistencia de la misma  persona
8. Crear una inscripción con la misma persona para el año pasado
9. Crear un compromiso de pago de la persona inscrita al evento con Tipo de pago: Servicios agregados, Periodicidad: Mensual, Fecha del primer pago: el año pasado
10. Relacionar el compromiso de pago con las inscripciones del paso 2 y del paso 7
11. Asociar el pago a la inscripción del paso 2
12. Duplicar el pago del Compromiso de pago sin modificar nada
13. Duplicar de nuevo el pago, editando: 
     1. Borrar el nombre
     2. Fecha de pago: modificar el año por el anterior
     3. Modificar la inscripción por la del paso 7
14. En el módulo Pagos, accionar "Calcular pagos agregados" 
15. Verificar que se han calculado correctamente los pagos:
     1. Se ha actualizado el importe de un único pago del mes en curso y del año actual 
     2. Los otros pagos no han sido modificados
     3. El pago del mes actual tiene asistencias correspondientes
     4. El pago del año anterior no tiene las asistencias del año actual
