### PR TITLE
Hotfix - Encuestas - Duplicación de preguntas mediante un flujo de trabajo

### DIFF
--- a/modules/Surveys/Surveys.php
+++ b/modules/Surveys/Surveys.php
@@ -155,10 +155,15 @@ class Surveys extends Basic
             unset($_REQUEST['survey_questions_ids']);
         }
         // STIC End
-        $res = parent::save($check_notify);
-        if (empty($_REQUEST['survey_questions_supplied'])) {
-            return $res;
-        }
+
+        // STIC-Custom 20241121 ART - Duplication of questions by having a workflow
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // First the survey was saved (with parent::save()), and then the questions were processed
+        // $res = parent::save($check_notify);
+        // if (empty($_REQUEST['survey_questions_supplied'])) {
+        //     return $res;
+        // }
+        // END STIC-Custom
 
         foreach ($_REQUEST['survey_questions_names'] as $key => $val) {
             if (!empty($_REQUEST['survey_questions_ids'][$key])) {
@@ -196,6 +201,14 @@ class Surveys extends Basic
             }
         }
 
+        // STIC-Custom 20241121 ART - Duplication of questions by having a workflow
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // The survey is saved after the questions are processed, allowing for more precise control of how many questions are created
+        $res = parent::save($check_notify);
+        if (empty($_REQUEST['survey_questions_supplied'])) {
+            return $res;
+        }
+        // END STIC-Custom
         return $res;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/91

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Como se describe en el issue, al tener un FdT y duplicar una encuesta se duplicaban también las preguntas. Esto es debido a:
1. Porque en el método save() original, primero se guardaba la encuesta (con parent::save()), y luego se procesaban las preguntas.
2. Durante el proceso de duplicación, la línea unset($_REQUEST['survey_questions_ids']); se usa para indicar que se están creando nuevas preguntas, pero no prevenía la duplicación de preguntas.
3. Al procesar las preguntas, el código recorría todas las preguntas existentes y las guardaba de nuevo, lo que resultaba en el doble de preguntas.

Ahora, añadiendo el save() al final de la función, es decir, primero se procesan las preguntas y luego se guarda la encuesta, permite tener un control más preciso de cuántas preguntas se crean.

La principal diferencia está en el orden de las operaciones y en cómo se manejan las preguntas durante el proceso de duplicación. Con esta soluión garantiza que no se dupliquen accidentalmente las preguntas, manteniendo el número original de preguntas de la encuesta que estás duplicando.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Crear una encuesta con varias preguntas con _Estado->Borrador_
2. Crear un Flujo de Trabajo
- Módulo base: Encuestas
- Ejecutar al guardar
- Registros nuevos
- Acción:
  - Modificar la propia encuesta, por ejemplo, pasar de estado borrador a publicado.
  - Calcular campos, por ejemplo, calcular el nombre.
3. Duplicar la encuesta del paso 1, comprobando el número de preguntas que tiene.
4. Comprobar que se ha duplicado la encuesta sin duplicar las preguntas y que tiene las mismas que la encuesta del paso 1.