### PR TITLE
Hotfix - KReports - Escapar valores del where (apóstrofe en concreto) para evitar errores SQL al filtrar

### DIFF
--- a/modules/KReports/KReportQuery.php
+++ b/modules/KReports/KReportQuery.php
@@ -1647,7 +1647,8 @@ class KReportQuery {
             break;
       }
       // process the operator
-      // STIC-Custom EPS 20241205
+      // STIC-Custom EPS 20241205 - quote the value to avoid errors when certain values are used (apostrophe)
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/505
       $value = $db->quote($value);
       // END STIC-Custom
       switch ($operator) {

--- a/modules/KReports/KReportQuery.php
+++ b/modules/KReports/KReportQuery.php
@@ -1549,6 +1549,7 @@ class KReportQuery {
    function getWhereOperatorClause($operator, $fieldname, $fieldid, $path, $value, $valuekey, $valueto, $valuetokey = '', $jointype = '') {
       global $current_user;
       // STIC-Custom EPS 20241205
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/505
       $db = DBManagerFactory::getInstance();
       // ENS STIC-Custom
 

--- a/modules/KReports/KReportQuery.php
+++ b/modules/KReports/KReportQuery.php
@@ -1548,6 +1548,9 @@ class KReportQuery {
 
    function getWhereOperatorClause($operator, $fieldname, $fieldid, $path, $value, $valuekey, $valueto, $valuetokey = '', $jointype = '') {
       global $current_user;
+      // STIC-Custom EPS 20241205
+      $db = DBManagerFactory::getInstance();
+      // ENS STIC-Custom
 
       // initialize
       $thisWhereString = '';
@@ -1644,6 +1647,9 @@ class KReportQuery {
             break;
       }
       // process the operator
+      // STIC-Custom EPS 20241205
+      $value = $db->quote($value);
+      // END STIC-Custom
       switch ($operator) {
          case 'autocomplete':
             $thisWhereString .= ' = \'' . $value . '\'';


### PR DESCRIPTION
- Closes #479 

## Descripción
Tal como se explica en #479, cuando se realiza una búsqueda en KReports por un string que contiene apóstrofes (típico en catalán), se generan errores SQL que hacen que no se devuelva ningún resultado.
En lugar de escapar directamente el apóstrofe se ha optado por utilizar la función $db->quote que ya proporciona SuiteCRM.
Se ha revisado tanto la búsqueda con equals en un string cómo otros operadores (empieza por, contiene...). También se ha probado que al hacer el quote no afecta a otros tipos de datos (fecha, número, lista, selección múltiple).
En KReportQuery.php:1651, observando el switch se puede ver las distintas condiciones para los distintos cómo se construyen, lo que puede contribuir a buscar la manera de encontrar unfallo por el hecho de haber utilizado el quote.

## How To Test This
1.- Crear una organización con un apóstrofe en el nombre
2.- Crear un informe que permita filtrar por nombre de organización
3.- Comprobar que el filtro funciona correctamente tanto para literales con apóstrofe como para literales que no
4.- Probar distintos filtros con tipo de datos "texto" para ver que todos se comportan correctamente
5.- Probar a aplicar filtros en otros tipos de campo para cerciorarse que no se ven afectados

