### PR TITLE
Hotfix - Importación - Evitar uso de variable no definida

### DIFF
--- a/custom/modules/Contacts/SticLogicHooksCode.php
+++ b/custom/modules/Contacts/SticLogicHooksCode.php
@@ -24,13 +24,13 @@
 class ContactsLogicHooks {
     public function before_save(&$bean, $event, $arguments) {
         // Calculate age
-        if ($bean->birthdate != $bean->fetched_row['birthdate']) {
+        if (empty($bean->fetched_row) || $bean->birthdate != $bean->fetched_row['birthdate']) {
             include_once 'custom/modules/Contacts/SticUtils.php';
             $bean->stic_age_c = ContactsUtils::getAge($bean->birthdate);
         }
 
         // Bring Incorpora location data, if there is any
-        if ($bean->fetched_row['stic_incorpora_locations_id_c'] != $bean->stic_incorpora_locations_id_c) {
+        if (empty($bean->fetched_row) || $bean->fetched_row['stic_incorpora_locations_id_c'] != $bean->stic_incorpora_locations_id_c) {
             include_once 'modules/stic_Incorpora_Locations/Utils.php';
             stic_Incorpora_LocationsUtils::transferLocationData($bean);
         }
@@ -49,7 +49,7 @@ class ContactsLogicHooks {
         // End of Patch issue
 
         // Generate automatic Call
-        if ($bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c']) {
+        if (empty($bean->fetched_row) || $bean->stic_postal_mail_return_reason_c != $bean->fetched_row['stic_postal_mail_return_reason_c']) {
             include_once 'custom/modules/Contacts/SticUtils.php';
             ContactsUtils::generateCallFromReturnMailReason($bean);
         }

--- a/custom/modules/Contacts/SticUtils.php
+++ b/custom/modules/Contacts/SticUtils.php
@@ -83,7 +83,7 @@ class ContactsUtils
     public static function generateCallFromReturnMailReason($contactBean)
     {
         $reasons = array('wrong_address', 'unknown', 'rejected');
-        if (in_array($contactBean->stic_postal_mail_return_reason_c, $reasons)) {
+        if (!empty($contactBean->stic_postal_mail_return_reason_c) && in_array($contactBean->stic_postal_mail_return_reason_c, $reasons)) {
             global $current_user, $timedate, $app_strings;
 
             // Create the new call

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2522,7 +2522,7 @@ class SugarBean
                 // STIC Custom - 20221213 - JCH - Trim name & varchar type values on save when the value is not null
                 // STIC#902
                 // STIC#982
-                // xxxxx
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/470
                 if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && property_exists($this, $key) && !is_null($this->$key)) {
                     $this->$key = trim($this->$key);
                 }

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2522,7 +2522,8 @@ class SugarBean
                 // STIC Custom - 20221213 - JCH - Trim name & varchar type values on save when the value is not null
                 // STIC#902
                 // STIC#982
-                if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && !is_null($this->$key)) {
+                // xxxxx
+                if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && property_exists($this, $key) && !is_null($this->$key)) {
                     $this->$key = trim($this->$key);
                 }
                 // END STIC

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2523,7 +2523,7 @@ class SugarBean
                 // STIC#902
                 // STIC#982
                 // https://github.com/SinergiaTIC/SinergiaCRM/pull/470
-                if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && property_exists($this, $key) && !is_null($this->$key)) {
+                if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && property_exists($this, $key) && !empty($this->$key)) {
                     $this->$key = trim($this->$key);
                 }
                 // END STIC

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2522,8 +2522,11 @@ class SugarBean
                 // STIC Custom - 20221213 - JCH - Trim name & varchar type values on save when the value is not null
                 // STIC#902
                 // STIC#982
+                // STIC-Custom 20241218 EPS - Avoid using property "key" if it is not setted
                 // https://github.com/SinergiaTIC/SinergiaCRM/pull/470
+                // if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && !is_null($this->$key)) {
                 if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && property_exists($this, $key) && !empty($this->$key)) {
+                // END STIC-Custom (EPS 20241218)
                     $this->$key = trim($this->$key);
                 }
                 // END STIC

--- a/modules/stic_Incorpora_Locations/Utils.php
+++ b/modules/stic_Incorpora_Locations/Utils.php
@@ -51,12 +51,12 @@ class stic_Incorpora_LocationsUtils {
             $recordBean->$inc_state = $location_bean->state;
         }
         else {
-            $recordBean->$inc_town_code = null;
-            $recordBean->$inc_town = null;
-            $recordBean->$inc_municipality_code = null;
-            $recordBean->$inc_municipality = null;
-            $recordBean->$inc_state_code = null;
-            $recordBean->$inc_state = null;
+            $recordBean->$inc_town_code = '';
+            $recordBean->$inc_town = '';
+            $recordBean->$inc_municipality_code = '';
+            $recordBean->$inc_municipality = '';
+            $recordBean->$inc_state_code = '';
+            $recordBean->$inc_state = '';
         }
     }
 }

--- a/modules/stic_Incorpora_Locations/Utils.php
+++ b/modules/stic_Incorpora_Locations/Utils.php
@@ -41,12 +41,22 @@ class stic_Incorpora_LocationsUtils {
         $inc_state = 'inc_state' .$sufix;
         $stic_incorpora_locations_id = 'stic_incorpora_locations_id' .$sufix;
 
-        $location_bean = BeanFactory::getBean('stic_Incorpora_Locations', $recordBean->$stic_incorpora_locations_id);
-        $recordBean->$inc_town_code = $location_bean->town_code;
-        $recordBean->$inc_town = $location_bean->town;
-        $recordBean->$inc_municipality_code = $location_bean->municipality_code;
-        $recordBean->$inc_municipality = $location_bean->municipality;
-        $recordBean->$inc_state_code = $location_bean->state_code;
-        $recordBean->$inc_state = $location_bean->state;
+        if(!empty($recordBean->$stic_incorpora_locations_id)) {
+            $location_bean = BeanFactory::getBean('stic_Incorpora_Locations', $recordBean->$stic_incorpora_locations_id);
+            $recordBean->$inc_town_code = $location_bean->town_code;
+            $recordBean->$inc_town = $location_bean->town;
+            $recordBean->$inc_municipality_code = $location_bean->municipality_code;
+            $recordBean->$inc_municipality = $location_bean->municipality;
+            $recordBean->$inc_state_code = $location_bean->state_code;
+            $recordBean->$inc_state = $location_bean->state;
+        }
+        else {
+            $recordBean->$inc_town_code = null;
+            $recordBean->$inc_town = null;
+            $recordBean->$inc_municipality_code = null;
+            $recordBean->$inc_municipality = null;
+            $recordBean->$inc_state_code = null;
+            $recordBean->$inc_state = null;
+        }
     }
 }


### PR DESCRIPTION
- Closes #451 
- 
## Description
Se resuelven las 2 trazas explicadas en #451.
En el primer caso se estaba usando $key enla expresión $this->$key sin comprobar que $key estuviera informado, lo que generaba el pertiennte warning.
En el segundo caso se realizaban acciones que sólo debían hacerse en creación del registro. Para ello se comparaban los datos con fetched_row pero sin comprobar si éste estaba informado.
Al corregir los primeros warnings se ha detectado tambiénq ue en Incorpora relacionado con el campo de localización había un problema parecido, que también se ha corregido.

## Motivation and Context
Derivado del proceso realizado para eliminar trazas innecesarias del log, se detectan estas 2 situaciones que se producen en la importación.

## How To Test This
1.- Realizar una importación de Personas
1.1.- Incluir personas con fecha de nacimiento y sin fecha de nacimiento
1.2.- Incluir personas con stic_postal_mail_return_reason_c informado y vacío
1.3.- Incluir personas con stic_incorpora_locations_id_c informado y vacío
1.4.- Comprobar el log de errores (suitecrm.log)
2.- Cambiar la localización de Incorpora
2.1.- Pasar de nulo a informado
2.2.- Cambiar un valor por otro
2.3.- Pasar de valor informado a nulo
2.4.- Comprobar el log de errores (suitecrm.log)
2.5.- Comprobar que los campos calculados a partir de la localización se actualizan correctamente

