### PR TITLE
Hotfix - Vistas Personalizadas - Verificación correcta de condiciones numéricas

### DIFF
--- a/modules/stic_Custom_Views/processor/LogicHooksCode.php
+++ b/modules/stic_Custom_Views/processor/LogicHooksCode.php
@@ -155,6 +155,9 @@ class stic_Custom_Views_ProcessorLogicHooks
                 foreach ($conditionBeanArray as $conditionBean) {
                     $value_typeArray = explode("|", $conditionBean->value_type);
                     $value_type = $value_typeArray[0];
+                    if ($value_type != "enum" && $value_type != "multienum" && $value_type != "dynamicenum") {
+                        $value_typeArray[1] = "";
+                    }
                     $value_list = $value_typeArray[1];
                     $condition_type = $conditionBean->condition_type;
                     if($condition_type=="value") {

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -301,8 +301,12 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
         conditionValue = conditionValue.replaceAll("^", "").split(",").sort().join(",");
       }
     }
-    if(this.type == "date") {
+    if (this.type == "date") {
       conditionValue = conditionValue.split(" ")[0];
+    }
+    if (this.type == "int" || this.type == "decimal" || this.type == "double") {
+      conditionValue = parseFloat(conditionValue);
+      currentValue = parseFloat(currentValue);
     }
     if (!this._isMultienumCancelledInline()) {
       conditionValue = sticCVUtils.normalizeToCompare(conditionValue);


### PR DESCRIPTION
- Closes #422 

## Descripción
Tal y como se comenta en #422, las condiciones no se validan correctamente en ciertos campos. Concretamente, se observa que no se validaban cuando:
1. El campo tenía asociada una lista mediante la declaración `options` en el vardefs y su valor no dependía de ella (numérico por ejemplo)
2. El campo a comparar es numérico

Este comportamiento erróneo se ha observado con el campo "Edad" del módulo "Personas", que en su definición:
- `'options' => 'numeric_range_search_dom',` 
- `'type' => 'int'`

Los cambios en el código incluyen:
1. No usar la lista de posibles valores si el campo no es de tipo `enum`, `multienum` o `dynamicenum`
2. Convertir los valores a comparar a numérico (si corresponde) cuando se verifique una condición de una VP

## Pruebas
1. Crear una Vista Personalizada para el Módulo Personas - Vista de detalle
2. Añadir la condición: Edad - Menor que - Valor - 18
3. Añadir la acción: Campo - Edad - Color de fondo - Rojo
4. Crear dos Personas y asignar fecha de nacimiento anterior a 18 años y posterior a 18 años
5. Verificar que el comportamiento de la VP es correcto