### PR TITLE
Enhancement - SinergiaDA - October2/November/December

### DIFF
--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -387,6 +387,7 @@ class ExternalReporting
                     case 'emailbody':
                     case 'none':
                     case 'ColourPicker':
+                    case 'collection':
                         continue 2;
                         break;
                     case 'relate':

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -819,7 +819,7 @@ class ExternalReporting
                 || $this->sdaSettings['publishAsTable'][0] == '1'
             ) {
                 $tableMode = 'table';
-                $createViewQueryHeader = " CREATE OR REPLACE TABLE {$viewName} ENGINE=MyISAM AS SELECT ";
+                $createViewQueryHeader = " CREATE OR REPLACE TABLE {$viewName} ENGINE=InnoDB AS SELECT ";
             } else {
                 $tableMode = 'view';
                 $createViewQueryHeader = " CREATE OR REPLACE VIEW {$viewName} AS SELECT ";
@@ -1403,7 +1403,7 @@ class ExternalReporting
                             `label` VARCHAR(100) NOT NULL,
                             `description` VARCHAR(255) NOT NULL,
                             `visible` BIT DEFAULT 1
-                        ) ENGINE = MyISAM;';
+                        ) ENGINE = InnoDB;';
 
         // 2) eda_def_columns
         $sqlMetadata[] = 'CREATE TABLE IF NOT EXISTS `sda_def_columns` (
@@ -1417,7 +1417,7 @@ class ExternalReporting
                             `visible` BIT DEFAULT 1,
                             `sda_hidden` INT DEFAULT 0,
                             `stic_type` VARCHAR(20)
-                        ) ENGINE = MyISAM;';
+                        ) ENGINE = InnoDB;';
         // 3) eda_def_relationships
         $sqlMetadata[] = 'CREATE TABLE IF NOT EXISTS `sda_def_relationships` (
                             `id` VARCHAR(64) NOT NULL,
@@ -1427,7 +1427,7 @@ class ExternalReporting
                             `target_column` VARCHAR(64) NOT NULL,
                             `label` VARCHAR(255) NOT NULL,
                             `info` VARCHAR(255) NOT NULL
-                        ) ENGINE = MyISAM;';
+                        ) ENGINE = InnoDB;';
 
         // 4) eda_def_enumerations
         $sqlMetadata[] = 'CREATE TABLE IF NOT EXISTS `sda_def_enumerations` (
@@ -1442,7 +1442,7 @@ class ExternalReporting
                             `target_bridge` VARCHAR(64) NOT NULL,
                             `stic_type` VARCHAR(20) NOT NULL,
                             `info` VARCHAR(255) NOT NULL
-                        ) ENGINE = MyISAM;';
+                        ) ENGINE = InnoDB;';
 
         // 5) eda_def_permissions
 
@@ -1469,7 +1469,7 @@ class ExternalReporting
         $sqlMetadata[] = 'CREATE TABLE IF NOT EXISTS `sda_def_config` (
                             `key` VARCHAR(64) NOT NULL,
                             `value` VARCHAR(64) NOT NULL
