### PR TITLE
Find function changed to search for exact match

### DIFF
--- a/modules/KReports/js/kreportsbase2.js
+++ b/modules/KReports/js/kreportsbase2.js
@@ -659,7 +659,11 @@ var aL = function (e) {
                                 e.record.set(e.column.id + "key", e.value);
                                 e.record.set(
                                     e.column.id,
-                                    K.kreports.whereOperators.ay.getAt(K.kreports.whereOperators.ay.find("value", e.value)).get("text")
+                                    // STIC-Custom 20240117 EPS - Wrong literal was being displayed when keys begin with same root. Changed find to search for exact match
+                                    // https://cdn.sencha.com/ext/gpl/4.2.1/docs/#!/api/Ext.data.Store
+                                    // K.kreports.whereOperators.ay.getAt(K.kreports.whereOperators.ay.find("value", e.value)).get("text")
+                                    K.kreports.whereOperators.ay.getAt(K.kreports.whereOperators.ay.findExact("value", e.value)).get("text")
+                                    // ENS STIC-Custom
                                 );
                                 break;
                         }


### PR DESCRIPTION
- Closes #546 
- 
## Description
Se modifica una llamada de KReports a extjs4 para que busque por toda la clave y no se conforme con que comparta el inicio. En concreto se modifica un "find" por un "findExact" (https://cdn.sencha.com/ext/gpl/4.2.1/docs/#!/api/Ext.data.Store)

## Motivation and Context
Corregir el bug #546 que puede llevar a error si el usuario no se fija en que no le está cogiendo correctamente el valor seleccionado.

## How To Test This
Seguir los pasos indicados para reproducir la incidencia y comprobar que se mantiene el valor seleccionado y no el que comparte raíz.

