### PR TITLE
Hotfix - Vistas Personalizadas - Modificación de obligatoriedad en campos multienum

### DIFF
--- a/modules/stic_Custom_Views/processor/js/sticCVUtils.js
+++ b/modules/stic_Custom_Views/processor/js/sticCVUtils.js
@@ -480,7 +480,7 @@ var sticCVUtils = class sticCVUtils {
     sticCVUtils.show(field.header.$element.find("span.required"), customView, false);
     if (required) {
       sticCVUtils.addClass(field.header.$element, customView, "conditional-required");
-      removeFromValidate(customView.formName, field.name);
+      removeFromValidate(customView.formName, field.validateName);
       var fieldName = field.header.text();
       if (fieldName === null || fieldName === undefined || fieldName.trim() === "") {
         fieldName = SUGAR.language.get("app_strings", "ERR_MISSING_REQUIRED_FIELDS");
@@ -492,24 +492,24 @@ var sticCVUtils = class sticCVUtils {
       }
       addToValidate(
         customView.formName,
-        field.name,
+        field.validateName,
         field.content.type,
         true,
         fieldName
       );
       if (!oldRequired) {
         customView.addUndoFunction(function() {
-          removeFromValidate(customView.formName, field.name);
+          removeFromValidate(customView.formName, field.validateName);
         });
       }
     } else {
-      removeFromValidate(customView.formName, field.name);
+      removeFromValidate(customView.formName, field.validateName);
       sticCVUtils.removeClass(field.header.$element, customView, "conditional-required");
       if (oldRequired) {
         customView.addUndoFunction(function() {
           addToValidate(
             customView.formName,
-            field.name,
+            field.validateName,
             field.content.type,
             true,
             SUGAR.language.get("app_strings", "ERR_MISSING_REQUIRED_FIELDS")
@@ -530,7 +530,7 @@ var sticCVUtils = class sticCVUtils {
       var validateFields = validate[field.customView.formName];
       for (var i = 0; i < validateFields.length; i++) {
         // Array(name, type, required, msg);
-        if (validateFields[i][0] == field.name) {
+        if (validateFields[i][0] == field.validateName) {
           return validateFields[i][2];
         }
       }

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field.js
@@ -34,6 +34,11 @@ var sticCV_Record_Field = class sticCV_Record_Field extends sticCV_Record_Contai
     this.container = new sticCV_Record_Field_Container(this, $fieldElement);
     this.header = new sticCV_Record_Field_Header(this.customView, $fieldElement);
     this.content = new sticCV_Record_Field_Content(this, $fieldElement, fieldName);
+
+    this.validateName = this.name;
+    if (this.content.type == "multienum") {
+      this.validateName += "[]";
+    }
   }
   readonly(readonly = true) {
     return this.applyAction({ action: "readonly", value: readonly });


### PR DESCRIPTION
- Closes #316 

## Descripción del problema
Tal y como se describe en #316, si se definía en Estudio un campo multiselección como obligado, las Vistas Personalizadas no podían cambiar su obligatoriedad.
Esto era debido a que para los campos multienum, el nombre que figura en el array de campos para validar finaliza con `[]` y el motor de Vistas Personalizadas no lo tenía en cuenta.

## Pruebas a realizar
1. En Estudio, editar los campos del módulo "Personas"
2. Modificar el campo "stic_professional_profile_c" - "Perfil trabajador/a", y definirlo como "Obligado"
3. Reparación rápida
4. Crear una Vista Personalizada sobre el módulo "Personas", "Vista de edición"
    1. Debe modificar la obligatoriedad del campo: Acción: "Campo" - "Perfil trabajador/a" - "Obligado" - "No"
    2. Se le puede añadir una condición para evaluar el cambio de obligatoriedad
5. Editar una Persona
6. Verificar que el campo "Perfil trabajador/a" modifica su obligatoriedad según los criterios de la Vista Personalizada
