### PR TITLE
Hotfix - Administración - Valores por defecto de DateTime traducidos y valor "first day of next month" corregido

### DIFF
--- a/include/language/ca_ES.lang.php
+++ b/include/language/ca_ES.lang.php
@@ -2053,7 +2053,7 @@ $app_strings = array(
 
     'LBL_YESTERDAY' => 'ahir',
     // STIC-Custom 20241126 ART - Translated Default Datetime Values
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/488
     'LBL_NOW' => 'ahora',
     // END STIC-Custom
     'LBL_TODAY' => 'avui',

--- a/include/language/ca_ES.lang.php
+++ b/include/language/ca_ES.lang.php
@@ -2052,10 +2052,7 @@ $app_strings = array(
     'LBL_DESCRIPTION' => 'Descripció',
 
     'LBL_YESTERDAY' => 'ahir',
-    // STIC-Custom 20241126 ART - Translated Default Datetime Values
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/488
     'LBL_NOW' => 'ara',
-    // END STIC-Custom
     'LBL_TODAY' => 'avui',
     'LBL_TOMORROW' => 'demà',
     'LBL_NEXT_WEEK' => 'la setmana vinent',

--- a/include/language/ca_ES.lang.php
+++ b/include/language/ca_ES.lang.php
@@ -2054,25 +2054,25 @@ $app_strings = array(
     'LBL_YESTERDAY' => 'ahir',
     // STIC-Custom 20241126 ART - Translated Default Datetime Values
     // https://github.com/SinergiaTIC/SinergiaCRM/pull/488
-    'LBL_NOW' => 'ahora',
+    'LBL_NOW' => 'ara',
     // END STIC-Custom
     'LBL_TODAY' => 'avui',
     'LBL_TOMORROW' => 'demà',
     'LBL_NEXT_WEEK' => 'la setmana vinent',
     'LBL_NEXT_MONDAY' => 'el dilluns vinent',
     'LBL_NEXT_FRIDAY' => 'el divendres vinent',
-    'LBL_TWO_WEEKS' => 'dues setmanes',
+    'LBL_TWO_WEEKS' => "d'aquí a dues setmanes",
     'LBL_NEXT_MONTH' => 'el mes vinent',
     'LBL_FIRST_DAY_OF_NEXT_MONTH' => 'el primer dia del mes vinent',
-    'LBL_THREE_MONTHS' => 'tres mesos',
-    'LBL_SIXMONTHS' => 'sis mesos',
-    'LBL_NEXT_YEAR' => 'l\'any següent',
+    'LBL_THREE_MONTHS' => "d'aquí a tres mesos",
+    'LBL_SIXMONTHS' => "d'aquí a sis mesos",
+    'LBL_NEXT_YEAR' => "l'any vinent",
 
     //Datetimecombo fields
     'LBL_HOURS' => 'Hores',
     'LBL_MINUTES' => 'Minuts',
     'LBL_MERIDIEM' => 'Meridiem',
-    'LBL_DATE' => 'Fecha',
+    'LBL_DATE' => 'Data',
     'LBL_DASHLET_CONFIGURE_AUTOREFRESH' => 'Auto-Refrescar',
 
     'LBL_DURATION_DAY' => 'dia',
@@ -2083,9 +2083,9 @@ $app_strings = array(
     'LBL_DURATION_MINUTES' => 'Minuts de durada',
 
     //Calendar widget labels
-    'LBL_CHOOSE_MONTH' => 'Triï mes',
-    'LBL_ENTER_YEAR' => 'Triï any',
-    'LBL_ENTER_VALID_YEAR' => 'Si us plau, entri un any vàlid',
+    'LBL_CHOOSE_MONTH' => 'Trieu el mes',
+    'LBL_ENTER_YEAR' => "Trieu l'any",
+    'LBL_ENTER_VALID_YEAR' => 'Indiqueu un any vàlid',
 
     //File write error label
     'ERR_FILE_WRITE' => 'Error: No es pot escriure el fitxer {0}. Si us plau, comprovi els permisos del sistema i del servidor web.',

--- a/include/language/ca_ES.lang.php
+++ b/include/language/ca_ES.lang.php
@@ -2052,6 +2052,10 @@ $app_strings = array(
     'LBL_DESCRIPTION' => 'Descripció',
 
     'LBL_YESTERDAY' => 'ahir',
+    // STIC-Custom 20241126 ART - Translated Default Datetime Values
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    'LBL_NOW' => 'ahora',
+    // END STIC-Custom
     'LBL_TODAY' => 'avui',
     'LBL_TOMORROW' => 'demà',
     'LBL_NEXT_WEEK' => 'la setmana vinent',

--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -2000,7 +2000,7 @@ $app_strings = array(
 
     'LBL_YESTERDAY' => 'yesterday',
     // STIC-Custom 20241126 ART - Translated Default Datetime Values
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/488
     'LBL_NOW' => 'now',
     // END STIC-Custom
     'LBL_TODAY' => 'today',

--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -1999,6 +1999,10 @@ $app_strings = array(
     'LBL_DESCRIPTION' => 'Description',
 
     'LBL_YESTERDAY' => 'yesterday',
+    // STIC-Custom 20241126 ART - Translated Default Datetime Values
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    'LBL_NOW' => 'now',
+    // END STIC-Custom
     'LBL_TODAY' => 'today',
     'LBL_TOMORROW' => 'tomorrow',
     'LBL_NEXT_WEEK' => 'next week',

--- a/include/language/es_ES.lang.php
+++ b/include/language/es_ES.lang.php
@@ -2056,7 +2056,7 @@ $app_strings = array(
 
     'LBL_YESTERDAY' => 'Ayer',
     // STIC-Custom 20241126 ART - Translated Default Datetime Values
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/488
     'LBL_NOW' => 'ahora',
     // END STIC-Custom
     'LBL_TODAY' => 'hoy',

--- a/include/language/es_ES.lang.php
+++ b/include/language/es_ES.lang.php
@@ -2055,6 +2055,10 @@ $app_strings = array(
     'LBL_DESCRIPTION' => 'Descripción',
 
     'LBL_YESTERDAY' => 'Ayer',
+    // STIC-Custom 20241126 ART - Translated Default Datetime Values
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    'LBL_NOW' => 'ahora',
+    // END STIC-Custom
     'LBL_TODAY' => 'hoy',
     'LBL_TOMORROW' => 'mañana',
     'LBL_NEXT_WEEK' => 'la semana que viene',

--- a/include/language/es_ES.lang.php
+++ b/include/language/es_ES.lang.php
@@ -2054,7 +2054,7 @@ $app_strings = array(
     'LBL_ASSIGNED_TO_NAME' => 'Asignado a',
     'LBL_DESCRIPTION' => 'Descripción',
 
-    'LBL_YESTERDAY' => 'Ayer',
+    'LBL_YESTERDAY' => 'ayer',
     'LBL_NOW' => 'ahora',
     'LBL_TODAY' => 'hoy',
     'LBL_TOMORROW' => 'mañana',

--- a/include/language/es_ES.lang.php
+++ b/include/language/es_ES.lang.php
@@ -2055,10 +2055,7 @@ $app_strings = array(
     'LBL_DESCRIPTION' => 'Descripción',
 
     'LBL_YESTERDAY' => 'Ayer',
-    // STIC-Custom 20241126 ART - Translated Default Datetime Values
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/488
     'LBL_NOW' => 'ahora',
-    // END STIC-Custom
     'LBL_TODAY' => 'hoy',
     'LBL_TOMORROW' => 'mañana',
     'LBL_NEXT_WEEK' => 'la semana que viene',

--- a/include/language/gl_ES.lang.php
+++ b/include/language/gl_ES.lang.php
@@ -2054,7 +2054,7 @@ $app_strings = array(
     'LBL_ASSIGNED_TO_NAME' => 'Asignado a',
     'LBL_DESCRIPTION' => 'Descrición',
 
-    'LBL_YESTERDAY' => 'Onte',
+    'LBL_YESTERDAY' => 'onte',
     'LBL_NOW' => 'ahora',
     'LBL_TODAY' => 'hoxe',
     'LBL_TOMORROW' => 'mañá',

--- a/include/language/gl_ES.lang.php
+++ b/include/language/gl_ES.lang.php
@@ -2055,10 +2055,7 @@ $app_strings = array(
     'LBL_DESCRIPTION' => 'Descrición',
 
     'LBL_YESTERDAY' => 'Onte',
-    // STIC-Custom 20241126 ART - Translated Default Datetime Values
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/488
     'LBL_NOW' => 'ahora',
-    // END STIC-Custom
     'LBL_TODAY' => 'hoxe',
     'LBL_TOMORROW' => 'mañá',
     'LBL_NEXT_WEEK' => 'a semana que ven',

--- a/include/language/gl_ES.lang.php
+++ b/include/language/gl_ES.lang.php
@@ -2056,7 +2056,7 @@ $app_strings = array(
 
     'LBL_YESTERDAY' => 'Onte',
     // STIC-Custom 20241126 ART - Translated Default Datetime Values
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/488
     'LBL_NOW' => 'ahora',
     // END STIC-Custom
     'LBL_TODAY' => 'hoxe',

--- a/include/language/gl_ES.lang.php
+++ b/include/language/gl_ES.lang.php
@@ -2055,6 +2055,10 @@ $app_strings = array(
     'LBL_DESCRIPTION' => 'Descrición',
 
     'LBL_YESTERDAY' => 'Onte',
+    // STIC-Custom 20241126 ART - Translated Default Datetime Values
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    'LBL_NOW' => 'ahora',
+    // END STIC-Custom
     'LBL_TODAY' => 'hoxe',
     'LBL_TOMORROW' => 'mañá',
     'LBL_NEXT_WEEK' => 'a semana que ven',

--- a/modules/DynamicFields/templates/Fields/TemplateDatetimecombo.php
+++ b/modules/DynamicFields/templates/Fields/TemplateDatetimecombo.php
@@ -49,7 +49,7 @@ class TemplateDatetimecombo extends TemplateRange
     public $type = 'datetimecombo';
     public $len = '';
     // STIC-Custom 20241126 ART - Translated Default Datetime Values
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/488
     // public $dateStrings = array(
     //     '-none-' => '',
     //     // STIC-Custom 20221229 AAM - Adding "now" option to default datetime values

--- a/modules/DynamicFields/templates/Fields/TemplateDatetimecombo.php
+++ b/modules/DynamicFields/templates/Fields/TemplateDatetimecombo.php
@@ -48,26 +48,54 @@ class TemplateDatetimecombo extends TemplateRange
 {
     public $type = 'datetimecombo';
     public $len = '';
-    public $dateStrings = array(
-        '-none-' => '',
-        // STIC-Custom 20221229 AAM - Adding "now" option to default datetime values
-        // STIC#949
-        // 'today'=>'now',
-        'now' => 'now',
-        'today'=> 'today',
-        // END STIC-Custom
-        'yesterday'=> '-1 day',
-        'tomorrow'=>'+1 day',
-        'next week'=> '+1 week',
-        'next monday'=>'next monday',
-        'next friday'=>'next friday',
-        'two weeks'=> '+2 weeks',
-        'next month'=> '+1 month',
-        'first day of next month'=> 'first of next month', // must handle this non-GNU date string in SugarBean->populateDefaultValues; if we don't this will evaluate to 1969...
-        'three months'=> '+3 months',  //kbrill Bug #17023
-        'six months'=> '+6 months',
-        'next year'=> '+1 year',
-    );
+    // STIC-Custom 20241126 ART - Translated Default Datetime Values
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // public $dateStrings = array(
+    //     '-none-' => '',
+    //     // STIC-Custom 20221229 AAM - Adding "now" option to default datetime values
+    //     // STIC#949
+    //     // 'today'=>'now',
+    //     'now' => 'now',
+    //     'today'=> 'today',
+    //     // END STIC-Custom
+    //     'yesterday'=> '-1 day',
+    //     'tomorrow'=>'+1 day',
+    //     'next week'=> '+1 week',
+    //     'next monday'=>'next monday',
+    //     'next friday'=>'next friday',
+    //     'two weeks'=> '+2 weeks',
+    //     'next month'=> '+1 month',
+    //     'first day of next month'=> 'first of next month', // must handle this non-GNU date string in SugarBean->populateDefaultValues; if we don't this will evaluate to 1969...
+    //     'three months'=> '+3 months',  //kbrill Bug #17023
+    //     'six months'=> '+6 months',
+    //     'next year'=> '+1 year',
+    // );
+    public $dateStrings;
+
+    public function __construct()
+    {
+        parent::__construct();
+        global $app_strings;
+        $this->dateStrings = array(
+            $app_strings['LBL_NONE']=>'',
+            $app_strings['LBL_NOW'] => 'now',
+            $app_strings['LBL_YESTERDAY']=> '-1 day',
+            $app_strings['LBL_TODAY']=>'today',
+            $app_strings['LBL_TOMORROW']=>'+1 day',
+            $app_strings['LBL_NEXT_WEEK']=> '+1 week',
+            $app_strings['LBL_NEXT_MONDAY']=>'next monday',
+            $app_strings['LBL_NEXT_FRIDAY']=>'next friday',
+            $app_strings['LBL_TWO_WEEKS']=> '+2 weeks',
+            $app_strings['LBL_NEXT_MONTH']=> '+1 month',
+            // Changed the value because “first of next moth” was generating an error
+            // https://github.com/SinergiaTIC/SinergiaCRM/issues/99
+            $app_strings['LBL_FIRST_DAY_OF_NEXT_MONTH']=> 'first day of next month', // must handle this non-GNU date string in SugarBean->populateDefaultValues; if we don't this will evaluate to 1969...
+            $app_strings['LBL_THREE_MONTHS']=> '+3 months',  //kbrill Bug #17023
+            $app_strings['LBL_SIXMONTHS']=> '+6 months',
+            $app_strings['LBL_NEXT_YEAR']=> '+1 year',
+        );
+    }
+    // END STIC-Custom
     
     public $hoursStrings = array(
         '' => '',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/466
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/99

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Este PR resuelve dos incidencias.
1. La primera, como se describe en el issue, se detectaba que en la vista de creación/edición de campos de Estudio, para campos de tipo DateTime, los valores por defecto a seleccionar no se muestran en los diferentes idiomas, si no que se muestran siempre en inglés.
2. En la segunda, se detecta que si se selecciona el Valor por defecto "first day of next month" para un campo de tipo "DateTime", de cualquier módulo, la instancia da un error que la deja inutilizable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. Se ha añadido la función del constructor junto a `$app_strings` donde se recoge las etiquetas del desplegable. Generando dicho desplegable.
2. Se ha corregido el valor `"first of next month"` que estaba generando problema, por `"first day of next month"`.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Ir a Estudio, a un módulo cualquiera y añadir un campo.
3. Crear un campo de tipo Fecha y hora (DateTime) y comprobar que se muestra la lista de los valores por defecto en el idioma que el usuario ha seleccionado en el login o tiene la instancia por defecto.
4. Además, comprobar que al seleccionar "primer día del próximo mes" (first day of next month), se puede guardar el campo y se visualiza correctamente sin generar un error que impide acceder a "Administración".
