### PR TITLE
Hotfix - Importación - Evitar errores innecesarios en el log

### DIFF
--- a/modules/Import/Importer.php
+++ b/modules/Import/Importer.php
@@ -826,7 +826,9 @@ class Importer
      */
     public static function handleImportErrors($errno, $errstr, $errfile, $errline)
     {
-        $GLOBALS['log']->fatal("Caught error: $errstr");
+        // STIC-Custom EPS 20241217 Instead of writing always fatal errors, we use the corresponding log
+        // $GLOBALS['log']->fatal("Caught error: $errstr");
+        // END STIC-Custom
 
         if (!defined('E_DEPRECATED')) {
             define('E_DEPRECATED', '8192');
@@ -839,25 +841,40 @@ class Importer
         switch ($errno) {
             case E_USER_ERROR:
                 $message = "ERROR: [$errno] $errstr on line $errline in file $errfile<br />\n";
+                // STIC-Custom EPS 20241217 Instead of writing always fatal errors, we use the corresponding log
+                $GLOBALS['log']->fatal("Caught error: $errstr $errfile $errline");
+                // END STIC-Custom
                 $isFatal = true;
                 break;
             case E_USER_WARNING:
             case E_WARNING:
                 $message = "WARNING: [$errno] $errstr on line $errline in file $errfile<br />\n";
+                // STIC-Custom EPS 20241217 Instead of writing always fatal errors, we use the corresponding log
+                $GLOBALS['log']->warn("Caught error: $errstr $errfile $errline");
+                // END STIC-Custom
                 break;
             case E_USER_NOTICE:
             case E_NOTICE:
                 $message = "NOTICE: [$errno] $errstr on line $errline in file $errfile<br />\n";
+                // STIC-Custom EPS 20241217 Instead of writing always fatal errors, we use the corresponding log
+                $GLOBALS['log']->error("Caught error: $errstr $errfile $errline");
+                // END STIC-Custom
                 break;
             case E_STRICT:
             case E_DEPRECATED:
             case E_USER_DEPRECATED:
                 // don't worry about these
                 // $message = "STRICT ERROR: [$errno] $errstr on line $errline in file $errfile<br />\n";
+                // STIC-Custom EPS 20241217 Instead of writing always fatal errors, we use the corresponding log
+                $GLOBALS['log']->warn("Caught error: $errstr $errfile $errline");
+                // END STIC-Custom
                 $message = "";
                 break;
             default:
                 $message = "Unknown error type: [$errno] $errstr on line $errline in file $errfile<br />\n";
+                // STIC-Custom EPS 20241217 Instead of writing always fatal errors, we use the corresponding log
+                $GLOBALS['log']->fatal("Caught error: $errstr $errfile $errline");
+                // END STIC-Custom
                 break;
         }
 

--- a/modules/Import/Importer.php
+++ b/modules/Import/Importer.php
@@ -827,6 +827,7 @@ class Importer
     public static function handleImportErrors($errno, $errstr, $errfile, $errline)
     {
         // STIC-Custom EPS 20241217 Instead of writing always fatal errors, we use the corresponding log
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/518
         // $GLOBALS['log']->fatal("Caught error: $errstr");
         // END STIC-Custom
 
@@ -842,6 +843,7 @@ class Importer
             case E_USER_ERROR:
                 $message = "ERROR: [$errno] $errstr on line $errline in file $errfile<br />\n";
                 // STIC-Custom EPS 20241217 Instead of writing always fatal errors, we use the corresponding log
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/518
                 $GLOBALS['log']->fatal("Caught error: $errstr $errfile $errline");
                 // END STIC-Custom
                 $isFatal = true;
@@ -850,6 +852,7 @@ class Importer
             case E_WARNING:
                 $message = "WARNING: [$errno] $errstr on line $errline in file $errfile<br />\n";
                 // STIC-Custom EPS 20241217 Instead of writing always fatal errors, we use the corresponding log
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/518
                 $GLOBALS['log']->warn("Caught error: $errstr $errfile $errline");
                 // END STIC-Custom
                 break;
@@ -857,6 +860,7 @@ class Importer
             case E_NOTICE:
                 $message = "NOTICE: [$errno] $errstr on line $errline in file $errfile<br />\n";
                 // STIC-Custom EPS 20241217 Instead of writing always fatal errors, we use the corresponding log
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/518
                 $GLOBALS['log']->error("Caught error: $errstr $errfile $errline");
                 // END STIC-Custom
                 break;
@@ -866,6 +870,7 @@ class Importer
                 // don't worry about these
                 // $message = "STRICT ERROR: [$errno] $errstr on line $errline in file $errfile<br />\n";
                 // STIC-Custom EPS 20241217 Instead of writing always fatal errors, we use the corresponding log
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/518
                 $GLOBALS['log']->warn("Caught error: $errstr $errfile $errline");
                 // END STIC-Custom
                 $message = "";
@@ -873,6 +878,7 @@ class Importer
             default:
                 $message = "Unknown error type: [$errno] $errstr on line $errline in file $errfile<br />\n";
                 // STIC-Custom EPS 20241217 Instead of writing always fatal errors, we use the corresponding log
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/518
                 $GLOBALS['log']->fatal("Caught error: $errstr $errfile $errline");
                 // END STIC-Custom
                 break;

--- a/modules/stic_Attendances/Utils.php
+++ b/modules/stic_Attendances/Utils.php
@@ -55,6 +55,7 @@ class stic_AttendancesUtils
         }
 
         // Add session filter if needed
+        // $sessionIdWhere = '';
         if (!empty($sessionId)) {
             $sessionIdWhere = " AND s.id='$sessionId' ";
         }

--- a/modules/stic_Attendances/Utils.php
+++ b/modules/stic_Attendances/Utils.php
@@ -55,7 +55,7 @@ class stic_AttendancesUtils
         }
 
         // Add session filter if needed
-        // $sessionIdWhere = '';
+        $sessionIdWhere = '';
         if (!empty($sessionId)) {
             $sessionIdWhere = " AND s.id='$sessionId' ";
         }

--- a/modules/stic_Import_Validation/Importer.php
+++ b/modules/stic_Import_Validation/Importer.php
@@ -978,8 +978,6 @@ class Importer
      */
     public static function handleImportErrors($errno, $errstr, $errfile, $errline)
     {
-        $GLOBALS['log']->fatal("Caught error: $errstr");
-
         if (!defined('E_DEPRECATED')) {
             define('E_DEPRECATED', '8192');
         }
@@ -991,25 +989,30 @@ class Importer
         switch ($errno) {
             case E_USER_ERROR:
                 $message = "ERROR: [$errno] $errstr on line $errline in file $errfile<br />\n";
+                $GLOBALS['log']->fatal("Caught error: $errstr $errfile $errline");
                 $isFatal = true;
                 break;
             case E_USER_WARNING:
             case E_WARNING:
                 $message = "WARNING: [$errno] $errstr on line $errline in file $errfile<br />\n";
+                $GLOBALS['log']->warn("Caught error: $errstr $errfile $errline");
                 break;
             case E_USER_NOTICE:
             case E_NOTICE:
                 $message = "NOTICE: [$errno] $errstr on line $errline in file $errfile<br />\n";
+                $GLOBALS['log']->error("Caught error: $errstr $errfile $errline");
                 break;
             case E_STRICT:
             case E_DEPRECATED:
             case E_USER_DEPRECATED:
                 // don't worry about these
                 // $message = "STRICT ERROR: [$errno] $errstr on line $errline in file $errfile<br />\n";
+                $GLOBALS['log']->warn("Caught error: $errstr $errfile $errline");
                 $message = "";
                 break;
             default:
                 $message = "Unknown error type: [$errno] $errstr on line $errline in file $errfile<br />\n";
+                $GLOBALS['log']->fatal("Caught error: $errstr $errfile $errline");
                 break;
         }
 

--- a/modules/stic_Registrations/Utils.php
+++ b/modules/stic_Registrations/Utils.php
@@ -247,12 +247,13 @@ class stic_RegistrationsUtils {
         }
         $endDay = date('Y-m-d');
 
-        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ':  ' . $startDay . '|' . $today);
+        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ':  ' . $startDay . '|' . $endDay);
         $start = new DateTime($startDay);
         $end = new DateTime($endDay);
 
         $numDays = $start->diff($end)->days;
         $dayToCreate = $start->format('Y-m-d');