-                        ) ENGINE = MyISAM;';
+                        ) ENGINE = InnoDB;';
 
         foreach ($sqlMetadata as $key => $value) {
             if (!$db->query($value)) {

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1316,6 +1316,8 @@ class ExternalReporting
                                 CONCAT('SCRM_',s.name) as name
                             FROM
                                 users u
+                            JOIN users_cstm uc ON
+                                uc.id_c=u.id
                             JOIN securitygroups_users su ON
                                 u.id = su.user_id
                             JOIN securitygroups s ON
@@ -1325,6 +1327,8 @@ class ExternalReporting
                                 AND u.deleted = 0
                                 AND su.deleted = 0
                                 AND s.deleted = 0
+                                AND uc.sda_allowed_c=1
+                                AND u.status='Active'
                             UNION
                             -- Administrator users should always belong to the EDA_ADMIN group.
                             SELECT
@@ -1334,7 +1338,8 @@ class ExternalReporting
                                 users u
                             WHERE
                                 u.is_admin = 1
-                                AND u.deleted = 0;";
+                                AND u.deleted = 0
+                                AND u.status='Active';";
         // 4) eda_def_security_group_records
 
         // Set a switch to determine whether to populate the sda_def_security_group_records view based

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1721,7 +1721,7 @@ class ExternalReporting
      * This function processes user permissions in batches, creating records in the sda_def_permissions table.
      * It processes:
      * - All admin users with sda_allowed_c enabled
-     * - Non-admin users up to the limit specified in $sugar_config['stic_sinergiada']['max_user_processed']
+     * - Non-admin users up to the limit specified in $sugar_config['stic_sinergiada']['max_users_processed']
      *   (defaults to 100 if not set)
      *
      * @param array $modules List of modules to process ACL settings for
@@ -1755,7 +1755,7 @@ class ExternalReporting
         ];
 
         // Get maximum number of non-admin users to process
-        $maxNonAdminUsers = $sugar_config['stic_sinergiada']['max_user_processed'] ?? 100;
+        $maxNonAdminUsers = $sugar_config['stic_sinergiada']['max_users_processed'] ?? 100;
 
         // Get count of admin users
         $totalAdminUsers = $db->getOne("SELECT COUNT(*) FROM users u

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -144,8 +144,6 @@ class ExternalReporting
     public function createViews($callUpdateModel = true, $rebuildFilter = 'all')
     {
 
-        ini_set('memory_limit', '256M');
-
         $startTime = microtime(true);
         $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "SinergiaDA rebuild script starts!");
 
@@ -1775,14 +1773,19 @@ class ExternalReporting
 
                     $userActions = ACLAction::getUserActions($u['id'], false, $moduleName);
 
-                    if (empty($userActions[$moduleName])) {
+                    $value = $userActions[$moduleName]['module'];
+
+                    if(empty($value)){
+                        $value=$userActions['module'];
+                    }
+
+                    if (empty($value)) {
                         continue;
                     }
 
-                    $value = $userActions[$moduleName];
 
-                    if ($u['is_admin'] == 0 && $value['module']['access']['aclaccess'] >= 0 && $value['module']['view']['aclaccess'] >= 0) {
-                        $aclSource = $aclSourcesList[$value['module']['view']['aclaccess']];
+                    if ($u['is_admin'] == 0 && $value['access']['aclaccess'] >= 0 && $value['view']['aclaccess'] >= 0) {
+                        $aclSource = $aclSourcesList[$value['view']['aclaccess']];
 
                         // Fix for special cases
                         $key = $moduleName == 'ProjectTask' ? 'Project_Task' : $moduleName;
@@ -1790,7 +1793,7 @@ class ExternalReporting
 
                         $currentTable = $this->viewPrefix . '_' . strtolower($key);
 
-                        switch ($value['module']['view']['aclaccess']) {
+                        switch ($value['view']['aclaccess']) {
                             case '80': // Security groups
                                 if (($sugar_config['stic_sinergiada']['group_permissions_enabled'] ?? null) != true) {
                                     continue 2;

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1580,7 +1580,6 @@ class ExternalReporting
     private function createEnumView($listName, $listViewName)
     {
 
-        // return $this->createEnumTable($listName, $listViewName);
 
         // Get the global variable $app_list_strings
         global $app_list_strings;
@@ -1588,8 +1587,15 @@ class ExternalReporting
         // Get instance of DBManagerFactory
         $db = DBManagerFactory::getInstance();
 
-        // Get the current list
+        // Get the current listm or return if not exists
         $currentList = $app_list_strings[$listName];
+        if(!$currentList) {
+            $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "The referenced dropdown list [{$listName}] is not available. Ommited");
+        return;
+        }
+
+
+
 
         // Start building the SQL command
         $sqlCommand = "CREATE OR REPLACE VIEW {$this->listViewPrefix}_{$listViewName} AS ";
@@ -1609,7 +1615,7 @@ class ExternalReporting
         // Execute the SQL command
         if (!$db->query($sqlCommand)) {
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Error has occurred: [{$db->last_error}] running Query: [{$sqlCommand}]");
-            // $this->info .= "[FATAL: No se ha podido crear la vista {$this->listViewPrefix}_{$listViewName}]";
+            
         } else {
             return $listViewName;
         };
@@ -1839,6 +1845,7 @@ class ExternalReporting
                             case '75': // Owner-based permissions
                                 $permissionsBatch[] = [
                                     'user_name' => $user['user_name'],
+                                    'group' =>null,
                                     'table' => $currentTable,
                                     'column' => 'assigned_user_name',
                                     'stic_permission_source' => $aclSource,
@@ -1849,6 +1856,7 @@ class ExternalReporting
                             default: // Global permissions
                                 $permissionsBatch[] = [
                                     'user_name' => $user['user_name'],
+                                    'group' =>null,
                                     'table' => $currentTable,
                                     'column' => 'users_id',
                                     'stic_permission_source' => $aclSource,

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1818,18 +1818,7 @@ class ExternalReporting
                                             ]
                                         );
 
-                                        // Guardar registro inmediatamente para el usuario dentro del grupo
-                                        $this->addMetadataRecord(
-                                            'sda_def_permissions',
-                                            [
-                                                'user_name' => $u['user_name'],
-                                                'group' => $userGroups['group'],
-                                                'table' => $currentTable,
-                                                'column' => 'assigned_user_name',
-                                                'stic_permission_source' => "{$aclSource}_priv",
-                                                'global' => 0,
-                                            ]
-                                        );
+                                        
                                     }
                                 }
                                 break;

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -144,6 +144,8 @@ class ExternalReporting
     public function createViews($callUpdateModel = true, $rebuildFilter = 'all')
     {
 
+        // ini_set('memory_limit', '256M');
+
         $startTime = microtime(true);
         $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "SinergiaDA rebuild script starts!");
 
@@ -1338,6 +1340,7 @@ class ExternalReporting
                             SELECT * from sda_def_permissions_actions  p where p.stic_permission_source IN ('ACL_ALLOW_ALL', 'ACL_ALLOW_GROUP_priv','ACL_ALLOW_OWNER')
                             UNION
                      SELECT
+                        id,
                         sdug.user_name,
                         `group`,
                         `table`,
@@ -1464,14 +1467,22 @@ class ExternalReporting
 
         // 5) eda_def_permissions
         $sqlMetadata[] = 'DROP TABLE IF EXISTS `sda_def_permissions_actions`';
-        $sqlMetadata[] = 'CREATE TABLE IF NOT EXISTS `sda_def_permissions_actions` (
-                            `user_name` VARCHAR(64) NOT NULL,
-                            `group` VARCHAR(64) NOT NULL,
-                            `table` VARCHAR(64) NOT NULL,
-                            `column` VARCHAR(64) NOT NULL,
-                            `global` VARCHAR(64) NOT NULL,
-                            `stic_permission_source` VARCHAR (20) NOT NULL
-                        ) ENGINE = MyISAM;';
+        $sqlMetadata[] = 'CREATE TABLE `sda_def_permissions_actions` (
+                            `id` bigint(20) NOT NULL AUTO_INCREMENT,
+                            `user_name` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+                            `group` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+                            `table` varchar(64) NOT NULL,
+                            `column` varchar(64) NOT NULL,
+                            `global` tinyint(1) NOT NULL,
+                            `stic_permission_source` varchar(20) NOT NULL,
+                            PRIMARY KEY (`id`),
+                            KEY `sda_def_permissions_actions_user_name_IDX` (`user_name`) USING BTREE,
+                            KEY `sda_def_permissions_actions_group_IDX` (`group`) USING BTREE,
+                            KEY `sda_def_permissions_actions_table_IDX` (`table`) USING BTREE,
+                            KEY `sda_def_permissions_actions_stic_permission_source_IDX` (`stic_permission_source`) USING BTREE,
+                            KEY `idx_table_user` (`table`, `user_name`),
+                            KEY `idx_table_group` (`table`, `group`)
+                        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;';
 
         // 6) sda_def_config
         $sqlMetadata[] = 'DROP TABLE IF EXISTS `sda_def_config`';
@@ -1745,138 +1756,151 @@ class ExternalReporting
      * @return void
      */
     public function getAndSaveUserACL($modules)
-    {
-        global $sugar_config;
+{
+    global $sugar_config;
 
-        $db = DBManagerFactory::getInstance();
-        include_once 'modules/ACLActions/ACLAction.php';
+    $db = DBManagerFactory::getInstance();
+    include_once 'modules/ACLActions/ACLAction.php';
 
-        // List of ACL sources
-        $aclSourcesList = [
-            100 => 'ACL_ALLOW_ADMIN_DEV',
-            99 => 'ACL_ALLOW_ADMIN',
-            90 => 'ACL_ALLOW_ALL',
-            89 => 'ACL_ALLOW_ENABLED',
-            80 => 'ACL_ALLOW_GROUP',
-            75 => 'ACL_ALLOW_OWNER',
-            1 => 'ACL_ALLOW_NORMAL',
-            0 => 'ACL_ALLOW_DEFAULT',
-        ];
+    // List of ACL sources
+    $aclSourcesList = [
+        100 => 'ACL_ALLOW_ADMIN_DEV',
+        99 => 'ACL_ALLOW_ADMIN',
+        90 => 'ACL_ALLOW_ALL',
+        89 => 'ACL_ALLOW_ENABLED',
+        80 => 'ACL_ALLOW_GROUP',
+        75 => 'ACL_ALLOW_OWNER',
+        1 => 'ACL_ALLOW_NORMAL',
+        0 => 'ACL_ALLOW_DEFAULT',
+    ];
 
-        // Get list of active users
-        $res = $db->query("SELECT id,user_name, is_admin FROM users join users_cstm on users.id = users_cstm.id_c  WHERE status='Active' AND deleted=0 AND sda_allowed_c=1;");
+    // Tamaño del lote
+    $batchSize = 100; // Reducido el tamaño del lote
+    $offset = 0;
+
+    do {
+        // Obtener usuarios en lotes
+        $query = "SELECT id, user_name, is_admin 
+                 FROM users 
+                 JOIN users_cstm ON users.id = users_cstm.id_c 
+                 WHERE status='Active' AND deleted=0 AND sda_allowed_c=1 
+                 LIMIT {$batchSize} OFFSET {$offset}";
+        
+        $res = $db->query($query);
+        $processedUsers = 0;
 
         while ($u = $db->fetchByAssoc($res, false)) {
-            $allModulesACL = array_intersect_key(ACLAction::getUserActions($u['id'], true), $modules);
-            foreach ($allModulesACL as $key => $value) {
-                unset($aclSource);
-                // Access to the users module is allowed only for administrator users
-                if ($u['is_admin'] == 0 && $key == 'Users') {
+            $processedUsers++;
+            
+            // Procesar módulos uno por uno para cada usuario
+            foreach ($modules as $moduleName => $moduleData) {
+                if ($u['is_admin'] == 0 && $moduleName == 'Users') {
                     continue;
                 }
 
-                $aclSource = $aclSourcesList[$value['module']['view']['aclaccess']];
+                $userActions = ACLAction::getUserActions($u['id'], false, $moduleName);
+                
+                if (empty($userActions[$moduleName])) {
+                    continue;
+                }
 
-                // Fix for special cases when the module name is different from the table name
-                $key = $key == 'ProjectTask' ? 'Project_Task' : $key;
-                $key = $key == 'CampaignLog' ? 'Campaign_Log' : $key;
-
-                $currentTable = $this->viewPrefix . '_' . strtolower($key);
+                $value = $userActions[$moduleName];
                 
                 if ($u['is_admin'] == 0 && $value['module']['access']['aclaccess'] >= 0 && $value['module']['view']['aclaccess'] >= 0) {
-                    // Determine the metadata to be saved based on the type of permissions,
-                    // first we'll add them to the $userModuleAccessMode array with a unique key to avoid duplicates
+                    $aclSource = $aclSourcesList[$value['module']['view']['aclaccess']];
+                    
+                    // Fix for special cases
+                    $key = $moduleName == 'ProjectTask' ? 'Project_Task' : $moduleName;
+                    $key = $key == 'CampaignLog' ? 'Campaign_Log' : $key;
+                    
+                    $currentTable = $this->viewPrefix . '_' . strtolower($key);
+
                     switch ($value['module']['view']['aclaccess']) {
                         case '80': // Security groups
-
-                            // If $sugar_config['stic_sinergiada']['group_permissions_enabled'] is disabled, access is also disabled to
-                            // modules where the user has restricted access to their group's records.
                             if (($sugar_config['stic_sinergiada']['group_permissions_enabled'] ?? null) != true) {
                                 continue 2;
                             }
 
-                            // In the case of Security Groups we add a unique entry for each of the groups the user belongs to,
-                            // ensuring that it does not exist previously for each module.
-                            $userGroupsRes = $db->query("SELECT distinct(name) as 'group' FROM sda_def_user_groups ug WHERE user_name='{$u['user_name']}';");
+                            $userGroupsQuery = "SELECT distinct(name) as 'group' 
+                                              FROM sda_def_user_groups ug 
+                                              WHERE user_name='{$u['user_name']}';";
+                            $userGroupsRes = $db->query($userGroupsQuery);
 
                             while ($userGroups = $db->fetchByAssoc($userGroupsRes, false)) {
-
                                 $crmGroupName = explode('SCRM_', $userGroups['group'])[1];
+                                
+                                if (groupHasAccess($crmGroupName, $u['id'], $key, 'view')) {
+                                    // Guardar registro inmediatamente para el grupo
+                                    $this->addMetadataRecord(
+                                        'sda_def_permissions_actions',
+                                        [
+                                            'user_name' => null,
+                                            'group' => $userGroups['group'],
+                                            'table' => $currentTable,
+                                            'column' => 'id',
+                                            'stic_permission_source' => $aclSource,
+                                            'global' => 0,
+                                        ]
+                                    );
 
-                                // Verify whether or not the group or user has access to the module for their roles
-                                $groupHasAccessToModule = groupHasAccess($crmGroupName, $u['id'], $key, 'view');
-
-                                if ($groupHasAccessToModule) {
-
-                                    $userModuleAccessMode["{$u['user_name']}_{$aclSource}_{$userGroups['group']}_{$currentTable}"] = [
-                                        'user_name' => null,
-                                        'group' => $userGroups['group'],
-                                        'table' => $currentTable,
-                                        'column' => 'id',
-                                        'stic_permission_source' => $aclSource,
-                                        'global' => 0,
-                                    ];
-
-                                    // Additionally we insert a record that allows each user's access to the records in which match
-                                    // the user_name with the assigned_user_name field content in each module in which the user has group permission
-                                    $userModuleAccessMode["{$u['user_name']}_{$aclSource}_{$userGroups['group']}_private_{$currentTable}"] = [
-                                        'user_name' => $u['user_name'],
-                                        'group' => $userGroups['group'],
-                                        'table' => $currentTable,
-                                        'column' => 'assigned_user_name',
-                                        'stic_permission_source' => "{$aclSource}_priv",
-                                        'global' => 0,
-                                    ];
+                                    // Guardar registro inmediatamente para el usuario dentro del grupo
+                                    $this->addMetadataRecord(
+                                        'sda_def_permissions_actions',
+                                        [
+                                            'user_name' => $u['user_name'],
+                                            'group' => $userGroups['group'],
+                                            'table' => $currentTable,
+                                            'column' => 'assigned_user_name',
+                                            'stic_permission_source' => "{$aclSource}_priv",
+                                            'global' => 0,
+                                        ]
+                                    );
                                 }
                             }
-
                             break;
 
                         case '75': // Owner case
-                            // Modules where the user has restricted access to their own/assigned records .
-
-                            $userModuleAccessMode["{$aclSource}_{$u['user_name']}_{$currentTable}"] = [
-                                'user_name' => $u['user_name'],
-                                'table' => $currentTable,
-                                'column' => 'assigned_user_name',
-                                'stic_permission_source' => $aclSource,
-                                'global' => 0,
-                            ];
+                            $this->addMetadataRecord(
+                                'sda_def_permissions_actions',
+                                [
+                                    'user_name' => $u['user_name'],
+                                    'table' => $currentTable,
+                                    'column' => 'assigned_user_name',
+                                    'stic_permission_source' => $aclSource,
+                                    'global' => 0,
+                                ]
+                            );
                             break;
 
-                        default: // Other (normal) cases
-                            // add metadata record for normal cases
-                            $userModuleAccessMode["{$aclSource}_{$u['user_name']}_{$currentTable}"] = [
-                                'user_name' => $u['user_name'],
-                                'table' => $currentTable,
-                                'column' => 'users_id',
-                                'stic_permission_source' => $aclSource,
-                                'global' => 1,
-                            ];
+                        default: // Other cases
+                            $this->addMetadataRecord(
+                                'sda_def_permissions_actions',
+                                [
+                                    'user_name' => $u['user_name'],
+                                    'table' => $currentTable,
+                                    'column' => 'users_id',
+                                    'stic_permission_source' => $aclSource,
+                                    'global' => 1,
+                                ]
+                            );
                             break;
                     }
-                    $aclList[$u['user_name']][$key] = $value['module']['view']['aclaccess'];
                 }
             }
-            unset($allModulesACL);
+            
+            // Limpiar memoria después de procesar cada usuario
+            unset($userActions);
+            gc_collect_cycles();
         }
 
-        // Add the permissions with the values determined in the previous switch case to the metadata table, based on the case.
-        foreach (array_unique($userModuleAccessMode, SORT_REGULAR) as $key => $value) {
-            $this->addMetadataRecord(
-                'sda_def_permissions_actions',
-                [
-                    'user_name' => $value['user_name'],
-                    'group' => $value['group'],
-                    'table' => $value['table'],
-                    'column' => $value['column'],
-                    'global' => $value['global'],
-                    'stic_permission_source' => $value['stic_permission_source'],
-                ]
-            );
-        }
-    }
-
+        $offset += $batchSize;
+        
+        // Limpiar memoria después de cada lote
+        unset($res);
+        gc_collect_cycles();
+        
+    } while ($processedUsers > 0);
+}
     /**
      * Check the columns in the sda_def_columns table against the columns in the views.
      * Display the columns that do not exist in the views.

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -381,6 +381,7 @@ class ExternalReporting
                     case 'currency_id':
                     case 'emailbody':
                     case 'none':
+                    case 'ColourPicker':
                         continue 2;
                         break;
                     case 'relate':

--- a/SticInclude/SinergiaDARebuild.php
+++ b/SticInclude/SinergiaDARebuild.php
@@ -63,7 +63,10 @@ class SinergiaDARebuild
                 $msg .= $match . "<br>";
             }
 
-            unlink('sdaRebuildError.txt');
+            if(file_exists('sdaRebuildError.txt'))
+            {
+                unlink('sdaRebuildError.txt');
+            }
             
             // Return 'ok' or the error message
             if (empty($msg)) {


### PR DESCRIPTION
## 1. Añadir _ColourPicker_ y _collection_ como tipos de campo excluidos del procesamiento.
**Como validarlo**
 - Por inspección de código 
https://github.com/SinergiaTIC/SinergiaCRM/blob/3fc9c2b697b83e32ca37dfe6b0f3f4e83c918969/SticInclude/SinergiaDA.php#L389-L390

## 2. Mejoras en la gestión de tabla sda_def_permissions
Se ha visto que en escenarios con un alto número de permisos (usuarios*grupos) el procesamiento es excesivamente lento si _sda_def_permissions_ es una vista y no una tabla, por lo que se revierte este cambio hecho en la anterior versión. Paralelamente se mejora el proceso de guardado de los registros de esta tabla, que hasta el momento se hacía por cada registro, y ahora se procesan en bloque, haciendo 
Se ha establecido una limitación práctica de 100 usuarios no administradores + todos los usuarios administradores de la instancia (los usuarios administradores no añadirán muchos registros ya que no tienen limitaciones de acceso a módulos). Este límite puede ser aumentado o disminuido usando la variable `$sugar_config['stic_sinergiada']['max_users_processed']=<num>` en config_override.php.

**Cómo probarlo**
1. Ejecutar rebuild sin modificar la variable `$sugar_config['stic_sinergiada']['max_users_processed'] y verificar que se han procesado 100 usuarios no administradores + los usuarios no administradores
2. Verificar que todos las tablas sda_def_* han sido pobladas correctamente, especialmente la tabla `sda_def_permissions`, que debe incluir los permisos de los usuarios procesados.
3. Analizar los tiempos de respuesta y verificar que está dentro de unos límites aceptables.  (< 1 minuto)
4. Hacer alguna prueba estableciendo valores diferentes en `$sugar_config['stic_sinergiada']['max_users_processed']


## 3. Incluir solo a usuarios activos en la tabla sda_def_users
Ahora solo se incluyen en la tabla sda_def_users a los usuarios activos con SinergiaDA activado, puesto que esta tabla ya solamente se usa para el proceso de login de los usuarios y no es necesario que estén en la misma, como se creía hasta ahora, los usuario inactivos o con el acceso a SDA desactivado.
**Cómo probarlo**
Verificar que en tras el rebuild, la tabla sda_def_users y sda_def_users_groups unicamente incluyen a los usuarios activo y con SDA habilitado.


## 4. Eliminar operaciones DROP redundantes
Se han eliminado las operaciones DROP table redundantes existentes, sobre tablas  que generaban errores del tipo [FATAL] en los logs. Aunque estos errores eran inocuos en cuanto a sus consecuencias, se ha corregido esta situación anómala.

**Cómo probarlo**
Verificar que tras reconstruir, no aparecen en el log entradas como las siguientes:

```log
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL] Mysqli_query failed.
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL]  Query Failed: DROP TABLE sda_def_config: MySQL error 1051: Unknown table 'myaladina.sda_def_config'
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL] Mysqli_query failed.
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL]  Query Failed: DROP TABLE sda_def_tables: MySQL error 1051: Unknown table 'myaladina.sda_def_tables'
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL] Mysqli_query failed.
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL]  Query Failed: DROP TABLE sda_def_enumerations: MySQL error 1051: Unknown table 'myaladina.sda_def_enumerations'
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL] Mysqli_query failed.
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL]  Query Failed: DROP TABLE sda_stic_payments: MySQL error 1051: Unknown table 'myaladina.sda_stic_payments'
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL] Mysqli_query failed.
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL]  Query Failed: DROP TABLE sda_def_permissions_actions: MySQL error 1051: Unknown table 'myaladina.sda_def_permissions_actions'
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL] Mysqli_query failed.
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL]  Query Failed: DROP TABLE sda_def_relationships: MySQL error 1051: Unknown table 'myaladina.sda_def_relationships'
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL] Mysqli_query failed.
2024-12-06 02:02:03 [1944709][41b8185c-3817-3a9a-697e-551937375073][FATAL]  Query Failed: DROP TABLE sda_def_columns: MySQL error 1051: Unknown table 'myaladina.sda_def_columns'
``` 


## 5. Cambio de motor de tablas de SDA a InnoDB
Ahora las tablas sda_* se crean siempre como InnoDB, en consonancia con el cambio realizado en SinergiaCRM
**Cómo probarlo**
Verificar que tras reconstruir todas las tablas con prefijo sda_ tienen el motor InnoDB


## 6. Se corrige la causa de algunas entradas de log indebidas.
-   closes #439 
**Cómo probarlo**
- Verificar que no aparecen las entradas de log indicadas en
   -  https://github.com/SinergiaTIC/SinergiaCRM/pull/478#pullrequestreview-2505801894
   -  https://github.com/SinergiaTIC/SinergiaCRM/pull/478#pullrequestreview-2508417535
   
