### PR TITLE
Hotfix - Llamadas - Añadir duración por defecto al crear la llamada

### DIFF
--- a/modules/Calls/Call.php
+++ b/modules/Calls/Call.php
@@ -180,6 +180,14 @@ class Call extends SugarBean
             // if (!empty($this->duration_hours) && !empty($this->duration_minutes)) {
             if (!empty($this->duration_hours + $this->duration_minutes)) {
             // END STIC
+                // STIC-Custom 20241002 AAM - Setting duration to 0 in case a call is created without these values
+                if (!$this->duration_hours) {
+                    $this->duration_hours = 0;
+                }
+                if (!$this->duration_minutes) {
+                    $this->duration_minutes = 0;
+                }
+                // END STIC
                 $td = $timedate->fromDb($this->date_start);
                 if ($td) {
                     $this->date_end = $td->modify(


### PR DESCRIPTION
En la adaptación de una instancia se ha detectado que al crear un registro de Llamada desde un proceso automatizado, por ejemplo un Flujo de trabajo, sin informar los campos de duración, la creación da error y el proceso no finaliza correctamente.

En este PR se ha añadido una duración "0" por defecto, cuando estos campos no vienen informados por defecto. 

**Pruebas:**
- Crear un Flujo de trabajo con una acción que cree un registro de Llamadas.
- Informar todos los campos menos los campos de duración minutos/horas.
- Comprobar que el FdT se ejecuta correctamente y que el registro de Llamada se ha creado.