+        $a = 0;
         while ($a <= $numDays) {
             stic_AttendancesUtils::createAttendances($dayToCreate, $registrationBean->id, null);
             $dayToCreate = $start->add(new DateInterval('P1D'))->format('Y-m-d');


### PR DESCRIPTION
## Description
Derivado de un problema en una entidad en que se generó un log de errores muy grande, se observa que se estaba grabando el error "Caught error: Undefined variable: sessionIdWhere".
Este error se producía por estar usando una variable que no se definía en todos los casos. Se corrige este punto.
Además se observa que en la importación, cuando hay un error, éste pasa por la rutina handleImportErrors. Esta rutina está grabando en el log connivel fatal todos los errores que le lleguen aunque luego en la mayoría de casos prosigue con la ejecución. Se modifica la rutina para utilizar el log correspondiente al nivel de criticidad y se añade también las referencias al fichero y línea en que se origina el error.

## Motivation and Context
Reducir el número de errores que se graban en el log y tener mayor información cuando se generen nuevos.

## How To Test This
Para comprobar que no se produce el error de sessionIdWhere:
1.- Realizar una importación de un par de inscripciones
2.- Modificar la fecha de inscripción de las inscripciones en el fichero de importación
3.- Volver a importar
4.- Comprobar que no aparecen referencias al sessionIdWhere

Para comprobar las modificaciones a la gestión de errores del importador
1.- Provocar algún error en una importación (por ejemplo, modificar temporalmente el Utils.php modificado en este mismo POR para que genere el aviso de variable no definida)
2.- Comrpobar en el log que aparece con la criticidad adecuada e indicando el fichero y línea en que se origina el error


Nota: En las importaciones de inscripciones es posible que aparezca un error como ```Caught error: Trying to access array offset on value of type bool /application/testissues2/modules/stic_Events/LogicHooksCode.php 34```. Se abre issue a parte para tratar ese caso: #519 .
