### PR TITLE
Hotfix - SinergiaDA - Varios cambios

### DIFF
--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1298,7 +1298,8 @@ class ExternalReporting
                             users u
                             INNER JOIN users_cstm uc on u.id =uc.id_c
                         WHERE
-                            deleted = 0;";
+                            deleted = 0
+                        AND user_hash IS NOT NULL;";
 
         // 2) eda_def_groups
         $sqlMetadata[] = "CREATE or REPLACE VIEW `sda_def_groups` AS
@@ -1764,7 +1765,7 @@ class ExternalReporting
         ];
 
         // Get list of active users
-        $res = $db->query("SELECT id,user_name, is_admin FROM users join users_cstm on users.id = users_cstm.id_c  WHERE status='Active' AND deleted=0 AND sda_allowed_c=1;");
+        $res = $db->query("SELECT id,user_name, is_admin FROM users join users_cstm on users.id = users_cstm.id_c  WHERE status='Active' AND deleted=0 AND sda_allowed_c=1 AND user_hash IS NOT NULL;");
 
         while ($u = $db->fetchByAssoc($res, false)) {
             $allModulesACL = array_intersect_key(ACLAction::getUserActions($u['id'], true), $modules);

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -629,7 +629,7 @@ class ExternalReporting
                         $fieldV['alias'] = $fieldV['name'];
                         // Numeric type columns are converted to decimal to ensure they remain in this type in the view,
                         // avoiding errors in min and max aggregations due to ordering
-                        $fieldSrc = "CONVERT(IFNULL({$fieldPrefix}.{$fieldV['name']},''), decimal(10,4)  ) AS {$fieldName}";
+                        $fieldSrc = "CONVERT(IFNULL({$fieldPrefix}.{$fieldV['name']},''), decimal(20,4)  ) AS {$fieldName}";
                         break;
 
                     default:


### PR DESCRIPTION
## 1. No truncar cifras superiores a 1.000.000
Se ha visto un error introducido en el último release, por el que cualquier número superior a 999999.9999 se trunca a esta cantidad en el proceso de reconstrucción de SinergiaDA.

Para corregirlo se aumenta el tipo de datos usado en la conversión a 20 digitos, lo que incluyendo los 4 decimales previstos, permite cifras de hasta 999.999.999.999.999  (Novecientos noventa y nueve billones novecientos noventa y nueve mil novecientos noventa y nueve millones novecientos noventa y nueve mil novecientos noventa y nueve) lo que se considera suficiente para nuestro contexto de trabajo

**Pruebas**
- Crear varios registros en Pagos con importe superior a 1.000.000, incluyendo decimales. Verificar que en SinergiaDA se trasladan correctamente. (basta con mirar en la vista sda_stic_payments

## 2. Omitir usuarios sin password de SinergiaDA
Para evitar problemas en updateModel, se omiten en la vista sda_def_users los usuarios que no tienen password creado, por la razón que sea.

**Pruebas:**
- Borrar en base de datos el password de un usuario y tras ejecutar rebuild, verificar que este se ha omitido de la vista sda_def_users


