### PR TITLE
Hotfix - Economía - Formularios web - No redondear pagos Paypal con decimales

### DIFF
--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php
@@ -702,7 +702,7 @@ class PaymentBO extends WebFormDataBO
                     if ($paymentStatus == 'Completed') {
                         $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ": {$paymentBean->name} successfully processed. PayPal data: [message: {$txnType}] [status: {$paymentStatus}] [subscr_id (only for recurring payments): {$ipnMessage['subscr_id']}]");
                         $paymentBean->status = 'paid';
-                        $paymentBean->amount = intval($ipnMessage['mc_gross']);
+                        $paymentBean->amount = floatval($ipnMessage['mc_gross']);
                     } else {
                         $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ": {$paymentBean->name} unsuccessfully processed. PayPal data: [message: {$txnType}] [status: {$paymentStatus}] [subscr_id (only for recurring payments): {$ipnMessage['subscr_id']}]");
                         $paymentBean->status = 'rejected_gateway';


### PR DESCRIPTION
- solves  #345 

## Descripción
Se modifica la conversión del importe de los pagos de Paypal para preservar los decimales.

**Como probarlo**
1. Establecer la configuración PAYPAL_ID_TEST a una id válido de paypal en modo test y `PAYPAL_TEST = 1`
2. Crear un formulario de captación de fondos
3. Enviar el formulario seleccionando pago con Paypal y una cantidad que incluya decimales.
4. De manera inmediata, verificar que el pago creado muestra los decimales correctamente 
5. Verificar que después de recibirse la confirmación del pago por parte de Paypal (puede tardar hasta 3 minutos) el pago se ha marcado como pagado y los decimales se mantienen.

