### PR TITLE
Hotfix - Formularios - Chequeo de variables vacías

### DIFF
--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
@@ -485,7 +485,7 @@ class PaymentController extends WebFormDataController {
         ];
 
         foreach ($requiredConsts as $key) {
-            if (empty($settings[$key])) {
+            if (empty($settings[$key]) && $settings[$key] != 0 ) { 
                 $GLOBALS['log']->fatal('Line ' . __LINE__ . ': ' . __METHOD__ . ": The setting {$key} is missing or empty.");
                 $this->returnCode('UNEXPECTED_ERROR');
                 return $this->feedBackError($this);


### PR DESCRIPTION
Se evita que el chequeo del setting TPVCECA_TEST sea evaluado como inexistente al contener el valor 0, lo que ocurre en entornos de producción con el TPV CECA en modo real, evitando que se genere un error que impide que continúe el proceso que lanza la pasarela de pago CECA.

En la corrección empleada se valida que el valor de las variables además de estar vacías sean distintas de 0.

**Pruebas a realizar**
- Rellenar las variables de CECA con los siguientes valores fake (se puede hacer una importación e actualización)
[settings.csv](https://github.com/user-attachments/files/18058548/settings.csv)
- Preparar un formulario de captación de fondos y enviarlo usando Tarjeta (Vía CECA)
- Verificar que el proceso no se interrumpe y se muestra la página de CECA (aunque mostrará _NO AUTORIZADA_, puesto que los datos de validación no son correctos)
![image](https://github.com/user-attachments/assets/0d16ffdd-bde0-4d3b-b402-f3727ab077ce)
En caso de que error persistiera, se mostraría la ṕagina de error configurada en el formulario.





