### PR TITLE
Hotfix - Vistas Personalizadas - Procesar correctamente los valores de fecha sin horas

### DIFF
--- a/modules/stic_Custom_Views/processor/LogicHooksCode.php
+++ b/modules/stic_Custom_Views/processor/LogicHooksCode.php
@@ -258,6 +258,7 @@ class stic_Custom_Views_ProcessorLogicHooks
                 return str_replace('.', $dec_sep, $value);
 
             case "date":
+                return $timedate->asUser($timedate->fromDbFormat($value, TimeDate::DB_DATE_FORMAT), $current_user);
             case "datetime":
             case "datetimecombo":
                 return $timedate->asUser($timedate->fromDbFormat($value, TimeDate::DB_DATETIME_FORMAT), $current_user);


### PR DESCRIPTION
- Closes #605 

## Descripción
Tal y como se describe en la incidencia #605, si en una Vista Personalizada se le define una condición con un valor fijo sobre un campo Fecha, se produce un error en el servidor y no se procesan los scripts, incluyendo los de las Vistas Personalizadas.

Esto se producía por un error en la conversión del valor leído de la Base de Datos: Convertía la fecha usando el formato `const DB_DATETIME_FORMAT = 'Y-m-d H:i:s'` pero la fecha guardada no tenía información de la hora. El formato correcto de conversión es: `const DB_DATE_FORMAT = 'Y-m-d';`

## Pruebas
1. Crear una Vista Personalizada sobre el módulo de Pagos - Vista de detalle
2. Añadir condición: Campo "fecha de pago", Operador "Más pequeño que", Tipo "Valor", Valor "01/01/2025"
3. Añadir cualquier acción
4. Acceder a la vista detalle de un pago
5. Verificar que se aplica la Vista Personalizada cuando se cumple la condición de la fecha de pago y la vista funciona correctamente

