### PR TITLE
Hotfix - Vistas Personalizadas - Ocultar módulos de Vistas personalizadas en "Selección de módulos y Subpaneles"

### DIFF
--- a/custom/Extension/application/Ext/Include/SticModules.php
+++ b/custom/Extension/application/Ext/Include/SticModules.php
@@ -61,11 +61,6 @@ $moduleList[] = 'stic_Journal';
 $moduleList[] = 'stic_Training';
 $moduleList[] = 'stic_Work_Experience';
 $moduleList[] = 'stic_Skills';
-$moduleList[] = 'stic_Custom_Views';
-$moduleList[] = 'stic_Custom_View_Customizations';
-$moduleList[] = 'stic_Custom_View_Conditions';
-$moduleList[] = 'stic_Custom_View_Actions';
-$moduleList[] = 'stic_Group_Opportunities';
 
 // Bean names for custom modules
 // Although they should be singular ModuleBuilder outputs them in plural and we keep them this way


### PR DESCRIPTION
- Closes #215 

## Descripción del problema
En Administración -> Seleccionar Pestañas de Módulos y Subpaneles aparecían los módulos de Vistas Personalizadas: "Vistas Personalizadas", "Personalizaciones", "Condiciones" y "Acciones".

## Pruebas a realizar
1. Ir a Adminstración -> Seleccionar Pestañas de Módulos y Subpaneles
2. Verificar que NO aparecen en "Pestañas Ocultas" los módulos "Vistas Personalizadas", "Personalizaciones", "Condiciones" y "Acciones".
3. Abrir Vistas Personalizadas y crear/editar una
4. Verificar que en la Vista Personalizada aparece el subpanel "Personalizaciones" 
5. Verificar que se define correctamente una Vista Personalizada

