### PR TITLE
Enhancement - Calendario laboral - Añadir nuevo tipo: Anulado

### DIFF
--- a/custom/Extension/application/Ext/Language/ca_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/ca_ES.SticLang.php
@@ -3244,6 +3244,7 @@ $app_list_strings['stic_work_calendar_types_list']['personal'] = 'Assumptes prop
 $app_list_strings['stic_work_calendar_types_list']['sick'] = 'Baixa';
 $app_list_strings['stic_work_calendar_types_list']['leave'] = 'Permís/Excedència';
 $app_list_strings['stic_work_calendar_types_list']['other'] = 'Altres';
+$app_list_strings['stic_work_calendar_types_list']['canceled'] = 'Anul·lat';
 
 // Diari: Tipus
 $app_list_strings['stic_journal_types_list'][''] = '';

--- a/custom/Extension/application/Ext/Language/en_us.SticLang.php
+++ b/custom/Extension/application/Ext/Language/en_us.SticLang.php
@@ -3243,6 +3243,7 @@ $app_list_strings['stic_work_calendar_types_list']['personal'] = 'Personal day';
 $app_list_strings['stic_work_calendar_types_list']['sick'] = 'Sick';
 $app_list_strings['stic_work_calendar_types_list']['leave'] = 'Leave';
 $app_list_strings['stic_work_calendar_types_list']['other'] = 'Other';
+$app_list_strings['stic_work_calendar_types_list']['canceled'] = 'Canceled';
 
 // Journal: Type
 $app_list_strings['stic_journal_types_list'][''] = '';

--- a/custom/Extension/application/Ext/Language/es_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/es_ES.SticLang.php
@@ -3244,6 +3244,7 @@ $app_list_strings['stic_work_calendar_types_list']['personal'] = 'Asuntos propio
 $app_list_strings['stic_work_calendar_types_list']['sick'] = 'Baja';
 $app_list_strings['stic_work_calendar_types_list']['leave'] = 'Permiso/Excedencia';
 $app_list_strings['stic_work_calendar_types_list']['other'] = 'Otros';
+$app_list_strings['stic_work_calendar_types_list']['canceled'] = 'Anulado';
 
 // Diario: Tipo de diario
 $app_list_strings['stic_journal_types_list'][''] = '';

--- a/custom/Extension/application/Ext/Language/gl_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/gl_ES.SticLang.php
@@ -3245,6 +3245,7 @@ $app_list_strings['stic_work_calendar_types_list']['personal'] = 'Persoal';
 $app_list_strings['stic_work_calendar_types_list']['sick'] = 'Baixa';
 $app_list_strings['stic_work_calendar_types_list']['leave'] = 'Permiso/Excedencia';
 $app_list_strings['stic_work_calendar_types_list']['other'] = 'Outros';
+$app_list_strings['stic_work_calendar_types_list']['canceled'] = 'Anulado';
 
 // Diario: Tipo de diario
 $app_list_strings['stic_journal_types_list'][''] = '';

--- a/custom/modules/Calendar/Calendar.php
+++ b/custom/modules/Calendar/Calendar.php
@@ -238,11 +238,15 @@ class CustomCalendar extends Calendar
                     $item['color'] = $act->sugar_bean->color ? '#'.$act->sugar_bean->color : '';
                 }
                 if ($item['module_name'] == 'stic_Work_Calendar') {
-                    $item['event_type'] = $act->sugar_bean->type;
-                    $totalMinutes = $act->sugar_bean->duration * 60;
-                    $item['duration_hours'] = floor($totalMinutes / 60);
-                    $item['duration_minutes'] = round($totalMinutes - $item['duration_hours'] * 60);
-                    $item['rendering'] = 'background';
+                    if ($act->sugar_bean->type == 'canceled' ) {
+                        break;
+                    } else {
+                        $item['event_type'] = $act->sugar_bean->type;
+                        $totalMinutes = $act->sugar_bean->duration * 60;
+                        $item['duration_hours'] = floor($totalMinutes / 60);
+                        $item['duration_minutes'] = round($totalMinutes - $item['duration_hours'] * 60);
+                        $item['rendering'] = 'background';
+                    }
                 }
                 // END STIC-Custom
 

