### PR TITLE
Hotfix - Pagos agregados - Evitar multiplicar por 100 si el usuario no tiene separador de decimales definido

### DIFF
--- a/modules/stic_Payments/AggregatePayments.php
+++ b/modules/stic_Payments/AggregatePayments.php
@@ -272,6 +272,7 @@ $processedAttendances = 0;
 $completePaymentsId = array();
 
 // Process included payments
+global $sugar_config;
 while ($row = $db->fetchByAssoc($res)) {
     if (!$paymentId = $row['payment_id']) {
         continue;
@@ -290,7 +291,9 @@ while ($row = $db->fetchByAssoc($res)) {
     }
 
     // Set the payment amount
-    $paymentBean->amount = str_replace('.', $current_user->getPreference('dec_sep'), $row['attendances_amount']);
+    $user_dec_sep = $current_user->getPreference('dec_sep');
+    $dec_sep = (empty($user_dec_sep) ? $sugar_config['default_decimal_seperator'] : $user_dec_sep);
+    $paymentBean->amount = str_replace('.', $dec_sep, $row['attendances_amount']);
 
     // Build an array of complete payments
     if (!in_array($paymentId, $uncompletePaymentsId)) {

--- a/modules/stic_Payments/AggregatePayments.php
+++ b/modules/stic_Payments/AggregatePayments.php
@@ -272,7 +272,6 @@ $processedAttendances = 0;
 $completePaymentsId = array();
 
 // Process included payments
-global $sugar_config;
 while ($row = $db->fetchByAssoc($res)) {
     if (!$paymentId = $row['payment_id']) {
         continue;
@@ -291,9 +290,8 @@ while ($row = $db->fetchByAssoc($res)) {
     }
 
     // Set the payment amount
-    $user_dec_sep = $current_user->getPreference('dec_sep');
-    $dec_sep = (empty($user_dec_sep) ? $sugar_config['default_decimal_seperator'] : $user_dec_sep);
-    $paymentBean->amount = str_replace('.', $dec_sep, $row['attendances_amount']);
+    require_once('SticInclude/Utils.php');
+    $paymentBean->amount = SticUtils::formatDecimalInConfigSettings($row['attendances_amount'], true);
 
     // Build an array of complete payments
     if (!in_array($paymentId, $uncompletePaymentsId)) {


### PR DESCRIPTION
- Closes #427 

## Descripción del problema
Tal y como se describe en #427, si un usuario no tiene definido el separador decimal, al calcular los pagos agregados éstos se multiplican por 100.

## Solución propuesta
El método de cálculo de los pagos agregados no tenía en cuenta la posibilidad que la configuración del separador decimal del usuario (`'dec_sep'`) estuviese vacía. Se ha protegido usando en este caso la configuración global `'default_decimal_seperator'`, tal y como se usa en:
https://github.com/SinergiaTIC/SinergiaCRM/blob/41e7eb1e604762fe8f6b76dcff9c23e20ce1c667/include/utils.php#L2186-L2187

## Pruebas
1. En el Perfil del usuario actual, pestaña Avanzado, eliminar el "Símbolo Decimal" definido y guardar
2. Crear un evento con fecha inicio el mes anterior y estado "Activo".
3. Crear una inscripción al evento
4. Crear un algunas sesiones al evento con fecha del mes anterior
5. Crear asistencias a las sesiones, con importe
6. Crear un compromiso de pago de la persona inscrita al evento con Tipo de pago: Servicios agregados, Periodicidad: Mensual, Fecha del primer pago: anterior al mes pasado
7. Relacionar el compromiso de pago con la inscripción del paso 3
8. Asociar el pago a la inscripción del paso 3
9. En el módulo Pagos, accionar "Calcular pagos agregados" 
10. Verificar que se han calculado los pagos correctamente, sin multiplicarse por 100 su importe
11. Editar el perfil de usuario actual, indicando el separador de "Símbolo Decimal"
12. Volver a calcular los pagos agregados
13. Verificar que el importe no ha sido modificado