### PR TITLE
Hotfix - Formularios Web - Excluir campos IFrame y WYSIWYG de los campos posibles de un formulario

### DIFF
--- a/modules/stic_Web_Forms/Assistant/AssistantController.php
+++ b/modules/stic_Web_Forms/Assistant/AssistantController.php
@@ -463,6 +463,8 @@ class stic_Web_FormsAssistantController extends stic_Web_FormsController
     			|| $field_def['type'] == 'link' 
     			|| $field_def['type'] == 'currency_id' 
     			|| $field_def['type'] == 'image' 
+				|| $field_def['type'] == 'iframe' 
+				|| $field_def['type'] == 'wysiwyg' 
     			|| (isset($field_def['source']) && $field_def['source'] == 'non-db' && !$emailFields)
     		   ) 
     		{

--- a/modules/stic_Web_Forms/Assistant/AssistantController.php
+++ b/modules/stic_Web_Forms/Assistant/AssistantController.php
@@ -463,8 +463,8 @@ class stic_Web_FormsAssistantController extends stic_Web_FormsController
     			|| $field_def['type'] == 'link' 
     			|| $field_def['type'] == 'currency_id' 
     			|| $field_def['type'] == 'image' 
-				|| $field_def['type'] == 'iframe' 
-				|| $field_def['type'] == 'wysiwyg' 
+    			|| $field_def['type'] == 'iframe' 
+    			|| $field_def['type'] == 'wysiwyg' 
     			|| (isset($field_def['source']) && $field_def['source'] == 'non-db' && !$emailFields)
     		   ) 
     		{


### PR DESCRIPTION
- Closes #436 

## Descripción
Tal y como se decribe en #436, en los formularios stic (inscripción a eventos y captación de fondos) se permitía incluir campos del tipo IFrame y WYSIWYG

## Solución propuesta
Se han añadido los tipos `'iframe'` y `'wysiwyg'` en la verificación de exclusión de campos por su tipo

## Pruebas
1. En Estudio, editar los campos del módulo Persona y añadir un campo del tipo IFrame y otro del tipo WYSIWYG
2. Iniciar el asistente de creación de un Formulario de inscripción a eventos (módulo Eventos)
3. Verificar que en el selector de campos NO aparecen los nuevos campos IFrame y WYSIWYG
4. Iniciar el asistente de creación de un Formulario de Captación de Fondos (módulo Campañas)
5. Verificar que en el selector de campos NO aparecen los nuevos campos IFrame y WYSIWYG
