### PR TITLE
Improvement - Validación de importación - Eliminar validación innecesaria del proceso de validación de importación

### DIFF
--- a/modules/stic_Import_Validation/ImporterValidationFunctions.php
+++ b/modules/stic_Import_Validation/ImporterValidationFunctions.php
@@ -39,10 +39,10 @@ function identificationNumberValidation($module, $rowValue, $row)
             // since in $row we have the label and not the key
             global $app_list_strings;
             $identification_types_list = $app_list_strings['stic_contacts_identification_types_list'];
-            $existLabel = false;
+            // $existLabel = false;
             foreach ($identification_types_list as $key => $value) {
                 if (!empty($value) && in_array($value, $row)){
-                    $existLabel = true;   
+                    // $existLabel = true;   
                     // If the stic_identification_type_c field is mapped and its value is NIF or NIE
                     if ($value == $identification_types_list['nif'] || $value == $identification_types_list['nie']) {
                         return SticUtils::isValidNIForNIE($rowValue) ? $rowValue : 'LBL_ERROR_INVALID_IDENTIFICATION_NUMBER';
@@ -51,10 +51,14 @@ function identificationNumberValidation($module, $rowValue, $row)
                     } 
                 }
             }
+
+            // This validation is cancelled because the CRM has a LH that calculates the Identification Type in case this field is not informed and the Identification Number field is.
+            // More information at:
             // If there is no label, it means that the Identification type field has not been mapped
-            if (!$existLabel) {
-                return 'LBL_ERROR_INVALID_IDENTIFICATION_NUMBER_MISSING_TYPE_FIELD';
-            }
+            // if (!$existLabel) {
+            //     return 'LBL_ERROR_INVALID_IDENTIFICATION_NUMBER_MISSING_TYPE_FIELD';
+            // }
+            return true;
             break;
 
         default:


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/510

## Descripción
Este PR implementa la solución propuesta en el issue relacionado.


## Pruebas
1. Crear una persona con **Tipo de identificación** y **Número de identificación**
2. Exportarlo y eliminar todas las columnas menos las de **Apellido**, **Tipo de identificación** y **Número de identificación**
3. Eliminar el valor del campo **Tipo de identificación**
4. Realizar la validación del fichero de importación y comprobar que el proceso indica que el registro ha sido validado correctamente. 
5. Duplicar el fichero y eliminar la columna de Número de identificación. 
6. Realizar la validación del fichero de importación y comprobar que el proceso indica que el registro ha sido validado correctamente. 
7. Importar el fichero y comprobar que el CRM, durante la importación, ha indicado el campo **Tipo de identificación** aunque en el fichero de importación no estuviera indicado. 
