### PR TITLE
Hotfix - Formularios - Eliminar mensajes de error innecesarios

### DIFF
--- a/modules/stic_Web_Forms/Catcher/Donation/DonationBO.php
+++ b/modules/stic_Web_Forms/Catcher/Donation/DonationBO.php
@@ -148,6 +148,7 @@ class DonationBO extends WebFormDataBO
         $requiredParams = $this->requiredFormFields;
 
         // Define those required based on the target module.
+        $this->formParams['stic_identification_number_c'] = trim($this->formParams['stic_identification_number_c']);
         switch ($this->defParams['web_module']) {
             case 'Contacts':
                 $moduleRequiredFields = array('last_name', 'stic_identification_number_c');

--- a/modules/stic_Web_Forms/Catcher/Donation/DonationController.php
+++ b/modules/stic_Web_Forms/Catcher/Donation/DonationController.php
@@ -141,7 +141,7 @@ class DonationController extends WebFormDataController
                     }
                 } // If it is an immediate operation the notification is automatically sent
                 else if (!$mailer->sendUserMail($defParams['decodedDefParams']['email_template_id'], $objWeb, $payment)) {
-                    $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Unable to send confirmation email to user.");
+                    $GLOBALS['log']->warn('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Unable to send confirmation email to user.");
                 }
             }
         }

--- a/modules/stic_Web_Forms/Catcher/Donation/DonationMailer.php
+++ b/modules/stic_Web_Forms/Catcher/Donation/DonationMailer.php
@@ -251,6 +251,11 @@ class DonationMailer extends WebFormMailer
             return false;
         }
 
+        if (empty($templateId)) {
+            $GLOBALS['log']->warn('Line ' . __LINE__ . ': ' . __METHOD__ . ":  No template ID received.");
+            return false;
+        }
+
         // Add the recipient
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Adding recipient [{$objWeb->email1}] ...");
         $this->addMailsDest($objWeb->email1);

--- a/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionBO.php
+++ b/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionBO.php
@@ -272,6 +272,7 @@ class EventInscriptionBO extends WebFormDataBO
 
         if ($_REQUEST["validate_identification_number"] == '1') {
             // If identification type is not set or it is a NIF/NIE, validate it. In other case, don't validate
+            $this->formParams['Contacts___stic_identification_number_c'] = trim($this->formParams['Contacts___stic_identification_number_c']);
             if ($this->formParams['Contacts___stic_identification_number_c']
                 && (empty($this->formParams['Contacts___stic_identification_type_c'])
                     || $this->formParams['Contacts___stic_identification_type_c'] == 'nif'
@@ -283,6 +284,7 @@ class EventInscriptionBO extends WebFormDataBO
             }
 
             // If organization's id is available, validate it
+            $this->formParams['Accounts___stic_identification_number_c'] = trim($this->formParams['Accounts___stic_identification_number_c']);
             if (!empty($this->formParams['Accounts___stic_identification_number_c']) &&
                 !self::checkTaxIdentity($this->formParams['Accounts___stic_identification_number_c'])) {
                 $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  The organization ID [{$this->formParams['Accounts___stic_identification_number_c']}] is not valid.");

--- a/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionController.php
+++ b/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionController.php
@@ -200,7 +200,7 @@ class EventInscriptionController extends WebFormDataController
         } else { // Otherwise, send the emails immediately
             $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Sending mail to the registered user...");
             if (!$mailer->sendUserMail($defParams['email_template_id'])) {
-                $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Unable to send the email to the user.");
+                $GLOBALS['log']->warn('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Unable to send the email to the user.");
             }
         }
     }

--- a/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionMailer.php
+++ b/modules/stic_Web_Forms/Catcher/EventInscription/EventInscriptionMailer.php
@@ -193,6 +193,10 @@ class EventInscriptionMailer extends WebFormMailer
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  The data received does not include user email, notification cannot be sent.");
             return false;
         }
+        if (empty($templateId)) {
+            $GLOBALS['log']->warn('Line ' . __LINE__ . ': ' . __METHOD__ . ":  No templateId present.");
+            return false;
+        }
 
         // Añade el destinatario
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Adding recipient [{$objContactWeb->email1}] ...");

--- a/modules/stic_Web_Forms/Catcher/Include/Mailer/WebFormMailer.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Mailer/WebFormMailer.php
@@ -245,7 +245,7 @@ class WebFormMailer
 
         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ":  Sending mail...");
         if (!$mail->Send()) {
-            $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ":  There was an error sending the mail.");
+            $GLOBALS['log']->warn('Line ' . __LINE__ . ': ' . __METHOD__ . ":  There was an error sending the mail.");
             return false;
         }
         return true;

--- a/modules/stic_Web_Forms/Catcher/Include/Mailer/WebFormMailer.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Mailer/WebFormMailer.php
@@ -238,7 +238,7 @@ class WebFormMailer
                 $indice++;
             }
         } else {
-            LoggerManager::getLogger()->fatal('Attachements not found');
+            LoggerManager::getLogger()->warn('Attachements not found');
         }
         ////    END ATTACHMENTS
         ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Relate to #393 
- 
## Descripción
Derivado de las trazas detectadas y recogidas en #393 se decide intentar eliminar los mensajes de error que aprecen por el simple hecho de no indicar plantilla en elparámetro defParams de los formualrios.
Se protegen un par de puntos para comprobar si hay o no templateId informado y se mueven algunos mensajes de error a warn, ya que se trata de mensajes redundantes derivados de un error previo que queda reflejado en el log.

## Motivation and Context
Se quiere reducir el número de trazas innecesarias que van al log para reducir el log y mejorar también la velocidad de respuesta (aunque sea de manera infinitesimal)

## How To Test This
1.- Crear formularios de donación y de eventos sin idicar plantilla de comunicación a usuario
2.- Comprobar en las trazas que no aparecen las líneas
`
2024-10-21 09:01:47 [988190][1][ERROR] Line 316: WebFormMailer::parseEmailTemplateById:  No ID received.
2024-10-21 09:01:47 [988190][1][ERROR] Line 224: EventInscriptionMailer::__sendUserMail:  Error parsing the template.
2024-10-21 09:01:47 [988190][1][ERROR] Line 203: EventInscriptionController::sendMails:  Unable to send the email to the user.
2024-10-21 09:02:00 [990626][1][FATAL] Attachements not found
`
3.- Crear formularios de eventos y donación, tanto para Personas como Organización
4.- Modificar en los formularios las rutinas de validacion isValidDNI y isValidCif para que siempre devuelvan true
5.- Entrar en los formularios DNIS y CIFs válidos pero con espacios delante y/o detrás
6.- Comrpobar que no aparece traza de error y que el DNI/CIF queda correctamente (sin espacios) registrado en el CRM
`2024-09-19 15:56:05 [338463][1][ERROR] Line 281: EventInscriptionBO::checkParams: The person ID [12345678Z ] is not valid.`