### PR TITLE
Improvement - Flujos de trabajo - Deshacer cambios y modificar índice de búsqueda

### DIFF
--- a/modules/AOW_Processed/vardefs.php
+++ b/modules/AOW_Processed/vardefs.php
@@ -169,7 +169,10 @@ $dictionary['AOW_Processed'] = array(
         array(
             'name' => 'aow_processed_index_workflow',
             'type' => 'index',
-            'fields' => array('aow_workflow_id','status','parent_id','deleted'),
+            // STIC-Custom EPS 20241204
+            // 'fields' => array('aow_workflow_id','status','parent_id','deleted'),
+            'fields' => array('aow_workflow_id','parent_id','status','deleted'),
+            //END STIC-Custom
         ),
         array(
             'name' => 'aow_processed_index_status',

--- a/modules/AOW_Processed/vardefs.php
+++ b/modules/AOW_Processed/vardefs.php
@@ -170,6 +170,7 @@ $dictionary['AOW_Processed'] = array(
             'name' => 'aow_processed_index_workflow',
             'type' => 'index',
             // STIC-Custom EPS 20241204
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/507
             // 'fields' => array('aow_workflow_id','status','parent_id','deleted'),
             'fields' => array('aow_workflow_id','parent_id','status','deleted'),
             //END STIC-Custom

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -701,11 +701,7 @@ class AOW_WorkFlow extends Basic
 
         if (!$this->multiple_runs) {
             $processed = BeanFactory::getBean('AOW_Processed');
-            // STIC-Custom 20240930 EPS - Uso del índice y prevención de errores si hay alguna ejecución no completada
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/411
-            // $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id, 'parent_id' => $bean->id));
-            $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id, 'parent_id' => $bean->id, 'status' => 'Complete'));
-            // END STIC-Custom
+            $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id, 'parent_id' => $bean->id));
 
             if ($processed->status === 'Complete') {
                 //has already run so return false
@@ -1030,11 +1026,7 @@ class AOW_WorkFlow extends Basic
         require_once('modules/AOW_Processed/AOW_Processed.php');
         $processed = BeanFactory::newBean('AOW_Processed');
         if (!$this->multiple_runs) {
-            // STIC-Custom 20240930 EPS - Uso del índice y prevención de errores si hay alguna ejecución no completada
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/411
-            // $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id,'parent_id' => $bean->id));
-            $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id,'parent_id' => $bean->id, 'status' => 'Complete'));
-            // END STIC-Custom
+            $processed->retrieve_by_string_fields(array('aow_workflow_id' => $this->id,'parent_id' => $bean->id));
 
             if ($processed->status == 'Complete') {
                 //should not have gotten this far, so return


### PR DESCRIPTION
## Descripción
Se eliminan los cambios introducidos en el PR #411 debido a que podían provocar, indebidamente, la re-ejecución de algunas acciones de flujos que hubieran fallado previamente.

Se modifica el índice aow_processed_index_workflow, moviendo el campo parent_id delante del campo status para dar respuesta a las búsquedas que se realizan para comprobar si un flujo ya se ha ejecutado sobre un registro, donde no se utiliza el campo status.

Se han realizado búsquedas en el código para detectar si había algún punto en que se estuviera utilizando parcialmente el índice con el workflow_id y el status pero sin el parent_id. Al no encontrase ningúncaso se considera segura la modificación del índice.

## Pruebas
1.- Definir un flujo, sin ejecuciones múltiples y con varias acciones. Una de las acciones debe fallar (por ejemplo un envío de e-mail) y otra debe realizarse correctamente (por ejemplo modificar el registro)
2.- Ejecutar el flujo sobre algún registro y comprobar que una acción ha quedado completado y la otra fallada y que el flujo queda como fallado.
3.- Ejecutar de nuevo la acción que provocaba que se ejecutase el flujo y comprobar que sólo se vuelve a intentar ejecutar la acción que falló


