### PR TITLE
Incidencia - Calendario laboral - Acción masiva opera con los registros filtrados y seleccionados

### DIFF
--- a/modules/stic_Work_Calendar/controller.php
+++ b/modules/stic_Work_Calendar/controller.php
@@ -283,7 +283,8 @@ class stic_Work_CalendarController extends SugarController
         }
         if (!empty($searchdefs) && !empty($searchFields)) {
             $searchForm = new SearchForm($seed, $module);
-            $searchForm->setup($searchdefs, $searchFields, 'SearchFormGeneric.tpl');
+            $displayView = explode("_", $current_query_by_page_array["searchFormTab"])[0] ?? 'basic';               
+            $searchForm->setup($searchdefs, $searchFields, 'SearchFormGeneric.tpl', $displayView);
             $searchForm->populateFromArray($current_query_by_page_array, $searchForm->displayView);
             $where_clauses_arr = $searchForm->generateSearchWhere(true, $module);
             if (count($where_clauses_arr) > 0) {


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/581

**Descripción del problema**

El PR resuelve lo indicado en el issue relacionado identificando la vista de búsqueda utilizada por el usuario en la vista de lista de Calendario laboral y usando los filtros de está búsqueda en la aplicación de la acción masiva. El error ocurría por que siempre se usaba los filtros de la búsqueda básica y cuando se usaba la avanzada, no aplicaba ningún filtro.


**Pruebas**
1. Ir a Empleados y crear de forma masiva registros de Calendario laboral para 2 usuarios
2. Ir a la vista de lista de Calendario laboral y filtrar desde el filtro avanzado los registros de uno de los usuarios. 
3. Seleccionar la opción de "Seleccionar Todo" y aplicar la opción de "Actualizar la hora de inicio y finalización".
4. Comprobar que la modificación se ha aplicado solo a los registros filtrados 
5. Hacer diferentes pruebas aplicando más de un filtro en ambas vistas de búsqueda y comprobar que la acción se aplica en los registros filtrados. 
