### PR TITLE
Improvement - Tareas programadas - Retrasar unos segundos la ejecución del cron  de envio masivo de emails de campaña.

### DIFF
--- a/SticCronMassEmailCampaigns.php
+++ b/SticCronMassEmailCampaigns.php
@@ -31,7 +31,8 @@ if (!defined('sugarEntry')) {
     define('sugarEntry', true);
 }
 
-// STIC CUSTOM - "Sleep 3 seconds to avoid running multiple cron jobs at the same time"
+// STIC CUSTOM - "Sleep 3 seconds to priorize regular cron execution"
+// https://github.com/SinergiaTIC/SinergiaCRM/pull/534
 sleep(3);
 // End STIC CUSTOM
 

--- a/SticCronMassEmailCampaigns.php
+++ b/SticCronMassEmailCampaigns.php
@@ -31,6 +31,10 @@ if (!defined('sugarEntry')) {
     define('sugarEntry', true);
 }
 
+// STIC CUSTOM - "Sleep 3 seconds to avoid running multiple cron jobs at the same time"
+sleep(3);
+// End STIC CUSTOM
+
 // STIC Custom - "Run Nightly Mass Email Campaign" scheduler id
 if (!$schedulerId = $_REQUEST['scheduler_id']) {
     $schedulerId = '72ed826e-bd84-758a-d742-5e830d2ce892';

--- a/custom/include/SugarQueue/SticCronJobs.php
+++ b/custom/include/SugarQueue/SticCronJobs.php
@@ -47,7 +47,10 @@ class SticCronJobs extends SugarCronJobs
         
         // throttle
         if (!$this->throttle()) {
-            $GLOBALS['log']->fatal("Job runs too frequently, throttled to protect the system.");
+            // STIC CUSTOM - Log message with more info
+            // $GLOBALS['log']->fatal("Job runs too frequently, throttled to protect the system.");
+            $GLOBALS['log']->fatal('Line '.__LINE__.': '.__METHOD__.': '."Job runs too frequently, throttled to protect the system.");
+            // End STIC CUSTOM
             return;
         }
         

--- a/custom/include/SugarQueue/SticCronJobs.php
+++ b/custom/include/SugarQueue/SticCronJobs.php
@@ -48,6 +48,7 @@ class SticCronJobs extends SugarCronJobs
         // throttle
         if (!$this->throttle()) {
             // STIC CUSTOM - Log message with more info
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/534
             // $GLOBALS['log']->fatal("Job runs too frequently, throttled to protect the system.");
             $GLOBALS['log']->fatal('Line '.__LINE__.': '.__METHOD__.': '."Job runs too frequently, throttled to protect the system.");
             // End STIC CUSTOM


### PR DESCRIPTION
## Descripción
Este PR retrasa 3 segundos la ejecución del cron de envio de campañas, para provocar que, en caso de coincidencia (mismo minuto y segundo) en la ejecución de otro cron, la ejecución de este impida que se ejecute el cron principal, que ejecuta todas las tareas programadas que le correspondan y que provoca el mensaje `2024-11-28 02:16:02 [1910050][1][FATAL] Job runs too frequently, throttled to protect the system.`
Lo que se persigue es priorizar la ejecución del cron _ordinario_ (el cuál también ejecuta la tarea de envio de emails.) 


**Cómo probarlo**
- Verificar que en en una llamada concurrente de _SticCronMassEmailCampaigns.php_ y _SticCron.php_ la demora programada de 3 segundos en _SticCronMassEmailCampaigns.php_ provoca que se ejecute prioritariamente en todos los casos _SticCron.php_, mostrandose el nuevo log añadido en _custom/include/SugarQueue/SticCronJobs.php_

Esto se puede forzar usando el siguiente comando en la consola:
```bash 
 wget <ruta_instancia>/SticCron.php & wget <ruta_instancia>/SticCro
nMassEmailCampaigns.php & 

```