### PR TITLE
Hotfix - General - Recuperar el tipo de relación en relaciones con nombres largos

### DIFF
--- a/include/SubPanel/SubPanelDefinitions.php
+++ b/include/SubPanel/SubPanelDefinitions.php
@@ -259,7 +259,7 @@ class aSubPanel
         // STIC#1157
         global $dictionary;
 
-        // STIC_Custom EPS 20250516 On long relationship names, the name of the subpanel is not the name of the relationship
+        // STIC-Custom EPS 20250516 On long relationship names, the name of the subpanel is not the name of the relationship
         // https://github.com/SinergiaTIC/SinergiaCRM/pull/645
         // $relationshipType = $dictionary[$this->name]['true_relationship_type'] ?? null;
         $relationshipType = $dictionary[($dictionary[($this->parent_bean->module_name)]['fields'][($this->name)]['relationship'])]['true_relationship_type'] ?? null;

--- a/include/SubPanel/SubPanelDefinitions.php
+++ b/include/SubPanel/SubPanelDefinitions.php
@@ -262,7 +262,7 @@ class aSubPanel
         // STIC-Custom EPS 20250516 On long relationship names, the name of the subpanel is not the name of the relationship
         // https://github.com/SinergiaTIC/SinergiaCRM/pull/645
         // $relationshipType = $dictionary[$this->name]['true_relationship_type'] ?? null;
-        $relationshipType = $dictionary[($dictionary[($this->parent_bean->module_name)]['fields'][($this->name)]['relationship'])]['true_relationship_type'] ?? null;
+        $relationshipType = $dictionary[($dictionary[($this->parent_bean->object_name)]['fields'][($this->name)]['relationship'])]['true_relationship_type'] ?? null;
         // END STIC-Custom
         // if($relationshipType == 'one-to-many') {
         if($relationshipType == 'one-to-many' || $relationshipType == 'many-to-one') {

--- a/include/SubPanel/SubPanelDefinitions.php
+++ b/include/SubPanel/SubPanelDefinitions.php
@@ -260,6 +260,7 @@ class aSubPanel
         global $dictionary;
 
         // STIC_Custom EPS 20250516 On long relationship names, the name of the subpanel is not the name of the relationship
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/645
         // $relationshipType = $dictionary[$this->name]['true_relationship_type'] ?? null;
         $relationshipType = $dictionary[($dictionary[($this->parent_bean->module_name)]['fields'][($this->name)]['relationship'])]['true_relationship_type'] ?? null;
         // END STIC-Custom

--- a/include/SubPanel/SubPanelDefinitions.php
+++ b/include/SubPanel/SubPanelDefinitions.php
@@ -259,7 +259,10 @@ class aSubPanel
         // STIC#1157
         global $dictionary;
 
-        $relationshipType = $dictionary[$this->name]['true_relationship_type'] ?? null;
+        // STIC_Custom EPS 20250516 On long relationship names, the name of the subpanel is not the name of the relationship
+        // $relationshipType = $dictionary[$this->name]['true_relationship_type'] ?? null;
+        $relationshipType = $dictionary[($dictionary[($this->parent_bean->module_name)]['fields'][($this->name)]['relationship'])]['true_relationship_type'] ?? null;
+        // END STIC-Custom
         // if($relationshipType == 'one-to-many') {
         if($relationshipType == 'one-to-many' || $relationshipType == 'many-to-one') {
             // STIC-Custom JBL 20240123: Don't show button in Custom views


### PR DESCRIPTION
## Description
- Closes #644 
Se corrige la manera de recuperar el tipo de relación de un subpanel para evitar problemas cuando el nombre en el subpanel y de la relación no coinciden (nombres de relación largos)


## Motivation and Context
Cuando una relación tiene un nombre muy largo, en algunas partes se usa el nombre "reducido" (con números en medio) y en otras partes el nombre entero. Esto provoca, por ejemplo, que el nombre de la relación que se recupera en la definición del subpanel no coincida con el nombre real de la relación (el nombre que acaba en el $dictionary). Este hecho provocaba que al intentar recuperar el tipo de relación al mostrar un subpanel para ver si se debía mostrar o no el botón "Ver en vista de lista" no se encontrase la definición de la relación y el botón no se mostrase en relaciones con el nombre largo.


## How To Test This
1.- Crear dos módulos con módulos largos y una relación 1:n entre ellos
2.- Crear un registro en el módulo padre y comprobar que en el subpanel aparece el botón de "Ver en vista de lista"

