### PR TITLE
Hotfix - Flujos de trabajo - Elimnar mensaje de error por variable seteada a 0

### DIFF
--- a/modules/AOW_Actions/actions/actionCreateRecord.php
+++ b/modules/AOW_Actions/actions/actionCreateRecord.php
@@ -523,6 +523,10 @@ class actionCreateRecord extends actionBase
                 return -1;
             }
         } else {
+            // STIC-Custom EPS 202041021 - When unchecked the value is 0 (false)
+            if (isset($params['copy_email_addresses'])) {
+                return 0;
+            }
             // exception
             LoggerManager::getLogger()->error('Given parameter should contains index "copy_email_addresses"');
             return -2;
@@ -530,7 +534,9 @@ class actionCreateRecord extends actionBase
         
         return $ret;
     }
-    
+
+
+
     /**
      *
      * @param arra $currentEmailAddress


### PR DESCRIPTION
Relate to https://github.com/SinergiaTIC/SinergiaCRM/issues/393

## Descripción
Se observa que el mensaje de error aparece indebidamente siempre que se crea un registro y el check de copiar direcciones está a 0.

## Motivation and Context
Se intenta eliminar mensajes de error que no lo son para limpiar el log y ganar también velocidad.

## How To Test This
1. Crear un flujo de trabajo que cree registro, dejando el check de copiar direcciones de email en blanco
2. Comprobar en el log que no aparece el mensaje

