### PR TITLE
Hotfix - ModuleBuilder - No cargar etiquetas globales en los nuevos módulos

### DIFF
--- a/modules/ModuleBuilder/MB/MBLanguage.php
+++ b/modules/ModuleBuilder/MB/MBLanguage.php
@@ -84,7 +84,7 @@ class MBLanguage
     public function loadAppListStrings($file)
     {
         // STIC Custom 20250313 JBL - Fix Language labels in ModuleBuilder
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/601
         // global $app_list_strings;
         // $app_list_strings = $app_list_strings ?? [];
         $app_list_strings = [];

--- a/modules/ModuleBuilder/MB/MBLanguage.php
+++ b/modules/ModuleBuilder/MB/MBLanguage.php
@@ -83,8 +83,12 @@ class MBLanguage
 
     public function loadAppListStrings($file)
     {
-        global $app_list_strings;
-        $app_list_strings = $app_list_strings ?? [];
+        // STIC Custom 20250313 JBL - Fix Language labels in ModuleBuilder
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // global $app_list_strings;
+        // $app_list_strings = $app_list_strings ?? [];
+        $app_list_strings = [];
+        // END STIC Custom
         if (!file_exists($file)) {
             return;
         }


### PR DESCRIPTION
- Relacionado con: https://github.com/salesagility/SuiteCRM/issues/10646

## Descripción
Al crear un paquete o módulo con el constructor de módulos, se añaden en el paquete todas las etiquetas globales definidas en el crm.
Al desplegar el paquete provoca que las etiquetas se carguen de forma inconsistente, mezclando idiomas en ciertas etiquetas según cómo se hayan cargado (de la aplicación o del módulo)

## Cambios realizados
Tal y como se describe en https://github.com/salesagility/SuiteCRM/issues/10646, el error se introduce en la refactorización aplicando Rector en el módulo ModuleBuilder por SuiteCRM: https://github.com/salesagility/SuiteCRM/commit/b966550ea57bfc68926258d6e32d0e8a1416a798
Concretamente en la función `loadAppListStrings`: Antes no cargaba la lista global de etiquetas, ahora sí.

Se procede a no cargar la lista global de etiquetas, iniciando la variable `$app_list_strings` (de ámbito local) a un array vacío.

## Pruebas
1. Crear un nuevo Paquete
2. Añadir un módulo nuevo y guardarlo
3. Verificar que en la carpeta `custom/modulesbuilder/packages/.../application/language` el fichero NO contiene todas las cadenas generales
