### PR TITLE
Hotfix - General - Listados: evitar ejecución reiterada del contador de elementos

### DIFF
--- a/themes/SuiteP/include/ListView/ListViewSelectObjects.tpl
+++ b/themes/SuiteP/include/ListView/ListViewSelectObjects.tpl
@@ -44,9 +44,13 @@
 <script>
 {literal}
     $(document).ready(function () {
-        setInterval(function () {
+        // STIC-Custom 20250128 JBL - Avoiding repeated executions of toggleSelected
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+        // setInterval(function () {
+        setTimeout(function () {
+        // END STIC-Custom
             sListView.toggleSelected();
-        }, 100);
+        }, 100); 
     });
 {/literal}
 </script>


### PR DESCRIPTION
- Closes #566

## Descripción
Tal y como se describe en #566, la función que actualiza el contador de elementos seleccionados de un listado se ejecutaba 10 veces por segundo, cada 100ms. 
Esta ejecución reiterada es claramente un error ya que solo es necesaria una vez al cargarse la página.

## Pruebas
1. Abrir un listado de un módulo con muchos elementos (más de una página)
2. En el navegador, inspeccionar la página.
3. En el código de la página buscar y expandir el elemento <ul> con id=selectLinkTop
4. Observar que en su estructura no se actualizan constantemente ciertos elementos
5. Seleccionar registros en la primera página
6. Verificar que se actualiza el contador de registros seleccionados
7. Cambiar de página
8. Verificar que se mantiene el contador de registros seleccionados
9. Seleccionar más registros
10. Verificar que se actualiza correctamente
11. Volver a la página anterior
12. Verificar que el contador de registros contiene los elementos seleccionados
13. Seleccionar "Todos" los registros
14. Verificar que se actualiza el contador

