### PR TITLE
Hotfix - Usuarios - No resetear preferencias de usuario en Actualización Masiva

### DIFF
--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -804,11 +804,11 @@ class User extends Person implements EmailInterface
                     $this->setPreference('calendar_publish_key', create_guid());
                 }
             }
-            // STIC Custom 20250508 JBL - Set preferences only from Edit Form
+            // STIC Custom 20250508 JBL - Set preferences only from Edit Form and Initial User Config
             // https://github.com/SinergiaTIC/SinergiaCRM/pull/637
             // $this->saveFormPreferences();
             // $this->savePreferencesToDB();
-            if (isset($_POST['action']) && $_POST['action']=="Save") {
+            if (isset($_POST['action']) && ($_POST['action']=="Save" || $_POST['action']=="SaveUserWizard")) {
                 $this->saveFormPreferences();
                 $this->savePreferencesToDB();
             }

--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -804,8 +804,15 @@ class User extends Person implements EmailInterface
                     $this->setPreference('calendar_publish_key', create_guid());
                 }
             }
-            $this->saveFormPreferences();
-            $this->savePreferencesToDB();
+            // STIC Custom 20250508 JBL - Avoid reset preferences in MassUpdate
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+            // $this->saveFormPreferences();
+            // $this->savePreferencesToDB();
+            if (!isset($_POST['action']) || $_POST['action']!="MassUpdate") {
+                $this->saveFormPreferences();
+                $this->savePreferencesToDB();
+            }
+            // END STIC Custom
 
             // Set the new password in the database
             if ($saveUserAndPassword) {

--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -805,7 +805,7 @@ class User extends Person implements EmailInterface
                 }
             }
             // STIC Custom 20250508 JBL - Avoid reset preferences in MassUpdate
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/637
             // $this->saveFormPreferences();
             // $this->savePreferencesToDB();
             if (!isset($_POST['action']) || $_POST['action']!="MassUpdate") {

--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -808,7 +808,6 @@ class User extends Person implements EmailInterface
             // https://github.com/SinergiaTIC/SinergiaCRM/pull/637
             // $this->saveFormPreferences();
             // $this->savePreferencesToDB();
-            // if (!isset($_POST['action']) || $_POST['action']!="MassUpdate") {
             if (isset($_POST['action']) && $_POST['action']=="Save") {
                 $this->saveFormPreferences();
                 $this->savePreferencesToDB();

--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -804,11 +804,12 @@ class User extends Person implements EmailInterface
                     $this->setPreference('calendar_publish_key', create_guid());
                 }
             }
-            // STIC Custom 20250508 JBL - Avoid reset preferences in MassUpdate
+            // STIC Custom 20250508 JBL - Set preferences only from Edit Form
             // https://github.com/SinergiaTIC/SinergiaCRM/pull/637
             // $this->saveFormPreferences();
             // $this->savePreferencesToDB();
-            if (!isset($_POST['action']) || $_POST['action']!="MassUpdate") {
+            // if (!isset($_POST['action']) || $_POST['action']!="MassUpdate") {
+            if (isset($_POST['action']) && $_POST['action']=="Save") {
                 $this->saveFormPreferences();
                 $this->savePreferencesToDB();
             }


### PR DESCRIPTION
- Closes #636

## Descripción
Tal y como se describe en #636, al hacer una actualización masiva desde el Módulo Usuarios, estos perdían la configuración de la Zona horaria y quedaban en GMT +0.
Esto se producía también en SuiteCRM v7.14.6.

El error era debido a que al guardar un usuario siempre se guardaban sus preferencias, obteniéndolas de `POST` o bien reseteándolas. Para el formulario de edición es correcto, pero no para la Actualización Masiva que estas preferencias no se indican y por tanto se resetean al valor por defecto.

## Pruebas
1. Ir al módulo de Usuarios
2. Editar un usuario y verificar que tiene una Zona horaria distinta a GMT +0
3. En el listado, seleccionar el usuario y realizar una actualización masiva de cualquier campo
4. Al guardar ver que al usuario no se le ha modificado la Zona horaria