--- a/modules/iCals/iCal.php
+++ b/modules/iCals/iCal.php
@@ -289,6 +289,12 @@ class iCal extends vCal
         foreach ($acts_arr as $act) {
             $event = $act->sugar_bean;
             if (!$hide_calls || ($hide_calls && $event->object_name != "Call")) {
+                // STIC-Custom 20241004 MHP - Exclude canceled work calendar records from synchronization
+                //  
+                if ($event->module_dir == "stic_Work_Calendar" && $event->type == 'canceled'){
+                    break;
+                }
+                // END STIC-Custom
                 $ical_array[] = array("BEGIN", "VEVENT");
                 // STIC-Custom 20220315 AAM - Encoding the activity name to UTF8 in order to display special characters
                 // $ical_array[] = array("SUMMARY", $event->name);

--- a/modules/stic_Validation_Actions/DataAnalyzer/Functions/TimeTracker_HoursWorkedInPreviousWeek/CheckHoursWorkedInPreviousWeek.php
+++ b/modules/stic_Validation_Actions/DataAnalyzer/Functions/TimeTracker_HoursWorkedInPreviousWeek/CheckHoursWorkedInPreviousWeek.php
@@ -61,6 +61,7 @@ class CheckHoursWorkedInPreviousWeek extends DataCheckFunction
             JOIN users_cstm as swcu ON swc.assigned_user_id = swcu.id_c            
             WHERE DATE(CONVERT_TZ(swc.start_date, '+00:00', '" . $tzone ."')) BETWEEN DATE(DATE_SUB(CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '" . $tzone ."'), INTERVAL 7 DAY)) AND DATE(DATE_SUB(CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '" . $tzone ."'), INTERVAL 1 DAY))
                 AND swc.type = 'working'
+                AND swc.type != 'canceled'         
                 AND swc.deleted = 0
             GROUP BY swc.assigned_user_id) AS wc 
         ON tt.assigned_user_id = wc.assigned_user_id
@@ -80,11 +81,13 @@ class CheckHoursWorkedInPreviousWeek extends DataCheckFunction
             FROM stic_work_calendar swc
             JOIN users_cstm as swcu ON swc.assigned_user_id = swcu.id_c            
             WHERE DATE(CONVERT_TZ(swc.start_date, '+00:00', '" . $tzone ."')) BETWEEN DATE(DATE_SUB(CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '" . $tzone ."'), INTERVAL 7 DAY)) AND DATE(DATE_SUB(CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '" . $tzone ."'), INTERVAL 1 DAY))
-                AND swc.type = 'working'  
+                AND swc.type = 'working'
+                AND swc.type != 'canceled'
                 AND swc.deleted = 0
             GROUP BY swc.assigned_user_id) AS wc 
         ON tt.assigned_user_id = wc.assigned_user_id;";
 
+        $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ': SQL: ' . $sql);
         return $sql;
     }
 

--- a/modules/stic_Validation_Actions/DataAnalyzer/Functions/WorkCalendar_MainData/CheckWorkCalendarBeanData.php
+++ b/modules/stic_Validation_Actions/DataAnalyzer/Functions/WorkCalendar_MainData/CheckWorkCalendarBeanData.php
@@ -44,6 +44,7 @@ class CheckWorkCalendarBeanData extends DataCheckFunction
                 FROM stic_work_calendar
                 WHERE DATE(CONVERT_TZ(start_date, '+00:00', '" . $tzone ."')) = DATE(DATE_SUB(CONVERT_TZ(UTC_TIMESTAMP(), '+00:00', '" . $tzone ."'), INTERVAL 1 DAY))
                     AND type = 'working'
+                    AND type != 'canceled'
                     AND deleted = 0
                 ORDER BY assigned_user_id;";
 

