### PR TITLE
Improvement - Actividades - En Reuniones, al hacer un KReport no aparece la relación que tiene con proyectos

### DIFF
--- a/modules/Meetings/vardefs.php
+++ b/modules/Meetings/vardefs.php
@@ -439,21 +439,14 @@ $dictionary['Meeting'] = array('table' => 'meetings',
                 'vname' => 'LBL_NOTES',
             ),
         // STIC-Custom 20241128 EPS - Add vardefs for existing relationship with projects
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/493
         'projects' =>
             array(
                 'name' => 'projects',
                 'type' => 'link',
-                'relationship' => 'projects_tasks',
+                'relationship' => 'projects_meetings',
                 'source' => 'non-db',
                 'vname' => 'LBL_PROJECTS',
-            ),
-        'project_tasks' =>
-            array(
-                'name' => 'project_tasks',
-                'type' => 'link',
-                'relationship' => 'project_tasks_tasks',
-                'source' => 'non-db',
-                'vname' => 'LBL_PROJECT_TASKS',
             ),
         // ENS STIC-Custom
         'contact_id' => array(

--- a/modules/Meetings/vardefs.php
+++ b/modules/Meetings/vardefs.php
@@ -438,6 +438,24 @@ $dictionary['Meeting'] = array('table' => 'meetings',
                 'source' => 'non-db',
                 'vname' => 'LBL_NOTES',
             ),
+        // STIC-Custom 20241128 EPS - Add vardefs for existing relationship with projects
+        'projects' =>
+            array(
+                'name' => 'projects',
+                'type' => 'link',
+                'relationship' => 'projects_tasks',
+                'source' => 'non-db',
+                'vname' => 'LBL_PROJECTS',
+            ),
+        'project_tasks' =>
+            array(
+                'name' => 'project_tasks',
+                'type' => 'link',
+                'relationship' => 'project_tasks_tasks',
+                'source' => 'non-db',
+                'vname' => 'LBL_PROJECT_TASKS',
+            ),
+        // ENS STIC-Custom
         'contact_id' => array(
             'name' => 'contact_id',
             'type' => 'id',


### PR DESCRIPTION
- Closes #492 

## Descripción
Tal como se comenta en #492, el módulo de Meetings no tiene en los vardefs ninguna referencia a la relación que tiene con Projects, a diferencia de lo que sucede con Tasks. Eso hace que al seleccionar el módulo en KReports no se muestre la relación con Projects.
En este PR se añade a los vardefs de Meetings los mismos campos que tiene Tasks para que funcione la relación.

## How To Test This
1. Crear una Reunión relacionada con un proyecto
2. Crear un informe de KReports basado en elmódulo de Reuniones
3. Comprobar que se puede acceder al módulo d eProyectos a partir del de Reuniones
4. Comrpobar al ejecutar el informe que aparece el proyecto correcto 

