### PR TITLE
hotfix - Eventos y Sesiones - No rellenar campo Responsable si este no está relleno al crear sesiones periódicas 

### DIFF
--- a/modules/stic_Events/Utils.php
+++ b/modules/stic_Events/Utils.php
@@ -309,10 +309,9 @@ class stic_EventsUtils
             } else {
                 $sessionBean->assigned_user_id = $user;
             }
+            
             if (isset($_REQUEST['responsible_id']) && $_REQUEST['responsible_id'] != '') {
                 $sessionBean->contact_id_c = $_REQUEST['responsible_id'];
-            } else {
-                $sessionBean->contact_id_c = $user;
             }
 
             if (isset($_REQUEST['color']) && $_REQUEST['color'] != '') {


### PR DESCRIPTION
## Descripción
En este PR se elimina el código que asignaba el usuario actual al campo Responsable si esté no había sido rellenado en el formulario de generación periódica de sesiones. 

## Pruebas
1. Crear un evento y acceder al formulario para generar sesiones periódicamente
2. Crear una o varias sesiones sin indicar el campo Responsable
3. Editar una de las sesiones para indicar un color y pulsar en guardar.
4. Comprobar que sí se realiza el guardado y que ya no se muestra el error `No se han encontrado coincidencias para el campo: Responsable` debajo del campo de Responsable. 