--- a/modules/stic_Work_Calendar/Utils.js
+++ b/modules/stic_Work_Calendar/Utils.js
@@ -177,17 +177,28 @@ function manageAllDayView()
 
   type.addEventListener("change", function() 
   {
-    if (!allDayTypes.includes(document.getElementById("type").value)) 
+    var typeValue = document.getElementById("type").value;
+    if (!allDayTypes.includes(typeValue)) 
     {
       if (allDayTypes.includes(previousType)) {      // Set the previous values if the previous type was not type: all day
+        
+        if (typeValue == 'canceled')
+        {
+          $("#start_date_hours").val('00');
+          $("#start_date_minutes").val('00');
+          $("#end_date_hours").val('00');
+          $("#end_date_minutes").val('00');
+        } else {
           $("#start_date_hours").val(previousStartDateHours);
           $("#start_date_minutes").val(previousStartDateMinutes);
           $("#end_date_hours").val(previousEndDateHours);
           $("#end_date_minutes").val(previousEndDateMinutes);
-          $("#start_date_hours").change();
-          $("#start_date_minutes").change();
-          $("#end_date_hours").change();
-          $("#end_date_minutes").change();
+        }
+
+        $("#start_date_hours").change();
+        $("#start_date_minutes").change();
+        $("#end_date_hours").change();
+        $("#end_date_minutes").change();
 
         // Show the start time and the end_date section
         $("#start_date_time_section").parent().show();

--- a/modules/stic_Work_Calendar/stic_Work_Calendar.php
+++ b/modules/stic_Work_Calendar/stic_Work_Calendar.php
@@ -127,7 +127,7 @@ class stic_Work_Calendar extends Basic
     }
 
     /**
-     * Checks if the given user has a work calendar record between the previous 24 hours and now, in UTC.
+     * Checks if the given user has an uncancelled calendar record between the previous 24 hours and now, in UTC
      * @param userId User Identificator
      * @return void
      */
@@ -137,6 +137,7 @@ class stic_Work_Calendar extends Basic
         $query = "SELECT count(id) as count
                     FROM stic_work_calendar
                   WHERE deleted = 0 
+                    AND type != 'canceled'
                     AND start_date BETWEEN DATE_SUB(UTC_TIMESTAMP(), INTERVAL 1 DAY)  AND UTC_TIMESTAMP()
                     AND assigned_user_id = '" . $userId . "';";
 


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/363

## Descripción
El PR añade una opción nueva a la lista desplegable relacionada con el campo Tipo de Calendario laboral. Esta opción es de rango horario. 

**En la vista de edición:**
- En caso de anular un registro de rango horario, la hora de la fecha de inicio y la de finalización no serán modificadas. 
- En caso de anular un registro de todo el día, se configurará la fecha de inicio a las 00:00 y la fecha de finalización a las 00:00 del día siguiente. 

**Calendario:**
- No se pintan en el calendario 
- No se sincronizan a través de iCal

**En las validaciones**, los registros anulados no serán tenidos en cuenta


## Pruebas

**Vista de edición**
1. Crear un registro de Calendario laboral de tipo Laborable y otro de tipo Baja
2. Anular el registro de tipo laborable y comprobar que se mantienen las fechas de inicio y de finalización
3. Anular el registro de tipo baja y comprobar que las fechas de inicio y de finalización se configuran a las 00:00 del día actual y del siguiente

**Calendario**
4. Acceder al calendario y activar la opción de configuración: Ver registros de Calendario laboral
5. Comprobar que no se ve ninguno de los dos registros anteriores

**iCal**
6. Crear varios registros de tipo laborable. 
7. Sincronizar el calendario a través de iCal y comprobar que se muestran todos los registros
8. Anular uno de ellos.
9. Volver a sincronizar el calendario a través de iCal y comprobar que el registro anulado ya no es mostrado

**Validaciones**

_a) Actualización masiva_

10. Crear varios registros de calendario laboral de tipo laborable para un mismo día
11. Anularlos a través de la actualización masiva y comprobar, una vez anulados, que se puede crear un registro de tipo Vacaciones o de cualquier otro tipo para ese día. 

b) Calendario laboral - Revisión de los registros del día anterior

12. Crear un registro de tipo laborable que no tenga su equivalente en registro horario 
13. 


c) Revisión de las horas trabajadas durante la semana anterior