### PR TITLE
Hotfix - Calendario - Filtrar listas dinámicas desde QuickCreate del Calendario

### DIFF
--- a/custom/modules/Calendar/controller.php
+++ b/custom/modules/Calendar/controller.php
@@ -53,4 +53,27 @@ class CustomCalendarController extends CalendarController
         }
 
     }
+    /**
+     * This action is triggered when there are dynamic enums in the EditView, 
+     * and the parent enum needs to be retrieved from the vardef definition of the module.
+     */ 
+    function action_getFieldVardef() {
+    
+        $this->view = 'json';
+        header('Content-Type: application/json');
+        
+        $fieldName = $_REQUEST['field'];
+        
+        $module = isset($_REQUEST['record_module']) ? $_REQUEST['record_module'] : 'Calls';
+        
+        $bean = BeanFactory::newBean($module);
+        $vardef = isset($bean->field_defs[$fieldName]) ? $bean->field_defs[$fieldName] : null;
+        
+        echo json_encode(array(
+            'success' => true,
+            'vardef' => $vardef
+        ));
+        
+        exit();
+    }    
 }

--- a/include/SugarFields/Fields/Dynamicenum/SugarFieldDynamicenum.js
+++ b/include/SugarFields/Fields/Dynamicenum/SugarFieldDynamicenum.js
@@ -63,9 +63,13 @@ function loadDynamicEnum(field, subfield) {
         // STIC-Custom - PCS - 2023-05-19 - Enabling massupdate for dynamicenum
         // Adding recordId !== undefined condition to check if in ViewList we want to change one field or mass update
         // STIC#1109
-        var moduleName = module_sugar_grp1;
+        // STIC-Custom PCS 20240113 - Fix dynamicenum in Calendar quickcreateview
+        // The variable moduleName has been moved because it is not defined at this point.
+        // var moduleName = module_sugar_grp1;
         var recordId = $('input.listview-checkbox',$('form#EditView').closest('tr')).val();
         if(action_sugar_grp1 == 'index' && recordId !== undefined ){
+                var moduleName = module_sugar_grp1;
+        //END STIC-Custom
                 var dynamicFieldName = $('form#EditView select').attr('id');
                 var el = $('<input></input>',{
                 id:recordId+dynamicFieldName,


### PR DESCRIPTION
## Description
Las listas desplegables dinámicas no se filtraban correctamente según los valores del campo padre correspondiente. Esto causaba que los valores del campo hijo no estuvieran sincronizados con el campo padre, afectando la funcionalidad esperada.

1. Modificación de `Cal.js`:

- Se ha incluido el archivo `include/SugarFields/Fields/Dynamicenum/SugarFieldDynamicenum.js,` que contiene la función `loadDynamicEnum(field, subfield)` encargada de sincronizar los valores entre el campo padre e hijo en los desplegables dinámicos.
- Se ha actualizado Cal.js para utilizar esta función, asegurándose de que los campos padre e hijo estén correctamente vinculados.
2. Obtención del campo padre desde el Vardef:

- Se realizaron cambios en el controller para extraer el campo padre definido en el Vardef del campo hijo. Esto permite identificar dinámicamente las relaciones entre los campos en tiempo de ejecución.

3. Parámetros para la sincronización:

- La función `loadDynamicEnum` ahora recibe los identificadores del campo padre y el campo hijo como parámetros, asegurando que la sincronización se configure correctamente para cada caso.
Con estas modificaciones:

Las listas desplegables dinámicas ahora se filtran correctamente según el valor del campo padre.

## How To Test This
1. Ir a Estudio y, en el módulo de **Llamadas**, crear dos campos:
  - Un campo de lista desplegable.
  - Un campo de lista desplegable dinámica dependiente del anterior.
2. Ir al **Calendario**, seleccionar un día y abrir el formulario para programar una actividad.
3. Seleccionar la opción **Llamadas** y comprobar que los valores del campo hijo (lista desplegable dinámica)  se filtran según el valor seleccionado en el campo padre.
Comprobar que Actualización masiva desde la vista de lista y en la vista de edición de Llamadas sigue funcionando con normalidad. 
