### PR TITLE
Hotfix - Plantillas PDF - Formatear número con las preferencias del usuario

### DIFF
--- a/SticInclude/Utils.php
+++ b/SticInclude/Utils.php
@@ -484,7 +484,7 @@ EOQ;
     }
 
     /**
-     * Set the proper decimal separator according to the user/system configuration
+     * Set value with appropriate separators according to user/system configuration
      *
      * @param Decimal $decimalValue
      * @param Boolean $userSetting. Indicates whether to choose user or system configuration
@@ -494,13 +494,24 @@ EOQ;
     {
         global $current_user, $sugar_config;
 
+        // Get the user preferences for the thousands and decimal separator and the number of decimal places 
         if ($userSetting) {
+            // User decimal separator
             $user_dec_sep = (!empty($current_user->id) ? $current_user->getPreference('dec_sep') : null);
+            // User thousands separator
+            $user_grp_sep = (!empty($current_user->id) ? $current_user->getPreference('num_grp_sep') : null);
+            // User number of decimal places
+            $user_sig_digits = (!empty($current_user->id) ? $current_user->getPreference('default_currency_significant_digits') : null);
         }
 
+        // Set the user preferences or the default preferences
         $dec_sep = empty($user_dec_sep) ? $sugar_config['default_decimal_seperator'] : $user_dec_sep;
+        $grp_sep = empty($user_grp_sep) ? $sugar_config['default_number_grouping_seperator'] : $user_grp_sep;
+        $sig_digits = empty($user_sig_digits) ? $sugar_config['sigDigits'] : $user_sig_digits;
 
-        return str_replace('.', $dec_sep, $decimalValue);
+        // Format the number
+        $value = number_format($decimalValue, $sig_digits, $dec_sep, $grp_sep);
+        return $value;
     }
 
     /**

--- a/SticInclude/Utils.php
+++ b/SticInclude/Utils.php
@@ -507,7 +507,7 @@ EOQ;
         // Set the user preferences or the default preferences
         $dec_sep = empty($user_dec_sep) ? $sugar_config['default_decimal_seperator'] : $user_dec_sep;
         $grp_sep = empty($user_grp_sep) ? $sugar_config['default_number_grouping_seperator'] : $user_grp_sep;
-        $sig_digits = empty($user_sig_digits) ? $sugar_config['sigDigits'] : $user_sig_digits;
+        $sig_digits = empty($user_sig_digits) ? $sugar_config['default_currency_significant_digits'] : $user_sig_digits;
 
         // Format the number
         $value = number_format($decimalValue, $sig_digits, $dec_sep, $grp_sep);


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/420

## Description
<!--- Describe your changes in detail -->
Como se describe en el issue, se ha comprobado que en un campo de tipo decimal, no mostraba el separador de miles al generar una plantilla PDF. Debería reflejar el formato de número tal como se muestra en el CRM, donde sí aparece el separador de miles en las vistas.

Se ha implementado en la función que formatea el número decimal con las preferencias que tiene el usuario, o están por defecto, de los separadores y el número de decimales que se quiere mostrar con la función _number_format()_

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Ir a Estudio y en un módulo crear un campo de tipo decimal.
3. Añadir ese campo a la vista de edición y añadir un número mayor a 999 con decimales.
4. Ir a Perfil-Avanzado y comprobar o cambiar los valores de _Separador de miles_, _Separador decimal_ y _Dígitos Significativos en Moneda_
5. Incluir el campo decimal en una plantilla PDF.
6. Comprobar que dicho número se muestra con los separadores y el número de decimales correspondientes al generar la plantilla.
