### PR TITLE
Hotfix - General - Actualización masiva en campo multienum no trataba correctamente el valor para "limpiar" el campo

### DIFF
--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -219,6 +219,8 @@ eoq;
                     // STIC-Custom 20230519 PCS - Enabling massupdate for dynamicenum
                     // STIC#1109
                     // || ($this->sugarbean->field_defs[$post]['type'] == 'enum' && $value == '__SugarMassUpdateClearField__') // Set to '' if it's an explicit clear
+                    // Stic-Custom EPS 20241005 - Mass update on multienum was not cleaning the field
+                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/472
                     // || (($this->sugarbean->field_defs[$post]['type'] == 'enum' || $this->sugarbean->field_defs[$post]['type'] == 'dynamicenum') && $value == '__SugarMassUpdateClearField__') // Set to '' if it's an explicit clear
                     || ((in_array($this->sugarbean->field_defs[$post]['type'], array('enum', 'dynamicenum', 'multienum'))) && $value == '__SugarMassUpdateClearField__') // Set to '' if it's an explicit clear
                     //END STIC-Custom
@@ -238,10 +240,12 @@ eoq;
                     $_POST[$post] = $timedate->to_db($_POST[$post]);
                 }
             }
-            // ###EPS###
+            // Stic-Custom EPS 20241005 - Mass update on multienum was not cleaning the field
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/472
             else if(is_array($value) && count($value) === 1 && $this->sugarbean->field_defs[$post]['type'] == 'multienum' && $value[0] == '__SugarMassUpdateClearField__') {
                 $_POST[$post] = '';
             }
+            // END STic-Custom
         }
 
         //We need to disable_date_format so that date values for the beans remain in database format

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -219,7 +219,8 @@ eoq;
                     // STIC-Custom 20230519 PCS - Enabling massupdate for dynamicenum
                     // STIC#1109
                     // || ($this->sugarbean->field_defs[$post]['type'] == 'enum' && $value == '__SugarMassUpdateClearField__') // Set to '' if it's an explicit clear
-                    || (($this->sugarbean->field_defs[$post]['type'] == 'enum' || $this->sugarbean->field_defs[$post]['type'] == 'dynamicenum') && $value == '__SugarMassUpdateClearField__') // Set to '' if it's an explicit clear
+                    // || (($this->sugarbean->field_defs[$post]['type'] == 'enum' || $this->sugarbean->field_defs[$post]['type'] == 'dynamicenum') && $value == '__SugarMassUpdateClearField__') // Set to '' if it's an explicit clear
+                    || ((in_array($this->sugarbean->field_defs[$post]['type'], array('enum', 'dynamicenum', 'multienum'))) && $value == '__SugarMassUpdateClearField__') // Set to '' if it's an explicit clear
                     //END STIC-Custom
                 ) {
                     $_POST[$post] = '';
@@ -236,6 +237,10 @@ eoq;
                 if ($this->sugarbean->field_defs[$post]['type'] == 'datetimecombo' && !empty($_POST[$post])) {
                     $_POST[$post] = $timedate->to_db($_POST[$post]);
                 }
+            }
+            // ###EPS###
+            else if(is_array($value) && count($value) === 1 && $this->sugarbean->field_defs[$post]['type'] == 'multienum' && $value[0] == '__SugarMassUpdateClearField__') {
+                $_POST[$post] = '';
             }
         }
 


### PR DESCRIPTION
- Closes #471 
- 
## Descripción
Se corrige en MassUpdate.php el tratamiento de la constante ____SugarMassUpdateClearField____.
En primer lugar se estaba tratando sólo para campos enum y dynamicenum.
En segundo lugar sólo se contemplaba que legara un valor plano (string).

## Motivation and Context
Se ha detectado (#471) que cuando se intenta borrar el contenido de un campo multienum desde la actualización masiva, en lugar de borrarse el contenido del campo se rellena con el valor ____SugarMassUpdateClearField____

## How To Test This
1.- En Personas hacer visible el campo perfil del trabajador y el lawful_basis (el perfil de trabajador se visualiza como multienum en la actualización masiva mientras que lawful_basis a pesar de ser un multienum en la vista masiva se visualiza como una lista... lo que provoca que vayan por caminos distintos)
2.- Actualizar masivamente a blanco ambos campos
3.- Comprobar que el valor queda en blanco en ambos casos

