### PR TITLE
Hotfix - Organizaciones Subvencionadas - Mostrar el módulo en "Selección de módulos y Subpaneles"

### DIFF
--- a/custom/Extension/application/Ext/Include/SticModules.php
+++ b/custom/Extension/application/Ext/Include/SticModules.php
@@ -61,6 +61,7 @@ $moduleList[] = 'stic_Journal';
 $moduleList[] = 'stic_Training';
 $moduleList[] = 'stic_Work_Experience';
 $moduleList[] = 'stic_Skills';
+$moduleList[] = 'stic_Group_Opportunities';
 
 // Bean names for custom modules
 // Although they should be singular ModuleBuilder outputs them in plural and we keep them this way


### PR DESCRIPTION
- Closes #631 

## Descripción
Debido a la aplicación del PR #548, se ocultó por error el módulo "Organizaciones Subvencionadas" del listado de módulos en Administración -> Seleccionar Pestañas de Módulos y Subpaneles

Este PR vuelve a añadir el módulo en el listado de módulos a mostrar/ocultar

## Pruebas 
1. Ir a Adminstración -> Seleccionar Pestañas de Módulos y Subpaneles
2. Verificar que SÍ aparece en "Pestañas Ocultas" el módulo "Organizaciones Subvencionadas"
3. Mostrar el módulo "Organizaciones Subvencionadas"
4. Verificar que se puede acceder al módulo desde el menú "TODO"
