### PR TITLE
Hotfix - Mail Merge - Cuando se generan plantillas desde vista lista con TODOS los registros seleccionados, se respeta el orden de la vista

### DIFF
--- a/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
+++ b/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
@@ -911,6 +911,7 @@ EOJS;
    }
    
    // STIC-Custom EPS 20241210 Generate order by from current query
+   // https://github.com/SinergiaTIC/SinergiaCRM/pull/515
    function generateOrderBy($queryBin64) {
       $queryData = base64_decode($queryBin64);
       $query = json_decode(html_entity_decode($queryData), true);
@@ -944,6 +945,7 @@ EOJS;
       elseif(isset($_REQUEST['mode']) && $_REQUEST['mode'] == 'entire') {
          $this->generateSearchWhere($_REQUEST['moduloplantilladocumento'], $_REQUEST['current_query_by_page']);
          // STIC-Custom EPS 20241210 Generate order_by from current_query
+         // https://github.com/SinergiaTIC/SinergiaCRM/pull/515
          $order_by = $this->generateOrderBy($_REQUEST['current_query_by_page']);
          // END STIC-Custom
          

--- a/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
+++ b/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
@@ -910,6 +910,27 @@ EOJS;
       unset($mass);
    }
    
+   // STIC-Custom EPS 20241210 Generate order by from current query
+   function generateOrderBy($queryBin64) {
+      $queryData = base64_decode($queryBin64);
+      $query = json_decode(html_entity_decode($queryData), true);
+
+      // The name of the request field that contains the order by field
+      $var_name = $this->sugarbean->module_dir.'2_'.strtoupper($this->sugarbean->object_name);
+      // $order_by_name = $this->sugarbean->module_dir.'2_'.strtoupper($this->sugarbean->object_name).'_ORDER_BY' ;
+      $order_by_name = $var_name.'_ORDER_BY' ;
+      if (empty($query[$order_by_name])) {
+         // If there is no order by field, then the default order must be applied. We retrieve it from user preferences
+         $userPreferenceOrder = $GLOBALS['current_user']->getPreference('listviewOrder', $var_name);
+         return $userPreferenceOrder['orderBy'].' '.$userPreferenceOrder['sortOrder'];
+      }
+
+      // the order of the field is contained on lvso field.
+      return $query[$order_by_name] . ' ' . $query['lvso'];
+   }
+   // END STIC-Custom
+
+
    ///////////////////////////////////////////////////////////////////////////////////////////////////      
    function handleMassGenerateDocument(){
       
@@ -922,6 +943,9 @@ EOJS;
       }
       elseif(isset($_REQUEST['mode']) && $_REQUEST['mode'] == 'entire') {
          $this->generateSearchWhere($_REQUEST['moduloplantilladocumento'], $_REQUEST['current_query_by_page']);
+         // STIC-Custom EPS 20241210 Generate order_by from current_query
+         $order_by = $this->generateOrderBy($_REQUEST['current_query_by_page']);
+         // END STIC-Custom
          
          if (version_compare($sugar_version, '6.4.5', '<')) {
             if(empty($order_by)) $order_by = '';


### PR DESCRIPTION
- Closes #513 
## Descripción
En la función de generación masiva de documento, hay 2 ramas: una para respetar los documentos seleccionados uno a uno (recoge la lista y ejecuta el orden tal como le llegan en la lista) y en la otra rama ejecuta cuando se ha seleccionado la opción de TODOS los registros. En esta última rama, se utilizaba la variable $order_by sin haber llegado a rellenarla nunca, por lo que no se respetaba ningún orden.
Se ha modificado la rama para recoger el orden establecido por el usuario y en caso de que no haya ordenado de ninguna manera, se recoge el orden de las preferencias de usuario (orden por defecto).

## Motivation and Context
Algunas entidades precisan que se respete el orden de la lista, por ejemplo al generar etiquetas postales.

## How To Test This
1.- En distintos elementos (personas, seguimientos, etc) crear una plantilla MMR
2.- Ir a la vista de lista, marcar una columna para que se ordene por dicha columna
3.- Seleccionar TODOS los registros y generar documento
4.- Comprobar que el orden en el documento es el mismo que en la vista de lista
5.- Volver a la lista de lista, invertir el orden de la columna seleccionada y generar de nuevo
6.- Comprobar que se recoge el sentido correctamente
7.- Salir de la vista lista, volver a ella y, sin marcar ninguna columna, generar el documento
8.- Comprobar que el orden es el por defecto de la vista
9.- En alguno de los módulos, generar el documento sin haber seleccionadonunca ningún orden y comrpobar que el documento se genera.... aunque aquí no podremos pedir ningún orden

