### PR TITLE
Hotfix - General - Error al filtrar cuando el nombre del módulo y la tabla no tienen el mismo número de underscores

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3870,6 +3870,24 @@ class SugarBean
                     $matches
                 );
                 if ($match) {
+                    // Stic-Custom EPS 20250514 - When modules does not have underscore in name but table does (ProejctTask - project_task), it does not get the right values 
+                    if (substr_count($matches[2], '_') > substr_count($matches[3], '_')) {
+                        $matched = $matches[2] . '_ ' .$matches[3];
+                        $parts = explode('_', $matched);
+                        $matches[2] = '';
+                        $matches[3] = '';
+                        $partsLen = count($parts);
+
+                        for($iParts = 0; $iParts < $partsLen; $iParts++) {
+                            if ($iParts < floor($partsLen / 2)) {
+                                $matches[2] .= $parts[$iParts];
+                            }
+                            else {
+                                $matches[3] .= $parts[$iParts];
+                            }
+                        }
+                    }
+                    //END Stic-Custom
                     $joinTableAlias = 'jt' . $jtcount;
                     $joinModule = $matches[2];
                     $joinTable = $matches[3];


### PR DESCRIPTION
## Description
- Closes #640 

Se mantiene la expresión regular usada pero en caso de que los nombres obtenidos tengan distinto número de underscores (caso que no trata correctamente la regex), se realiza una división del nombre especifica dejando un underscore extra en el nombre de la tabla y no en el nombre del módulo como hasta ahora.

## Motivation and Context
Se producía un PHP FATAL y se inutilizaba la vista de lista delusuario cuando se intentaba realizar un filtro por ProjectTask en la vista de lista de reuniones (aplicable también a otros casos).

## How To Test This
1.- En la vista de lista de reuniones, filtrar por una projectTask y comprobar qu no hay error y funciona correctamente.
2.- Comprobar filtros por otras relaciones donde el módulo pueda contenter distinto número de underscores.


