### PR TITLE
Hotfix - Plantillas de Email - No llamar a la funcion loadtemplate()

### DIFF
--- a/custom/modules/EmailTemplates/SticSuiteEditorConnector.php
+++ b/custom/modules/EmailTemplates/SticSuiteEditorConnector.php
@@ -36,7 +36,9 @@ class SticSuiteEditorConnector extends SuiteEditorConnector
             }",
         );
 
-        $settings['tinyMCESetup'] = "{
+        if ($_REQUEST["module"] == "Campaigns") 
+        {   // module Campaigns
+            $settings['tinyMCESetup'] = "{
                 setup: function(editor) {
                     editor.on('focus', function(e){
                         onClickTemplateBody();
@@ -67,6 +69,38 @@ class SticSuiteEditorConnector extends SuiteEditorConnector
                 entity_encoding: 'raw',
                 convert_urls: false,
             }";
+        } 
+        else 
+        {   // module Email Templates
+            $settings['tinyMCESetup'] = "{
+                setup: function(editor) {
+                    editor.on('focus', function(e){
+                        onClickTemplateBody();
+                    });
+                },
+                width: '80%',
+                height : '480',
+                language: '{$userLang}',
+                language_url: 'SticInclude/vendor/tinymce/langs/{$userLang}.js',
+                toolbar1: 'code undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent',
+                toolbar2: 'print preview media | forecolor backcolor | image | emoticons | table | link | fontselect fontsizeselect',
+                resize: 'both',   
+                code_dialog_height: 600,
+                code_dialog_width: 650,
+                plugins: [
+                    'fullpage advlist autolink lists link image charmap print preview hr anchor pagebreak',
+                    'searchreplace wordcount visualblocks visualchars code fullscreen',
+                    'insertdatetime media nonbreaking save table contextmenu directionality',
+                    'emoticons template paste textcolor colorpicker textpattern imagetools'
+                ],                   
+                extended_valid_elements: 'style,html[xmlns],style[dir|lang|media|title|type],hr[class|width|size|noshade],@[class|style]',
+                custom_elements: 'style,link,~link',     
+                content_style:\"@import url('https://fonts.googleapis.com/css2?family=Open+Sans');\",
+                font_formats:'Andale Mono=andale mono,times;Arial=arial,helvetica,sans-serif;Arial Black=arial black,avant garde;Book Antiqua=book antiqua,palatino;Comic Sans MS=comic sans ms,sans-serif;Courier New=courier new,courier;Georgia=georgia,palatino;Helvetica=helvetica;Impact=impact,chicago;Open Sans=Open Sans, sans-serif;Symbol=symbol;Tahoma=tahoma,arial,helvetica,sans-serif;Terminal=terminal,monaco;Times New Roman=times new roman,times;Trebuchet MS=trebuchet ms,geneva;Verdana=verdana,geneva;Webdings=webdings;Wingdings=wingdings,zapf dingbats',                
+                entity_encoding: 'raw',
+                convert_urls: false,
+            }";
+        }
 
         return $settings;
     }


### PR DESCRIPTION
- Closes #658 

## Descripción
El PR soluciona que no se cargue la función **loadtemplate()** fuera del módulo de campañas ya que esta función es necesaria en el contexto 

## Pruebas
1. Configurar TinyMCE como editor del usuario
2. Crear una plantilla desde la opción de Menú de **Nueva Plantilla de Email** del módulo de Campañas
3. Escribir algo en el cuerpo del editor y comprobar que se puede deshacer el cambio pulsando en el icono de deshacer
4. Añadir una tabla y comprobar que se muestra el menú contextual al pulsar en el botón derecho del ratón
5. Crear una campaña y realizar la misma prueba en el paso 3 (Plantillas) del asistente de Campañas.
6. Realizar la misma prueba accediendo al email de marketing a través del subpanel de Emails de marketing. 