### PR TITLE
Hotfix - Proyectos - Inclusión de ficheros javascript en view.detail.php

### DIFF
--- a/custom/modules/Project/views/view.detail.php
+++ b/custom/modules/Project/views/view.detail.php
@@ -56,6 +56,8 @@ class CustomProjectViewDetail extends ProjectViewDetail
         SticViews::display($this);
 
         echo getVersionedScript("custom/modules/Project/SticUtils.js");
+        echo getVersionedScript('modules/Project/Project.js');
+        echo getVersionedScript('modules/Project/js/custom_project.js');
 
         // Write here you custom code
     }

--- a/modules/Project/metadata/detailviewdefs.php
+++ b/modules/Project/metadata/detailviewdefs.php
@@ -215,17 +215,6 @@ $viewdefs['Project']['DetailView'] = array (
         'field' => '30',
       ),
     ),
-    'includes' => 
-    array (
-      0 => 
-      array (
-        'file' => 'modules/Project/Project.js',
-      ),
-      1 => 
-      array (
-        'file' => 'modules/Project/js/custom_project.js',
-      ),
-    ),
     'form' => 
     array (
       'buttons' => 


### PR DESCRIPTION
- solves #272 

## Description
Para evitar el problema descrito en el issue se ha optado por hacer la inclusión de los ficheros Javascript usados en la vista de detalle de Proyectos directamente en el controlador de la vista `custom/modules/Project/views/view.detail.php`.

Además del fichero faltante detectado en el issue _(modules/Project/js/custom_project.js),_ se ha añadido el fichero _modules/Project/Project.js_, por igualar la estratégia, al menos en este fichero.

**Cómo probarlo**
1. Hacer cualquier modificación en estudio en la vista de detalle de Proyectos
2. En el fichero _custom/modules/Project/metadata/detailviewdefs.php_ eliminar o comentar las líneas correspondientes al array _includes_, que referencia a los ficheros javascript. 
3. Verificar que, tras hacerlo, las funcionalidades javascript de la vista de detalle siguen funcionando, incluido el borrado del proyecto desde el menú de acciones
