### PR TITLE
Hotfix - KReports - Deshacer los cambios del PR #505

### DIFF
--- a/modules/KReports/KReportQuery.php
+++ b/modules/KReports/KReportQuery.php
@@ -1549,6 +1549,7 @@ class KReportQuery {
    function getWhereOperatorClause($operator, $fieldname, $fieldid, $path, $value, $valuekey, $valueto, $valuetokey = '', $jointype = '') {
       global $current_user;
       // STIC-Custom EPS 20211220 - Anular el PR #505
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/524
       // // STIC-Custom EPS 20241205
       // // https://github.com/SinergiaTIC/SinergiaCRM/pull/505
       // $db = DBManagerFactory::getInstance();
@@ -1651,6 +1652,7 @@ class KReportQuery {
       }
       // process the operator
       // STIC-Custom EPS 20211220 - Anular el PR #505
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/524
       // // STIC-Custom EPS 20241205 - quote the value to avoid errors when certain values are used (apostrophe)
       // // https://github.com/SinergiaTIC/SinergiaCRM/pull/505
       // $value = $db->quote($value);

--- a/modules/KReports/KReportQuery.php
+++ b/modules/KReports/KReportQuery.php
@@ -1548,9 +1548,11 @@ class KReportQuery {
 
    function getWhereOperatorClause($operator, $fieldname, $fieldid, $path, $value, $valuekey, $valueto, $valuetokey = '', $jointype = '') {
       global $current_user;
-      // STIC-Custom EPS 20241205
-      // https://github.com/SinergiaTIC/SinergiaCRM/pull/505
-      $db = DBManagerFactory::getInstance();
+      // STIC-Custom EPS 20211220 - Anular el PR #505
+      // // STIC-Custom EPS 20241205
+      // // https://github.com/SinergiaTIC/SinergiaCRM/pull/505
+      // $db = DBManagerFactory::getInstance();
+      // // ENS STIC-Custom
       // ENS STIC-Custom
 
       // initialize
@@ -1648,9 +1650,11 @@ class KReportQuery {
             break;
       }
       // process the operator
-      // STIC-Custom EPS 20241205 - quote the value to avoid errors when certain values are used (apostrophe)
-      // https://github.com/SinergiaTIC/SinergiaCRM/pull/505
-      $value = $db->quote($value);
+      // STIC-Custom EPS 20211220 - Anular el PR #505
+      // // STIC-Custom EPS 20241205 - quote the value to avoid errors when certain values are used (apostrophe)
+      // // https://github.com/SinergiaTIC/SinergiaCRM/pull/505
+      // $value = $db->quote($value);
+      // // END STIC-Custom
       // END STIC-Custom
       switch ($operator) {
          case 'autocomplete':


### PR DESCRIPTION
# Description
Se detecta que en el PR #505 al hacer el quote al valor introducido por el usuario , se produce un error cuando el valor es un array.
Se deshace el cambio para poder probar mejor la corrección.

## How To Test This
1.- Crear un informe con un filtro "es uno de"
2.- Validar que el filtro se aplica correctamente y aparecen los valores que deben aparecer

