### PR TITLE
Hotfix - Encuestas - Evitar poder accionar el botón de envío de respuesta a encuesta repetidamente

### DIFF
--- a/modules/Surveys/Entry/Survey.php
+++ b/modules/Surveys/Entry/Survey.php
@@ -145,7 +145,11 @@ EOF;
 function displaySurvey($survey, $contactId, $trackerId)
 {
     ?>
-    <form method="post">
+    <!-- STIC-Custom 20241126 - JBL - Disable Submit when clicked -->
+    <!-- https://github.com/SinergiaTIC/SinergiaCRM/pull/ -->
+    <!-- <form method="post"> -->
+    <form method="post" onsubmit="disableSubmitButton(this)">
+    <!-- END STIC-Custom -->
         <input type="hidden" name="entryPoint" value="surveySubmit">
         <input type="hidden" name="id" value="<?= $survey->id ?>">
         <input type="hidden" name="contact" value="<?= $contactId ?>">
@@ -163,6 +167,14 @@ function displaySurvey($survey, $contactId, $trackerId)
     } ?>
         <button class="btn btn-primary" type="submit"><?php echo $survey->getSubmitText(); ?></button>
     </form>
+    <!-- STIC-Custom 20241126 - JBL - Disable Submit when clicked -->
+    <!-- https://github.com/SinergiaTIC/SinergiaCRM/pull/ -->
+    <script>
+        function disableSubmitButton(form) {
+            form.querySelector('button[type="submit"]').disabled = true; 
+        }
+    </script>
+    <!-- END STIC-Custom -->
     <?php
 }
 

--- a/modules/Surveys/Entry/Survey.php
+++ b/modules/Surveys/Entry/Survey.php
@@ -146,7 +146,7 @@ function displaySurvey($survey, $contactId, $trackerId)
 {
     ?>
     <!-- STIC-Custom 20241126 - JBL - Disable Submit when clicked -->
-    <!-- https://github.com/SinergiaTIC/SinergiaCRM/pull/ -->
+    <!-- https://github.com/SinergiaTIC/SinergiaCRM/pull/490 -->
     <!-- <form method="post"> -->
     <form method="post" onsubmit="disableSubmitButton(this)">
     <!-- END STIC-Custom -->
@@ -168,7 +168,7 @@ function displaySurvey($survey, $contactId, $trackerId)
         <button class="btn btn-primary" type="submit"><?php echo $survey->getSubmitText(); ?></button>
     </form>
     <!-- STIC-Custom 20241126 - JBL - Disable Submit when clicked -->
-    <!-- https://github.com/SinergiaTIC/SinergiaCRM/pull/ -->
+    <!-- https://github.com/SinergiaTIC/SinergiaCRM/pull/490 -->
     <script>
         function disableSubmitButton(form) {
             form.querySelector('button[type="submit"]').disabled = true; 


### PR DESCRIPTION
- Closes #489

## Descripción
Como se describe en #489, en los formularios de respuesta a una encuesta, se enviaban tantas respuestas como clics seamos capaces de hacer al submit correspondiente, antes de la redirección habitual. 

## Solución propuesta
Se ha modificado el código del formulario de respuesta para que deshabilite el botón de envio (submit) al enviar los datos (en la primera activación del botón)

## Pruebas
1. Crear una encuesta y hacerla pública
2. Acceder al link de la encuesta, responderla 
3. Intentar presionar repetidamente el botón "submit"
4. Verificar que no ha sido posible accionar repetidamente el botón "Submit".
5. En el crm, en la encuesta, verificar que solo tiene las respuestas correctas (no aparecen repetidas)

