### PR TITLE
Hotfix - Pagos agregados - Calcular correctamente los pagos agregados de Compromisos de Pago sin "Asignado a"

### DIFF
--- a/modules/stic_Payments/AggregatePayments.php
+++ b/modules/stic_Payments/AggregatePayments.php
@@ -49,17 +49,17 @@ $includedPaymentsQuery = "SELECT
     u.last_name as 'assigned_user_last_name',
     u.first_name as 'assigned_user_first_name',
     u.user_name as 'assigned_user_user_name',
-    u.id as 'assigned_user_id'
+    u.id as 'assigned_user_id',
+    u.deleted as 'assigned_user_deleted'
 FROM
     stic_payments sp
-JOIN users u
+LEFT JOIN users u
 ON
     sp.assigned_user_id = u.id
 JOIN stic_payments_stic_payment_commitments_c spspcc 
     ON sp.id = spspcc.stic_payments_stic_payment_commitmentsstic_payments_idb
 WHERE
     sp.deleted = 0
-    AND u.deleted = 0
     AND MONTH(sp.payment_date) = MONTH(NOW())
     AND YEAR(sp.payment_date) = YEAR(NOW())
     AND sp.payment_type = 'aggregated_services'
@@ -106,7 +106,8 @@ $warningAttendanceQuery = "SELECT
     u.last_name as 'assigned_user_last_name',
     u.first_name as 'assigned_user_first_name',
     u.user_name as 'assigned_user_user_name',
-    u.id as 'assigned_user_id'
+    u.id as 'assigned_user_id',
+    u.deleted as 'assigned_user_deleted'
 FROM
     stic_payments sp
 JOIN stic_payments_stic_payment_commitments_c spspcc
@@ -127,7 +128,7 @@ ON
 JOIN stic_attendances sa
 ON
     sasrc.stic_attendances_stic_registrationsstic_attendances_idb = sa.id
-JOIN users u
+LEFT JOIN users u
 ON
     sa.assigned_user_id = u.id
 WHERE
