### PR TITLE
Improvement - SinergiaDA - Limitación de usuarios para SDA y otras mejoras

### DIFF
--- a/ModuleInstall/ModuleInstaller.php
+++ b/ModuleInstall/ModuleInstaller.php
@@ -277,6 +277,7 @@ class ModuleInstaller
 
     public function post_uninstall()
     {
+        global $sugar_config;
         require_once($this->base_dir . '/manifest.php');
         if (isset($this->installdefs['post_uninstall']) && is_array($this->installdefs['post_uninstall'])) {
             foreach ($this->installdefs['post_uninstall'] as $includefile) {

--- a/ModuleInstall/ModuleInstaller.php
+++ b/ModuleInstall/ModuleInstaller.php
@@ -293,8 +293,8 @@ class ModuleInstaller
 
         if (file_exists($rebuildSDAFile) && $sdaEnabled) {
             require_once $rebuildSDAFile;
+            $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Uninstalling module. {$this->base_dir}. Rebuilding SinergiaDA");
             SinergiaDARebuild::callApiRebuildSDA(true, 'views');
-            $GLOBALS['log']->info('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Uninstalling module. {$this->base_dir}. Rebuilding SinergiaDA");
         }
         // END STIC
     }

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1293,7 +1293,7 @@ class ExternalReporting
                             -- Normal users are assigned to their own security groups.
                             SELECT * FROM (
                                 -- Select 1: Regular users with $this->maxNonAdminUsers LIMIT
-                                SELECT 
+                                SELECT
                                     user_name,
                                     CONCAT('SCRM_', s.name) as name
                                 FROM (
@@ -1551,7 +1551,6 @@ class ExternalReporting
     private function createEnumView($listName, $listViewName)
     {
 
-
         // Get the global variable $app_list_strings
         global $app_list_strings;
 
@@ -1560,13 +1559,10 @@ class ExternalReporting
 
         // Get the current listm or return if not exists
         $currentList = $app_list_strings[$listName];
-        if(!$currentList) {
+        if (!$currentList) {
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "The referenced dropdown list [{$listName}] is not available. Ommited");
-        return;
+            return;
         }
-
-
-
 
         // Start building the SQL command
         $sqlCommand = "CREATE OR REPLACE VIEW {$this->listViewPrefix}_{$listViewName} AS ";
@@ -1586,7 +1582,7 @@ class ExternalReporting
         // Execute the SQL command
         if (!$db->query($sqlCommand)) {
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Error has occurred: [{$db->last_error}] running Query: [{$sqlCommand}]");
-            
+
         } else {
             return $listViewName;
         };
@@ -1623,7 +1619,7 @@ class ExternalReporting
             $res = $db->query("select table_name, table_type from information_schema.tables where table_name like '{$prefix}%'");
             // Loop through the views
             while ($view = $db->fetchByAssoc($res, false)) {
-                if($view['table_type'] == 'VIEW'){
+                if ($view['table_type'] == 'VIEW') {
                     // Delete the view
                     if ($db->query("DROP VIEW IF EXISTS {$view['table_name']}")) {
                         $counterTable++;
@@ -1634,8 +1630,7 @@ class ExternalReporting
                         $counterTable++;
                     }
                 }
-                
-                
+
             }
 
         }
@@ -1743,9 +1738,6 @@ class ExternalReporting
             0 => 'ACL_ALLOW_DEFAULT',
         ];
 
-       
-       
-
         // Preload user groups if group permissions are enabled for better performance
         $userGroups = [];
         if ($sugar_config['stic_sinergiada']['group_permissions_enabled']) {
@@ -1816,7 +1808,7 @@ class ExternalReporting
                             case '75': // Owner-based permissions
                                 $permissionsBatch[] = [
                                     'user_name' => $user['user_name'],
-                                    'group' =>null,
+                                    'group' => null,
                                     'table' => $currentTable,
                                     'column' => 'assigned_user_name',
                                     'stic_permission_source' => $aclSource,
@@ -1827,7 +1819,7 @@ class ExternalReporting
                             default: // Global permissions
                                 $permissionsBatch[] = [
                                     'user_name' => $user['user_name'],
-                                    'group' =>null,
+                                    'group' => null,
                                     'table' => $currentTable,
                                     'column' => 'users_id',
                                     'stic_permission_source' => $aclSource,

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1563,6 +1563,7 @@
      */
     public function deleteOldViews()
     {
+        global $sugar_config;
         // List of prefixes to be deleted
         $prefixesToDelete = ['sda_'];
 
@@ -1574,8 +1575,8 @@
         // Loop through the prefixes
         foreach ($prefixesToDelete as $prefix) {
 
-            // Get all the views with matching prefixes
-            $res = $db->query("select table_name from information_schema.views where table_name like '{$prefix}%'");
+            // Get all the views with matching prefixes for the current database
+            $res = $db->query("SELECT table_name FROM information_schema.views WHERE table_name LIKE '{$prefix}%' AND table_schema='{$sugar_config['dbconfig']['db_name']}'");
             // Loop through the views
             while ($view = $db->fetchByAssoc($res, false)) {
                 // Delete the view

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1994,11 +1994,9 @@ class ExternalReporting
         FROM information_schema.tables
         WHERE table_schema = DATABASE();";
         $result = $db->query($query);
-        if ($result instanceof mysqli_result) {
-            while ($row = mysqli_fetch_assoc($result)) {
-                if ($row['table_name'] == $tableToCheck) {
-                    return true;
-                }
+        while ($row = $db->fetchByAssoc($result)) {
+            if ($row['table_name'] == $tableToCheck) {
+                return true;
             }
         }
         return false;
@@ -2030,7 +2028,7 @@ class ExternalReporting
 
         $result = $db->query($missingTables);
         if ($result !== false) {
-            if ($result instanceof mysqli_result && $result->num_rows > 0) {
+            if ($result->num_rows > 0) {
                 while ($row = $result->fetch_assoc()) {
                     $queryDelete = "DELETE FROM {$row['sda_def_columns']} WHERE {$row['column_name']} = '{$row['table']}';";
 

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -21,7 +21,7 @@
  * You can contact SinergiaTIC Association at email address info@sinergiacrm.org.
  */
 
-class ExternalReporting
+ class ExternalReporting
 {
     // Default language, it will be used if the instance language cannot be obtained from the settings.
     private $lang = 'es';
@@ -315,11 +315,11 @@ class ExternalReporting
 
                 // To avoid exceptional cases where the table name is defined in uppercase
                 // (like in the relationship between Contacts and Cases) we convert the table name to lowercase
-                $fieldV['table'] = strtolower($fieldV['table']);
+                $fieldV['table'] = strtolower($fieldV['table'] ?? null);
 
                 $fieldName = $fieldV['name'];
 
-                $fieldPrefix = $fieldV['source'] == 'custom_fields' ? 'c' : 'm';
+                $fieldPrefix = ($fieldV['source'] ?? null) == 'custom_fields' ? 'c' : 'm';
 
                 // If the field is excluded, skip it
                 if (in_array($fieldV['name'], $this->evenExcludedFields)) {
@@ -335,13 +335,13 @@ class ExternalReporting
                     $sdaHiddenField = true;
                 }
 
-                $fieldV['label'] = $this->sanitizeText($modStrings[$fieldV['vname']]);
+                $fieldV['label'] = $this->sanitizeText($modStrings[$fieldV['vname'] ?? null] ?? null);
 
                 // Attempts to assign a translated label to the field.
                 // If no translation is found, it tries to translate it directly.
                 // The field is skipped if no translation is obtained.
                 if (empty($fieldV['label']) && $fieldV['name'] != 'id') {
-                    $directTranslate = translate($fieldV['vname'], $fieldV['module']);
+                    $directTranslate = translate($fieldV['vname'] ?? '', $fieldV['module'] ?? null);
                     if (!empty($directTranslate)) {
                         $fieldV['label'] = $this->sanitizeText($directTranslate);
                     } else {
@@ -402,13 +402,13 @@ class ExternalReporting
                         break;
                     case 'relate':
                         if (
-                            (in_array($fieldV['module'], $this->evenExcludedModules) && $fieldV['name'] != 'assigned_user_name')
+                            (in_array($fieldV['module'] ?? null, $this->evenExcludedModules) && $fieldV['name'] != 'assigned_user_name')
 
                         ) {
                             continue 2;
                         } else {
 
-                            $relatedModuleName = "{$app_list_strings['moduleList'][$fieldV['module']]}";
+                            $relatedModuleName = $app_list_strings['moduleList'][$fieldV['module'] ?? ''] ?? '';
 
                             // The relationship between contacts and accounts does not have the 'link' property,
                             // which is necessary for retrieval of the relationship values, so we add it directly.
@@ -420,7 +420,7 @@ class ExternalReporting
 
                                 // Build and obtain the translated value from the other side of the relationship so it can be properly displayed in SinergiaDA
                                 $joinModuleRelLabel = 'LBL_' . strtoupper($fieldV['link']) . '_FROM_' . strtoupper($moduleName) . '_TITLE';
-                                $joinLabel = translate($joinModuleRelLabel, $fieldV['module']);
+                                $joinLabel = translate($joinModuleRelLabel, $fieldV['module'] ?? '');
                                 $joinLabel = empty($joinLabel) || $joinLabel == $joinModuleRelLabel ? $txModuleName : $joinLabel;
 
                                 $res = $this->createRelateLeftJoin($fieldV, $tableName, $joinLabel);
@@ -467,7 +467,7 @@ class ExternalReporting
                                 $secureName = preg_replace('([^A-Za-z0-9])', '_', $app_list_strings['moduleList'][$fieldV['module']]) . ' (' . $fieldV['label'] . ')';
 
                                 // It is necessary to detect whether or not the field is custom, and in this case, we obtain it looking at the property of the field containing the ID of the Relationship Table ("...id_c")
-                                $fieldV['source'] = $moduleBean->getFieldDefinitions()[$fieldV['id_name']]['source'] ?: $fieldV['source'];
+                                $fieldV['source'] = $moduleBean->getFieldDefinitions()[$fieldV['id_name']]['source'] ?? $fieldV['source'] ?? null;
 
                                 $fieldPrefix = $fieldV['source'] == 'custom_fields' ? 'c' : 'm';
 
@@ -485,7 +485,7 @@ class ExternalReporting
                                 $indexesToCreate[] = "{$fieldV['id_name']}";
 
                                 //Add relate record name
-                                if (in_array($fieldV['module'], ['Contacts', 'Leads']) || (Beanfactory::newBean($fieldV['module'])->field_defs['last_name']) && $fieldV['module'] != 'Users') {
+                                if (in_array($fieldV['module'], ['Contacts', 'Leads']) || (Beanfactory::newBean($fieldV['module'])->field_defs['last_name'] ?? null) && $fieldV['module'] != 'Users') {
                                     $relatedName = " concat_ws(' ', {$leftJoinAlias}.first_name, {$leftJoinAlias}.last_name) ";
                                 } elseif ($fieldV['module'] == 'Users') {
                                     $relatedName = "{$leftJoinAlias}.user_name";
@@ -667,7 +667,7 @@ class ExternalReporting
                     case 'float':
                         $edaType = 'numeric';
                         $edaPrecision = $fieldV['type'] == 'currency' ? 2 : 0;
-                        $edaPrecision = $fieldV['precision'] ? $fieldV['precision'] : $edaPrecision;
+                        $edaPrecision = $fieldV['precision'] ?? $edaPrecision;
                         break;
                     case 'date':
                     case 'datetime':
@@ -709,10 +709,10 @@ class ExternalReporting
 
                 if (isset($fieldSrc)) {
                     // Add to the array of normal base and custom fields
-                    if ($fieldV['source'] == 'custom_fields') {
+                    if (!empty($fieldV['source']) && $fieldV['source'] == 'custom_fields') {
                         $fieldList['custom'][$fieldK] = $fieldSrc;
                         $addColumnToMetadata = 1;
-                    } else if ($fieldV['source'] == 'non-db' && $fieldV['name'] != 'full_name' && $fieldV['name'] != 'email1') {
+                    } else if (!empty($fieldV['source']) && $fieldV['source'] == 'non-db' && $fieldV['name'] != 'full_name' && $fieldV['name'] != 'email1') {
                         // This source is not processed, so we are moving them away
                         $fieldList['non-db'][$fieldK] = $fieldSrc;
                         $addColumnToMetadata = 0;
@@ -723,7 +723,7 @@ class ExternalReporting
                         }
                     }
 
-                    if ($excludeColumnFromMetadada == true) {
+                    if (isset($excludeColumnFromMetadada) && $excludeColumnFromMetadada == true) {
                         $addColumnToMetadata = 0;
                     }
                     // Only the columns that are really going to be added to the views are added to the SDA_def_Columns table
@@ -735,7 +735,7 @@ class ExternalReporting
                                 'table' => "{$this->viewPrefix}_{$tableName}",
                                 'column' => $fieldV['alias'],
                                 'type' => $edaType,
-                                'decimals' => $edaPrecision,
+                                'decimals' => $edaPrecision ?? 0,
                                 'aggregations' => empty($edaAggregations) ? 'none' : $edaAggregations,
                                 'label' => html_entity_decode($fieldV['label'], ENT_QUOTES),
                                 'description' => addslashes($fieldV['label']),
@@ -827,7 +827,7 @@ class ExternalReporting
             // Sql Header. Depending on the value of the SDA_MODE_MODE setting we create tables or views mysql
             if (
                 in_array($moduleName, $this->sdaSettings['publishAsTable'])
-                || $this->sdaSettings['publishAsTable'][0] == '1'
+                || (!empty($this->sdaSettings['publishAsTable'][0]) && $this->sdaSettings['publishAsTable'][0] == '1')
             ) {
                 $tableMode = 'table';
                 $createViewQueryHeader = " CREATE OR REPLACE TABLE {$viewName} ENGINE=InnoDB AS SELECT ";
@@ -885,9 +885,9 @@ class ExternalReporting
             // Create FROM
             unset($createViewQueryFrom);
             if (isset($fieldList['custom'])) {
-                $createViewQueryFrom .= " FROM  {$tableName} m LEFT JOIN {$tableName}_cstm c ON m.id=c.id_c ";
+                $createViewQueryFrom = " FROM  {$tableName} m LEFT JOIN {$tableName}_cstm c ON m.id=c.id_c ";
             } else {
-                $createViewQueryFrom .= " FROM  {$tableName} AS m ";
+                $createViewQueryFrom = " FROM  {$tableName} AS m ";
             }
 
             // Create left joins
@@ -913,11 +913,11 @@ class ExternalReporting
             };
 
             $this->info .= "<h2>Base fields</h2>";
-            $this->info .= print_r($fieldList['base'], true);
+            $this->info .= print_r($fieldList['base'] ?? '', true);
             $this->info .= "<h2>Custom fields</h2>";
-            $this->info .= print_r($fieldList['custom'], true);
+            $this->info .= print_r($fieldList['custom'] ?? '', true);
             $this->info .= "<h2>Virtual Fields</h2>";
-            $this->info .= print_r($fieldList['virtual'], true);
+            $this->info .= print_r($fieldList['virtual'] ?? '', true);
 
             $this->info .= "</div>";
             $isTable = $tableMode == 'table' ? ' <b style=color:orange>[Table]</b> ' : ' <b style=color:green>[View]</b> ';
@@ -1111,7 +1111,7 @@ class ExternalReporting
             // Standard join using join table
 
             // **Determine join side based on current module:**
-            if ($rel['lhs_module'] == $field['module']) {
+            if (!empty($rel['lhs_module']) && !empty($field['module']) && $rel['lhs_module'] == $field['module']) {
                 // Current module is on the left side
 
                 // Add metadata record
@@ -1132,7 +1132,7 @@ class ExternalReporting
                     'field' => "{$rel['join_table']}.{$rel['join_key_lhs']}",
                     'leftJoin' => " LEFT JOIN {$rel['join_table']} ON {$rel['join_table']}.{$rel['join_key_rhs']}=m.id AND {$rel['join_table']}.deleted=0 ",
                 ];
-            } elseif ($rel['rhs_module'] == $field['module']) {
+            } elseif (!empty($rel['rhs_module']) && !empty($field['module']) && $rel['rhs_module'] == $field['module']) {
                 // Current module is on the right side
 
                 // Add metadata record
@@ -1526,8 +1526,8 @@ class ExternalReporting
         // Get instance of DBManagerFactory
         $db = DBManagerFactory::getInstance();
 
-        // Get the current listm or return if not exists
-        $currentList = $app_list_strings[$listName];
+        // Get the current list or return if not exists
+        $currentList = $app_list_strings[$listName] ?? null;
         if (!$currentList) {
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "The referenced dropdown list [{$listName}] is not available. Ommited");
             return;
@@ -1804,8 +1804,10 @@ class ExternalReporting
             }
 
             // Insert accumulated permissions in batch
-            $this->batchInsertPermissions($permissionsBatch);
-            unset($permissionsBatch);
+            if (!empty($permissionsBatch)) {
+                $this->batchInsertPermissions($permissionsBatch);
+                unset($permissionsBatch);
+            }
         }
 
         // Log total execution time

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -1325,6 +1325,7 @@ class ExternalReporting
                                     AND s.deleted=0
                                     AND uc.sda_allowed_c = 1
                                     AND u.status = 'Active'
+                                    AND u.user_hash IS NOT NULL
                                     -- Select 2: Administrator users should always belong to the EDA_ADMIN group.
                             UNION SELECT
                                     user_name,
@@ -1336,6 +1337,7 @@ class ExternalReporting
                                     u.is_admin = 1
                                     AND u.deleted = 0
                                     AND u.status = 'Active'
+                                    AND u.user_hash IS NOT NULL
                                 AND uc.sda_allowed_c =1;";
 
         // 4) eda_def_security_group_records

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -90,9 +90,6 @@ class ExternalReporting
         $this->hostName = $sugar_config['host_name'];
         $this->baseHostname = explode('.', $this->hostName)[0];
 
-        // Retrieve the settings related to SinergiaDA
-        require_once 'modules/stic_Settings/Utils.php';
-
         $this->sdaSettings['publishAsTable'] = $sugar_config['stic_sinergiada']['publish_as_table'] ?? [];
 
         // If a specific language is not provided, the language defined for the instance will be used.
@@ -121,10 +118,10 @@ class ExternalReporting
         $this->listViewPrefix = "{$this->viewPrefix}_l";
 
         // Get configured limit for non-admin user processing
-        $this->maxNonAdminUsers = $sugar_config['stic_sinergiada']['max_users_processed'] ?? 100;
+        $this->maxNonAdminUsers = $sugar_config['stic_sinergiada']['max_users_processed'] ?? 9999999;
     }
     /**
-     * Main function responsible for creating and managing MariaDB views and tables (as specified in stic_Settings) based on CRM modules.
+     * Main function responsible for creating and managing MariaDB views and tables based on CRM modules.
      *
      * Here's a breakdown of its operations:
      * 1) For each enabled CRM module (excluding specified ones), it creates a MariaDB view or table. These are derived from the module's primary table and, if present, the _cstm table, excluding records marked as deleted.

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -139,7 +139,7 @@ class ExternalReporting
         $startTime = microtime(true);
         $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "SinergiaDA rebuild script starts!");
 
-        global $app_list_strings;
+        global $app_list_strings, $current_user;
 
         $archivo = __FILE__; // Ruta del archivo actual
         $fechaModificacion = filemtime($archivo);
@@ -167,7 +167,10 @@ class ExternalReporting
         // If the number of non-admin users enabled is greater than the limit allowed, the operation is aborted  
         // to protect the system from possible performance problems   
         if(!empty($normalUsersEnabled) && is_object($normalUsersEnabled) && $normalUsersEnabled->num_rows > $this->maxNonAdminUsers){
-            $this->info .= "[FATAL: Is not possible to enable more than {$this->maxNonAdminUsers} non-admin users. There is a total of {$normalUsersEnabled->num_rows} non-admin users enabled.]";
+            $errorString = return_module_language($_SESSION['authenticated_user_language'], 'Administration')['LBL_STIC_SINERGIADA_MAX_USERS_ERROR'];
+            $errorString = str_replace('__max_users__', $this->maxNonAdminUsers, $errorString);
+            $errorString = str_replace('__enabled_users__', $normalUsersEnabled->num_rows, $errorString);
+            $this->info .= "[FATAL: {$errorString}]";
             $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ': Number of non-admin users enabled is greater than the limit allowed. Is not possible to enable more than {$this->maxNonAdminUsers} non-admin users. There is a total of {$normalUsersEnabled->num_rows} non-admin users enabled.');                
             return $this->info;
         }

--- a/SticInclude/SinergiaDARebuild.php
+++ b/SticInclude/SinergiaDARebuild.php
@@ -93,7 +93,7 @@ class SinergiaDARebuild
     public static function callApiRebuildSDA($callUpdateModel = false, $rebuildFilter = 'all')
     {
         global $sugar_config;
-        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Rebuilding SinergiaDA via API");
+        $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Rebuilding SinergiaDA via API");
 
         $db_user_name = $sugar_config['dbconfig']['db_user_name'];
 
@@ -130,13 +130,16 @@ class SinergiaDARebuild
 
         // Check if any error occurred
         if (curl_errno($ch)) {
-            $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Rebuilding SinergiaDA via API. ERROR " . curl_error($ch));
+            $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Rebuilding SinergiaDA via API. ERROR " . curl_error($ch));
+        } else{
+            $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Rebuilding SinergiaDA via API. OK " );
+
         }
 
         // Close the curl instance
         curl_close($ch);
 
-        $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Rebuilding SinergiaDA via API. END");
+        $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Rebuilding SinergiaDA via API. END");
     }
 
 }

--- a/custom/Extension/application/Ext/GlobalLinks/SticGlobalLinks.php
+++ b/custom/Extension/application/Ext/GlobalLinks/SticGlobalLinks.php
@@ -64,7 +64,7 @@ foreach ($settingLinks as $key => $value) {
         'linkinfo' => array($linkText => "javascript:void(window.open('{$linkUrl}'))", 'class' => 'custom_link'),
     );
 }
-
+global $sugar_config;
 // Set the final array: STIC elements + Custom links + Admin + Other core links. The Profile element is always added later at the top place.
 $global_control_links = array_merge($sticElements, $customLinks, $adminElement, $global_control_links);
 $sdaEnabled = $sugar_config['stic_sinergiada']['enabled'] ?? false;

--- a/custom/Extension/modules/Administration/Ext/Administration/SticManageSdaIntegration.php
+++ b/custom/Extension/modules/Administration/Ext/Administration/SticManageSdaIntegration.php
@@ -25,6 +25,7 @@ $admin_option_defs = array();
 
 // Create SinergiaDA element in SinergiaCRM admin section
 require_once 'modules/stic_Settings/Utils.php';
+global $sugar_config;
 $sdaEnabled = $sugar_config['stic_sinergiada']['enabled'] ?? false;
 if (!empty($sdaEnabled) && $sdaEnabled) {
     $admin_option_defs['Administration']['manage-sda-integration-link'] = array(

--- a/custom/Extension/modules/Administration/Ext/Language/ca_ES.SticLang.php
+++ b/custom/Extension/modules/Administration/Ext/Language/ca_ES.SticLang.php
@@ -43,6 +43,7 @@ $mod_strings['LBL_STIC_TEST_DATA_DESCRIPTION'] = 'Carrega o elimina dades de pro
 
 $mod_strings['LBL_STIC_SINERGIADA_LINK_TITLE'] = 'Sinergia Data Analytics';
 $mod_strings['LBL_STIC_SINERGIADA_DESCRIPTION'] = 'Reconstrueix la integració amb Sinergia Data Analytics.';
+$mod_strings['LBL_STIC_SINERGIADA_MAX_USERS_ERROR'] = "Límit d\'usuaris no administradors a SinergiaDA excedit. Màxim permès: <b>__max_users__</b>. Actuals: <b>__enabled_users__</b>. Desactivi alguns usuaris i torni a intentar-ho.";
 
 $mod_strings['LBL_STIC_MAIN_MENU_LINK_TITLE'] = 'Menú principal';
 $mod_strings['LBL_STIC_MAIN_MENU_DESCRIPTION'] = "Configuració de l'estructura i el contingut del menú";
@@ -63,7 +64,7 @@ $mod_strings['LBL_STIC_RUN_SDA_ACTIONS_LINK_TITLE'] = 'Reconstrueix ara';
 $mod_strings['LBL_STIC_RUN_SDA_ACTIONS_DESCRIPTION'] = "Reconstrueix i repara les vistes i els elements necessaris per a la integració amb Sinergia Data Analytics. Si n'hi ha, afegeix els nous camps.";
 $mod_strings['LBL_STIC_GO_TO_SDA_LINK_TITLE'] = 'Ves a Sinergia Data Analytics';
 $mod_strings['LBL_STIC_RUN_SDA_SUCCESS_MSG'] = 'La reconstrucció de Sinergia Data Analytics ha acabat correctament.';
-$mod_strings['LBL_STIC_RUN_SDA_ERROR_MSG'] = "Durant la reconstrucció de Sinergia Data Analytics s'han trobat els següents errors";
+$mod_strings['LBL_STIC_RUN_SDA_ERROR_MSG'] = "Durant la reconstrucció de Sinergia Data Analytics s\'han trobat els següents errors (Contacti amb el suport tècnic de SinergiaTIC si ho considera necessari)";
 
 // Menú principal avançat
 $mod_strings['LBL_STIC_MENU_CONFIGURE_TITLE'] = 'Configuració del menú principal';

--- a/custom/Extension/modules/Administration/Ext/Language/en_us.SticLang.php
+++ b/custom/Extension/modules/Administration/Ext/Language/en_us.SticLang.php
@@ -43,6 +43,7 @@ $mod_strings['LBL_STIC_TEST_DATA_DESCRIPTION'] = 'Load or delete test data.';
 
 $mod_strings['LBL_STIC_SINERGIADA_LINK_TITLE'] = 'Sinergia Data Analytics';
 $mod_strings['LBL_STIC_SINERGIADA_DESCRIPTION'] = 'Rebuild the integration with Sinergia Data Analytics.';
+$mod_strings['LBL_STIC_SINERGIADA_MAX_USERS_ERROR'] = 'Non-admin users limit in SinergiaDA exceeded. Maximum allowed: <b>__max_users__</b>. Current: <b>__enabled_users__</b>. Deactivate some users and try again.';
 
 $mod_strings['LBL_STIC_MAIN_MENU_LINK_TITLE'] = 'Main menu';
 $mod_strings['LBL_STIC_MAIN_MENU_DESCRIPTION'] = 'Set main menu structure and content';
@@ -63,7 +64,7 @@ $mod_strings['LBL_STIC_RUN_SDA_ACTIONS_LINK_TITLE'] = 'Rebuild now';
 $mod_strings['LBL_STIC_RUN_SDA_ACTIONS_DESCRIPTION'] = 'Rebuild and repair the views and other necessary elements for integration with Sinergia Data Analytics. Add new fields if needed.';
 $mod_strings['LBL_STIC_GO_TO_SDA_LINK_TITLE'] = 'Go to Sinergia Data Analytics';
 $mod_strings['LBL_STIC_RUN_SDA_SUCCESS_MSG'] = 'Rebuild of Sinergia Data Analytics has been successfully completed.';
-$mod_strings['LBL_STIC_RUN_SDA_ERROR_MSG'] = 'The following errors have been found in the rebuild of Sinergia Data Analytics';
+$mod_strings['LBL_STIC_RUN_SDA_ERROR_MSG'] = 'The following errors have been found in the rebuild of Sinergia Data Analytics (Contact SinergiaTIC technical support if needed)';
 
 // Advanced main menu
 $mod_strings['LBL_STIC_MENU_CONFIGURE_TITLE'] = 'Main menu settings';

--- a/custom/Extension/modules/Administration/Ext/Language/es_ES.SticLang.php
+++ b/custom/Extension/modules/Administration/Ext/Language/es_ES.SticLang.php
@@ -43,6 +43,7 @@ $mod_strings['LBL_STIC_TEST_DATA_DESCRIPTION'] = 'Cargar o eliminar datos de pru
 
 $mod_strings['LBL_STIC_SINERGIADA_LINK_TITLE'] = 'Sinergia Data Analytics';
 $mod_strings['LBL_STIC_SINERGIADA_DESCRIPTION'] = 'Reconstruye la integración con Sinergia Data Analytics.';
+$mod_strings['LBL_STIC_SINERGIADA_MAX_USERS_ERROR'] = 'Límite de usuarios no administradores en SinergiaDA excedido. Máximo permitido: <b>__max_users__</b>. Actuales: <b>__enabled_users__</b>. Desactive algunos usuarios y reintente.';
 
 $mod_strings['LBL_STIC_MAIN_MENU_LINK_TITLE'] = 'Menú principal';
 $mod_strings['LBL_STIC_MAIN_MENU_DESCRIPTION'] = 'Configuración de la estructura y el contenido del menú';
@@ -63,7 +64,7 @@ $mod_strings['LBL_STIC_RUN_SDA_ACTIONS_LINK_TITLE'] = 'Reconstruir ahora';
 $mod_strings['LBL_STIC_RUN_SDA_ACTIONS_DESCRIPTION'] = 'Reconstruye y repara las vistas y los elementos necesarios para la integración con Sinergia Data Analytics. Añade nuevos campos si los hay.';
 $mod_strings['LBL_STIC_GO_TO_SDA_LINK_TITLE'] = 'Ir a Sinergia Data Analytics';
 $mod_strings['LBL_STIC_RUN_SDA_SUCCESS_MSG'] = 'La reconstrucción de Sinergia Data Analytics se ha completado con éxito.';
-$mod_strings['LBL_STIC_RUN_SDA_ERROR_MSG'] = 'Durante la reconstrucción de Sinergia Data Analytics se han encontrado los siguientes errores';
+$mod_strings['LBL_STIC_RUN_SDA_ERROR_MSG'] = 'Durante la reconstrucción de Sinergia Data Analytics se han encontrado los siguientes errores (Contacte con el soporte técnico de SinergiaTIC si lo considera necesario).';
 
 // Menú principal avanzado
 $mod_strings['LBL_STIC_MENU_CONFIGURE_TITLE'] = 'Configuración del menú principal';

--- a/custom/Extension/modules/Administration/Ext/Language/gl_ES.SticLang.php
+++ b/custom/Extension/modules/Administration/Ext/Language/gl_ES.SticLang.php
@@ -43,6 +43,7 @@ $mod_strings['LBL_STIC_TEST_DATA_DESCRIPTION'] = 'Cargar ou eliminar datos de pr
 
 $mod_strings['LBL_STIC_SINERGIADA_LINK_TITLE'] = 'Sinergia Data Analytics';
 $mod_strings['LBL_STIC_SINERGIADA_DESCRIPTION'] = 'Reconstrúe a integración con Sinergia Data Analytics.';
+$mod_strings['LBL_STIC_SINERGIADA_MAX_USERS_ERROR'] = 'Límite de usuarios non administradores en SinergiaDA excedido. Máximo permitido: <b>__max_users__</b>. Actuais: <b>__enabled_users__</b>. Desactive algúns usuarios e ténteo de novo.';
 
 $mod_strings['LBL_STIC_MAIN_MENU_LINK_TITLE'] = 'Menú principal';
 $mod_strings['LBL_STIC_MAIN_MENU_DESCRIPTION'] = 'Configuración da estrutura e do contido do menú';
@@ -63,7 +64,7 @@ $mod_strings['LBL_STIC_RUN_SDA_ACTIONS_LINK_TITLE'] = 'Reconstruir agora';
 $mod_strings['LBL_STIC_RUN_SDA_ACTIONS_DESCRIPTION'] = 'Reconstrúe e repara as vistas e os elementos necesarios para a integración con Sinergia Data Analytics. Engade novos campos se os hai.';
 $mod_strings['LBL_STIC_GO_TO_SDA_LINK_TITLE'] = 'Ir a Sinergia Data Analytics';
 $mod_strings['LBL_STIC_RUN_SDA_SUCCESS_MSG'] = 'A reconstrución de Sinergia Data Analytics completouse con éxito.';
-$mod_strings['LBL_STIC_RUN_SDA_ERROR_MSG'] = 'Na reconstrución de Sinergia Data Analytics atopáronse os seguintes erros';
+$mod_strings['LBL_STIC_RUN_SDA_ERROR_MSG'] = 'Na reconstrución de Sinergia Data Analytics atopáronse os seguintes erros (Contacte co soporte técnico de SinergiaTIC se o considera necesario)';
 
 // Menú principal avanzado
 $mod_strings['LBL_STIC_MENU_CONFIGURE_TITLE'] = 'Configuración do menú principal';

--- a/custom/Extension/modules/Administration/Ext/Language/gl_ES.SticLang.php
+++ b/custom/Extension/modules/Administration/Ext/Language/gl_ES.SticLang.php
@@ -43,7 +43,7 @@ $mod_strings['LBL_STIC_TEST_DATA_DESCRIPTION'] = 'Cargar ou eliminar datos de pr
 
 $mod_strings['LBL_STIC_SINERGIADA_LINK_TITLE'] = 'Sinergia Data Analytics';
 $mod_strings['LBL_STIC_SINERGIADA_DESCRIPTION'] = 'Reconstrúe a integración con Sinergia Data Analytics.';
-$mod_strings['LBL_STIC_SINERGIADA_MAX_USERS_ERROR'] = 'Límite de usuarios non administradores en SinergiaDA excedido. Máximo permitido: <b>__max_users__</b>. Actuais: <b>__enabled_users__</b>. Desactive algúns usuarios e ténteo de novo.';
+$mod_strings['LBL_STIC_SINERGIADA_MAX_USERS_ERROR'] = 'Excedeuse o límite de usuarios non administradores en SinerxiaDA. Máximo permitido: <b>__max_users__</b>. Valor actual: <b>__enabled_users__</b>. Desactive os usuarios de máis e inténteo de novo.';
 
 $mod_strings['LBL_STIC_MAIN_MENU_LINK_TITLE'] = 'Menú principal';
 $mod_strings['LBL_STIC_MAIN_MENU_DESCRIPTION'] = 'Configuración da estrutura e do contido do menú';
@@ -64,7 +64,7 @@ $mod_strings['LBL_STIC_RUN_SDA_ACTIONS_LINK_TITLE'] = 'Reconstruir agora';
 $mod_strings['LBL_STIC_RUN_SDA_ACTIONS_DESCRIPTION'] = 'Reconstrúe e repara as vistas e os elementos necesarios para a integración con Sinergia Data Analytics. Engade novos campos se os hai.';
 $mod_strings['LBL_STIC_GO_TO_SDA_LINK_TITLE'] = 'Ir a Sinergia Data Analytics';
 $mod_strings['LBL_STIC_RUN_SDA_SUCCESS_MSG'] = 'A reconstrución de Sinergia Data Analytics completouse con éxito.';
-$mod_strings['LBL_STIC_RUN_SDA_ERROR_MSG'] = 'Na reconstrución de Sinergia Data Analytics atopáronse os seguintes erros (Contacte co soporte técnico de SinergiaTIC se o considera necesario)';
+$mod_strings['LBL_STIC_RUN_SDA_ERROR_MSG'] = 'Durante a reconstrución de Sinergia Data Analytics atopáronse os seguintes erros. Contacte co soporte técnico de SinergiaTIC se o considera necesario.';
 
 // Menú principal avanzado
 $mod_strings['LBL_STIC_MENU_CONFIGURE_TITLE'] = 'Configuración do menú principal';

--- a/modules/Administration/QuickRepairAndRebuild.php
+++ b/modules/Administration/QuickRepairAndRebuild.php
@@ -142,7 +142,7 @@ class RepairAndClear
                 isset($_REQUEST['silent']) && $_REQUEST['silent'] == 'true' &&
                 isset($_REQUEST['action']) && in_array($_REQUEST['action'], ['DeleteField', 'DeleteRelationship'])
             ) {
-                $GLOBALS['log']->info('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Action {$_REQUEST['action']}. Rebuilding SinergiaDA");
+                $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Action {$_REQUEST['action']}. Rebuilding SinergiaDA");
                 require_once 'SticInclude/SinergiaDARebuild.php';
                 SinergiaDARebuild::callApiRebuildSDA(true, 'views');
             }

--- a/modules/Administration/QuickRepairAndRebuild.php
+++ b/modules/Administration/QuickRepairAndRebuild.php
@@ -58,6 +58,7 @@ class RepairAndClear
     public function repairAndClearAll($selected_actions, $modules, $autoexecute = false, $show_output = true)
     {
         global $mod_strings;
+        global $sugar_config;
         $this->module_list = $modules;
         $this->show_output = $show_output;
         $this->actions = $selected_actions;


### PR DESCRIPTION
## Description
En este PR se acomenten los siguientes cambios:
1. Se elimina código obsoleto que no se usaba.
2. Se corrigen algunos errores detectado por intellisense.
3. Se elimina la limitación establecida en un PR anterior que limitaba de manera efectiva el número de usuarios no administrdaores que estaban disponibles en SinergiaDA. Ahora, en su lugar, se bloquea el proceso de reconstrucción si el número de usuarios no administradores habilitados de SinergiaDA supera el umbral establecido en la variable `'$sugar_config['stic_sinergiada']['max_users_processed']`, mostrandose un mensaje al usuario.

**Como probarlo**
- Ejecutar la reconstrucción y verificar que el proceso se bloquea si hay más usuarios no administradores habilitados en SinergiaDA que los indicados en la variable `$sugar_config['stic_sinergiada']['max_users_processed']`