### PR TITLE
Hotfix - Flujos de Trabajo - Modificar subpanel de auditoria de procesos para incluir titulo de Documentos

### DIFF
--- a/custom/include/generic/SugarWidgets/SugarWidgetSubPanelDynamicParentNameLink.php
+++ b/custom/include/generic/SugarWidgets/SugarWidgetSubPanelDynamicParentNameLink.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This file is part of SinergiaCRM.
+ * SinergiaCRM is a work developed by SinergiaTIC Association, based on SuiteCRM.
+ * Copyright (C) 2013 - 2023 SinergiaTIC Association
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program; if not, see http://www.gnu.org/licenses or write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * You can contact SinergiaTIC Association at email address info@sinergiacrm.org.
+ */
+
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+class SugarWidgetSubPanelDynamicParentNameLink extends SugarWidgetField
+{
+    public function displayList(&$layout_def)
+    {
+        $module = '';
+        if (!empty($layout_def['target_module_key']) &&
+            !empty($layout_def['fields'][strtoupper($layout_def['target_module_key'])])) {
+            $module = $layout_def['fields'][strtoupper($layout_def['target_module_key'])];
+        }
+        if (empty($module)) {
+            $module = !empty($layout_def['target_module']) ? $layout_def['target_module'] : $layout_def['module'];
+        }
+
+        $record = '';
+        if (!empty($layout_def['target_record_key']) &&
+            !empty($layout_def['fields'][strtoupper($layout_def['target_record_key'])])) {
+            $record = $layout_def['fields'][strtoupper($layout_def['target_record_key'])];
+        }
+
+        if (empty($module) || empty($record)) {
+            return '';
+        }
+
+        $bean = BeanFactory::newBean($module);
+        if (!$bean) {
+            return "";
+        }
+
+        $bean->disable_row_level_security = true;
+
+        $query = "SELECT * FROM {$bean->table_name} WHERE id = '" . $GLOBALS['db']->quote($record) . "'";
+        $result = $GLOBALS['db']->query($query);
+        $row = $GLOBALS['db']->fetchByAssoc($result);
+
+        if (empty($row)) {
+            return "";
+        }
+
+        $bean->fetched_row = $row;
+        $bean->populateFromRow($row);
+
+        if (method_exists($bean, '_create_proper_name_field')) {
+            $bean->_create_proper_name_field();
+        }
+
+        $value = '';
+        if ($module === 'Documents') {
+            $value = !empty($bean->document_name) ? $bean->document_name : '';
+        } else {
+            $value = !empty($bean->name) ? $bean->name : '';
+        }
+
+
+        $url = "index.php?module={$module}&action=DetailView&record={$record}";
+        return "<a href=\"{$url}\">{$value}</a>";
+    }
+}

--- a/modules/AOW_Processed/metadata/subpanels/default.php
+++ b/modules/AOW_Processed/metadata/subpanels/default.php
@@ -32,11 +32,11 @@ $subpanel_layout = array(
     'where' => '',
 
     'list_fields' => array(
-        'parent_name'=>array(
+        'custom_parent_name'=>array(
             'vname' => 'LBL_BEAN',
             'target_record_key' => 'parent_id',
             'target_module_key'=>'parent_type',
-            'widget_class' => 'SubPanelDetailViewLink',
+            'widget_class' => 'SubPanelDynamicParentNameLink',
             'sortable'=>false,
             'width' => '15%',
         ),


### PR DESCRIPTION
## Descripción

El subpanel de auditoría de procesos no mostraba correctamente el título de los documentos que habían sido modificados por los flujos de trabajo. Esto se debe a que se estaba recogiendo el campo `name`, y el módulo de **Documentos** no lo tiene; en su lugar utiliza el campo `document_name`.


Se ha creado un nuevo archivo, `custom/include/generic/SugarWidgets/SugarWidgetSubPanelDynamicParentNameLink.php`
Este widget personalizado muestra el name en módulos estándar, o document_name si se trata del módulo Documentos. También se ha modificado el archivo `modules/AOW_Processed/metadata/subpanels/default.php` Cambiando la columna `parent_name` para que utilice un nuevo campo `custom_parent_name` que apunta al nuevo widget.

```
        'custom_parent_name'=>array(
            'vname' => 'LBL_BEAN',
            'target_record_key' => 'parent_id',
            'target_module_key'=>'parent_type',
            'widget_class' => 'SubPanelDynamicParentNameLink',
            'sortable'=>false,
            'width' => '15%',
        ),

```
### Pruebas

1. Crear un Flujo de Trabajo basado en Documentos.
2. Forzar su ejecución
3. Verificar que en la auditoría de procesos del Flujo de Trabajo aparece informado el registro