@@ -183,8 +184,20 @@ while ($row = $db->fetchByAssoc($res)) {
 
     $warningAttendancesData[$warningAttendances]['name'] = SticUtils::createLinkToDetailView('stic_Attendances', $row['attendance_id'], $row['attendance_name']);
     $warningAttendancesData[$warningAttendances]['attendance_id'] = $attendanceId;
-    $warningAttendancesData[$warningAttendances]['assigned_user_id'] = $row['assigned_user_id'];
-    $warningAttendancesData[$warningAttendances]['assigned_user'] = SticUtils::createLinkToDetailView('Users', $row['assigned_user_id'], $row['assigned_user_first_name'] . ' ' . $row['assigned_user_last_name'] . ' (' . $row['assigned_user_user_name'] . ')');
+
+    if ($row['assigned_user_id'] != null) {
+        $warningAttendancesData[$warningAttendances]['assigned_user_id'] = $row['assigned_user_id'];
+        if ($row['assigned_user_deleted'] == 0) {
+            $warningAttendancesData[$warningAttendances]['assigned_user'] = SticUtils::createLinkToDetailView('Users', $row['assigned_user_id'], $row['assigned_user_first_name'] . ' ' . $row['assigned_user_last_name'] . ' (' . $row['assigned_user_user_name'] . ')');
+        } else {
+            // For deleted users: show only user name
+            $warningAttendancesData[$warningAttendances]['assigned_user'] = SticUtils::createLinkToDetailView('Users', $row['assigned_user_id'], $row['assigned_user_user_name']);
+        }
+    }
+    else {
+        $warningAttendancesData[$warningAttendances]['assigned_user_id'] = "";
+        $warningAttendancesData[$warningAttendances]['assigned_user'] = "";
+    }
     $warningAttendances++;
 
     // Build an array of uncomplete payments (because of warning attendances)
@@ -309,8 +322,21 @@ $warningPayments = 0;
 foreach ($includedPaymentsData as $includedPaymentId => $includedPaymentData) {
     if (!in_array($includedPaymentId, $uncompletePaymentsId) && !in_array($includedPaymentId, $completePaymentsId)) {
         $warningPaymentsData[$warningPayments]['name'] = SticUtils::createLinkToDetailView('stic_Payments', $includedPaymentData['payment_id'], $includedPaymentData['payment_name']);
-        $warningPaymentsData[$warningPayments]['assigned_user_id'] = $includedPaymentData['assigned_user_id'];
-        $warningPaymentsData[$warningPayments]['assigned_user'] = SticUtils::createLinkToDetailView('Users', $includedPaymentData['assigned_user_id'], $includedPaymentData['assigned_user_first_name'] . ' ' . $includedPaymentData['assigned_user_last_name'] . ' (' . $includedPaymentData['assigned_user_user_name'] . ')');
+
+
+        if ($includedPaymentData['assigned_user_id'] != null) {
+            $warningPaymentsData[$warningPayments]['assigned_user_id'] = $includedPaymentData['assigned_user_id'];
+            if ($row['assigned_user_deleted'] == 0) {
+                $warningPaymentsData[$warningPayments]['assigned_user'] = SticUtils::createLinkToDetailView('Users', $includedPaymentData['assigned_user_id'], $includedPaymentData['assigned_user_first_name'] . ' ' . $includedPaymentData['assigned_user_last_name'] . ' (' . $includedPaymentData['assigned_user_user_name'] . ')');
+            } else {
+                // For deleted users: show only user name
+                $warningPaymentsData[$warningPayments]['assigned_user'] = SticUtils::createLinkToDetailView('Users', $includedPaymentData['assigned_user_id'], $includedPaymentData['assigned_user_user_name']);
+            }
+        }
+        else {
+            $warningPaymentsData[$warningPayments]['assigned_user_id'] = "";
+            $warningPaymentsData[$warningPayments]['assigned_user'] = "";
+        }
         $warningPayments++;
     }
 }

--- a/modules/stic_Payments/AggregatePayments.php
+++ b/modules/stic_Payments/AggregatePayments.php
@@ -185,18 +185,17 @@ while ($row = $db->fetchByAssoc($res)) {
     $warningAttendancesData[$warningAttendances]['name'] = SticUtils::createLinkToDetailView('stic_Attendances', $row['attendance_id'], $row['attendance_name']);
     $warningAttendancesData[$warningAttendances]['attendance_id'] = $attendanceId;
 
+    $warningAttendancesData[$warningAttendances]['assigned_user_id'] = "";
+    $warningAttendancesData[$warningAttendances]['assigned_user'] = "";
+
     if ($row['assigned_user_id'] != null) {
-        $warningAttendancesData[$warningAttendances]['assigned_user_id'] = $row['assigned_user_id'];
         if ($row['assigned_user_deleted'] == 0) {
+            $warningAttendancesData[$warningAttendances]['assigned_user_id'] = $row['assigned_user_id'];
             $warningAttendancesData[$warningAttendances]['assigned_user'] = SticUtils::createLinkToDetailView('Users', $row['assigned_user_id'], $row['assigned_user_first_name'] . ' ' . $row['assigned_user_last_name'] . ' (' . $row['assigned_user_user_name'] . ')');
         } else {
             // For deleted users: show only user name
-            $warningAttendancesData[$warningAttendances]['assigned_user'] = SticUtils::createLinkToDetailView('Users', $row['assigned_user_id'], $row['assigned_user_user_name']);
+            $warningAttendancesData[$warningAttendances]['assigned_user'] = $row['assigned_user_user_name'];
         }
-    }
-    else {
-        $warningAttendancesData[$warningAttendances]['assigned_user_id'] = "";
-        $warningAttendancesData[$warningAttendances]['assigned_user'] = "";
     }
     $warningAttendances++;
 
@@ -323,19 +322,17 @@ foreach ($includedPaymentsData as $includedPaymentId => $includedPaymentData) {
     if (!in_array($includedPaymentId, $uncompletePaymentsId) && !in_array($includedPaymentId, $completePaymentsId)) {
         $warningPaymentsData[$warningPayments]['name'] = SticUtils::createLinkToDetailView('stic_Payments', $includedPaymentData['payment_id'], $includedPaymentData['payment_name']);
 
-
+        $warningPaymentsData[$warningPayments]['assigned_user_id'] = "";
+        $warningPaymentsData[$warningPayments]['assigned_user'] = "";
+    
         if ($includedPaymentData['assigned_user_id'] != null) {
-            $warningPaymentsData[$warningPayments]['assigned_user_id'] = $includedPaymentData['assigned_user_id'];
-            if ($row['assigned_user_deleted'] == 0) {
+            if ($includedPaymentData['assigned_user_deleted'] == 0) {
+                $warningPaymentsData[$warningPayments]['assigned_user_id'] = $includedPaymentData['assigned_user_id'];
                 $warningPaymentsData[$warningPayments]['assigned_user'] = SticUtils::createLinkToDetailView('Users', $includedPaymentData['assigned_user_id'], $includedPaymentData['assigned_user_first_name'] . ' ' . $includedPaymentData['assigned_user_last_name'] . ' (' . $includedPaymentData['assigned_user_user_name'] . ')');
             } else {
                 // For deleted users: show only user name
-                $warningPaymentsData[$warningPayments]['assigned_user'] = SticUtils::createLinkToDetailView('Users', $includedPaymentData['assigned_user_id'], $includedPaymentData['assigned_user_user_name']);
+                $warningPaymentsData[$warningPayments]['assigned_user'] = $includedPaymentData['assigned_user_user_name'];
             }
-        }
-        else {
-            $warningPaymentsData[$warningPayments]['assigned_user_id'] = "";
-            $warningPaymentsData[$warningPayments]['assigned_user'] = "";
         }
         $warningPayments++;
     }

--- a/modules/stic_Payments/tpls/AggregatePayments.tpl
+++ b/modules/stic_Payments/tpls/AggregatePayments.tpl
@@ -77,8 +77,10 @@
                     {$ITEM.assigned_user}
                 </td>
                 <td style="border-bottom: 0.5px inset silver;">
-                    <input type="button" id="{$ITEM.attendance_id}" name="{$ITEM.assigned_user_id}" onclick="sendEmail(this)"
-                        value="{$MOD.LBL_AGGREGATED_NOTIFICATION_BUTTON_SEND}">
+                    {if !empty($ITEM.assigned_user_id) }
+                        <input type="button" id="{$ITEM.attendance_id}" name="{$ITEM.assigned_user_id}" onclick="sendEmail(this)"
+                            value="{$MOD.LBL_AGGREGATED_NOTIFICATION_BUTTON_SEND}">
+                    {/if}
                 </td>
             </tr>
         {/foreach}


### PR DESCRIPTION
- Closes #512

## Descripción
Tal y como se describe en #512, en el PR #414 se corrigió un error relacionado con el cálculo de los Pagos agregados en el caso que existieran Pagos "no cerrados" de la persona, para el mismo mes pero de años diferentes.
En esta solución se unificó la obtención de "todos los pagos", "los pagos con alertas" y "los pagos a procesar".

Pero se restringió el número de pagos incluídos en el cálculo: No se procesaban aquellos cuyos campos "Asignado a" estuviese vacío o bién el usuario asignado estuviese borrado.

## Solución implementada
En la búsqueda de los ids de los pagos incluídos para los pagos agregados a procesar se ha cambiado el `JOIN` con la tabla `users` por un `LEFT JOIN`, para también tener en cuenta los pagos que no tengan usuario asignado.
También se ha eliminado la restricción que el usuario no esté eliminado. Esta información se obtiene en el resultado ya que será necesaria para mostrar el resumen.

En el resumen del proceso se muestran los pagos con alertas con el usuario asignado y la opción de enviarle un mensaje. Este resumen se ha modificado para adaptarlo:
- Si no existe usuario asignado, no se mostrará su información
- Si el usuario asignado está eliminado, se mostrará únicamente su nombre de usuario y no se permitirá enviarle un mensaje

## Pruebas
Las pruebas a realizar intentarán cubrir todos los casos:
1. Pago / Asistencia con "Asignado a"
2. Pago / Asistencia con "Asignado a" eliminado
3. Pago / Asistencia sin "Asignado a"

Y a demás, que cubra los posibles resultados:
1. Pago completado
2. Pago no completado (alguna asistencia no se ha podido procesar)
3. Pago con alerta (sin asistencias)

### Pasos
1. Crear un usuario (usrPR514): Administración -> Administración de usuarios
2. Crear tres Personas: Persona 1, Persona 2 y Persona 3
    1. Para cada Persona, crearle un Compromiso de Pago con: Importe: "0", Periodicidad: "Mensual", Tipo de pago: "Servicios agregados", Medio de pago: "Efectivo"
    2. En Asignado a: La Persona 1, el usuario actual, la Persona 2 el nuevo usuario (usrPR514), la Persona 3 sin usuario asignado
3. Crear un evento con fecha inicio el mes anterior, Estado "Activo", Importe de la sesión "5"
4. Crear 3 inscripciones al evento: Una para cada persona:
    1. Con Fecha de inscripción el mes anterior, Estado: "Participa"
    2. Indicar el Compromiso de Pago de la persona correspondiente
5. Crear 3 sesiones del evento en el mes anterior
    1. En Asignado a: La primera, el usuario actual, la segunda el nuevo usuario (usrPR514), la tercera sin usuario asignado
6. Eliminar el usuario usrPR514: Administración -> Administración de usuarios
7. En Pagos: Calcular los pagos agregados

**Verificar:**
1. Pagos incluídos: 3
2. Pagos no completados: 3
3. Asistencias incluídas: 9
4. Asistencias con alertas: 9
5. En las Asistencias con alertas:
    1. Sólo aparece "Enviar un correo" al usuario asignado actual
    2. El "Asignado a" para el usrPR514 sólo aparece el nombre de usuario y no es un enlace
    3. Aparecen las asistencias con alerta sin usuario asignado

**En Asistencias:**
1. Seleccionar los 9 registros de las asistencias de las 3 Personas.
2. Actualización masiva: Estado: "Sí"
3. En Pagos: Calcular los pagos agregados

**Verificar:**
1. Pagos incluídos: 3
2. Pagos completados: 3
3. Asistencias incluídas: 9
4. Asistencias procesadas: 9
5. En el listado de Pagos, los pagos de las 3 personas tienen importe de "15,00"

**En Asistencias:**
1. Eliminar los 9 registros de las asistencias de las 3 Personas
2. En Pagos: Calcular los pagos agregados

**Verificar:**
1. Pagos incluídos: 3
2. Pagos con alertas: 3
3. En los Pagos con alertas:
    1. El "Asignado a" para el usrPR514 sólo aparece el nombre de usuario y no es un enlace
    2. Aparece el pago con alerta sin usuario asignado
