### PR TITLE
Hotfix - Correo - Se añade comprobación de registro borrado al buscar la cuenta de correo saliente

### DIFF
--- a/include/OutboundEmail/OutboundEmail.php
+++ b/include/OutboundEmail/OutboundEmail.php
@@ -350,7 +350,7 @@ class OutboundEmail
             $mailer = "type = 'system'";
         } // if
 
-        $q = "SELECT id FROM outbound_email WHERE {$mailer}";
+        $q = "SELECT id FROM outbound_email WHERE {$mailer} AND deleted = 0";
         $r = $this->db->query($q);
         $a = $this->db->fetchByAssoc($r);
 


### PR DESCRIPTION
-Closes #559 

## Description
Se añade el deleted = 0 a un select sobre la tabla outbound_email que al no estar presente provocaba que, aleatoriamente, se recuperasen los datos del registro borrado provocando el consiguiente error.

## Motivation and Context
Corregir la incidencia #559

## How To Test This
1.- Desde la vista de detalle de Persona u Organización, clickar sobre la dirección de correo y enviar el mail
2.- Comprobar que el mail sale correctamente
3.- Provocar que haya 2 registros de tipo system en la tabla outbound_emails (uno deleted y el otro activo)
4.- En local, con el debugger, comprobar que la select cambiada sólo devuelve un registro.

