### PR TITLE
Hotfix - General - Correcciones de errores PHP

### DIFF
--- a/include/InlineEditing/InlineEditing.php
+++ b/include/InlineEditing/InlineEditing.php
@@ -609,7 +609,11 @@ function convertDateUserToDB($value)
 
 function checkAccess($bean)
 {
-    if ($bean->ACLAccess('EditView')) {
+    // STIC Custom 20250520 JBL - Fix Error: Call to a member function on false
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+    // if ($bean->ACLAccess('EditView')) {
+    if ($bean !== false && $bean->ACLAccess('EditView')) {
+    // END STIC Custom
         return true;
     }
     return false;

--- a/include/Popups/Popup_picker.php
+++ b/include/Popups/Popup_picker.php
@@ -67,9 +67,16 @@ class Popup_Picker
         }
         if (empty($popupMeta)) {
             if (!empty($_REQUEST['metadata']) && $_REQUEST['metadata'] != 'undefined') { // if custom metadata is requested
-                require_once('modules/' . $currentModule . '/metadata/' . $_REQUEST['metadata'] . '.php');
+                // STIC-Custom 20250529 MHP - Avoid requiring files that do not exist, such as modules/Home/metadata/popupdefs.php
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+                if (file_exists('modules/' . $currentModule . '/metadata/' . $_REQUEST['metadata'] . '.php')) {
+                    require_once('modules/' . $currentModule . '/metadata/' . $_REQUEST['metadata'] . '.php');
+                }
             } else {
-                require_once('modules/' . $currentModule . '/metadata/popupdefs.php');
+                if (file_exists('modules/' . $currentModule . '/metadata/popupdefs.php')) {
+                    require_once('modules/' . $currentModule . '/metadata/popupdefs.php');
+                }
+                // END STIC-Custom
             }
         }
         $this->_popupMeta = $popupMeta;

--- a/modules/AOS_PDF_Templates/PDF_Lib/mpdf.php
+++ b/modules/AOS_PDF_Templates/PDF_Lib/mpdf.php
@@ -21199,7 +21199,7 @@ public $aliasNbPgHex;
     }
     if ($w) {
         if (strpos($w, '%') && !$this->ignore_table_percents) {
-            $c['wpercent'] = $w + 0;
+            $c['wpercent'] = (int)$w + 0;
         }	// makes 80% -> 80
         elseif (!strpos($w, '%') && !$this->ignore_table_widths) {
             $c['w'] = $this->ConvertSize($w, $this->blk[$this->blklvl]['inner_width'], $this->FontSize, false);

--- a/modules/Import/views/view.step4.php
+++ b/modules/Import/views/view.step4.php
@@ -73,7 +73,11 @@ class ImportViewStep4 extends SugarView
         // Check to be sure we are getting an import file that is in the right place
         $uploadFile = "upload://".basename((string) $_REQUEST['tmp_file']);
         if (!file_exists($uploadFile)) {
-            trigger_error($mod_strings['LBL_CANNOT_OPEN'], E_USER_ERROR);
+            // STIC-Custom 20250529 MHP - Replace the deprecated trigger_error function with sugar_die function
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+            // trigger_error($mod_strings['LBL_CANNOT_OPEN'], E_USER_ERROR);
+            sugar_die($mod_strings['LBL_CANNOT_OPEN']);
+            // END STIC-Custom
         }
 
         // Open the import file
@@ -81,11 +85,19 @@ class ImportViewStep4 extends SugarView
 
         //Ensure we have a valid file.
         if (!$importSource->fileExists()) {
-            trigger_error($mod_strings['LBL_CANNOT_OPEN'], E_USER_ERROR);
+            // STIC-Custom 20250529 MHP - Replace the deprecated trigger_error function with sugar_die function
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+            // trigger_error($mod_strings['LBL_CANNOT_OPEN'], E_USER_ERROR);
+            sugar_die($mod_strings['LBL_CANNOT_OPEN']);
+            // END STIC-Custom
         }
 
         if (!ImportCacheFiles::ensureWritable()) {
-            trigger_error($mod_strings['LBL_ERROR_IMPORT_CACHE_NOT_WRITABLE'], E_USER_ERROR);
+            // STIC-Custom 20250529 MHP - Replace the deprecated trigger_error function with sugar_die function
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+            // trigger_error($mod_strings['LBL_ERROR_IMPORT_CACHE_NOT_WRITABLE'], E_USER_ERROR);
+            sugar_die($mod_strings['LBL_ERROR_IMPORT_CACHE_NOT_WRITABLE']);
+            // END STIC-Custom
         }
 
         $importer = new Importer($importSource, $this->bean);

--- a/modules/ModuleBuilder/parsers/parser.label.php
+++ b/modules/ModuleBuilder/parsers/parser.label.php
@@ -276,15 +276,25 @@ class ParserLabel
         // will overwrite stuff in custom/modules/{ModuleName}/Ext/Language/en_us.lang.ext.php after
         //  Quick Repair and Rebuild is applied.
         if ($forRelationshipLabel) {
-            if (!empty($_POST[view_module]) && !empty($_POST[relationship_name]) && !empty($_POST[rhs_label]) && !empty($_POST[lhs_module])) {
+            // STIC-Custom 20250603 ART - Undefined constants
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+            // if (!empty($_POST[view_module]) && !empty($_POST[relationship_name]) && !empty($_POST[rhs_label]) && !empty($_POST[lhs_module])) {
                 // 1. Overwrite custom/Extension/modules/{ModuleName}/Ext/Language
-                $extension_basepath = 'custom/Extension/modules/'.$_POST[view_module].'/Ext/Language';
+                // $extension_basepath = 'custom/Extension/modules/'.$_POST[view_module].'/Ext/Language';
+            if (!empty($_POST['view_module']) && !empty($_POST['relationship_name']) && !empty($_POST['rhs_label']) && !empty($_POST['lhs_module'])) {
+                // 1. Overwrite custom/Extension/modules/{ModuleName}/Ext/Language
+                $extension_basepath = 'custom/Extension/modules/'.$_POST['view_module'].'/Ext/Language';
                 mkdir_recursive($extension_basepath);
+                // END STIC-Custom
 
                 $headerString = "<?php\n//THIS FILE IS AUTO GENERATED, DO NOT MODIFY\n";
                 $out = $headerString;
 
-                $extension_filename = "$extension_basepath/$language.custom".$_POST[relationship_name].'.php';
+                // STIC-Custom 20250603 ART - Undefined constants
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+                // $extension_filename = "$extension_basepath/$language.custom".$_POST[relationship_name].'.php';
+                $extension_filename = "$extension_basepath/$language.custom".$_POST['relationship_name'].'.php';
+                // END STIC-Custom
 
                 $mod_strings = array();
                 if (file_exists($extension_filename)) {
@@ -294,9 +304,15 @@ class ParserLabel
 
                 foreach ($labels as $key => $value) {
                     foreach ($mod_strings as $key_mod_string => $value_mod_string) {
-                        if (strpos($key_mod_string, strtoupper($_POST[relationship_name])) !== false) {
-                            $mod_strings[$key_mod_string] = to_html(strip_tags(from_html($_POST[rhs_label]))); // must match encoding used in view.labels.php
+                        // STIC-Custom 20250603 ART - Undefined constants
+                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+                        // if (strpos($key_mod_string, strtoupper($_POST[relationship_name])) !== false) {
+                        //     $mod_strings[$key_mod_string] = to_html(strip_tags(from_html($_POST[rhs_label]))); // must match encoding used in view.labels.php
+                        // }
+                        if (strpos($key_mod_string, strtoupper($_POST['relationship_name'])) !== false) {
+                            $mod_strings[$key_mod_string] = to_html(strip_tags(from_html($_POST['rhs_label']))); // must match encoding used in view.labels.php
                         }
+                        // END STIC-Custom
                     }
                 }
 
@@ -328,7 +344,11 @@ class ParserLabel
                 $headerString = "<?php\n//THIS FILE IS AUTO GENERATED, DO NOT MODIFY\n";
                 $out = $headerString;
 
-                $relationships_filename = "$relationships_basepath/".$_POST[lhs_module].'.php';
+                // STIC-Custom 20250603 ART - Undefined constants
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+                // $relationships_filename = "$relationships_basepath/".$_POST[lhs_module].'.php';
+                $relationships_filename = "$relationships_basepath/".$_POST['lhs_module'].'.php';
+                // END STIC-Custom
 
                 $mod_strings = array();
                 if (file_exists($relationships_filename)) {
@@ -339,8 +359,13 @@ class ParserLabel
                 $changed_mod_strings = false;
                 foreach ($labels as $key => $value) {
                     foreach ($mod_strings as $key_mod_string => $value_mod_string) {
-                        if (strpos($key_mod_string, strtoupper($_POST[relationship_name])) !== false) {
-                            $mod_strings[$key_mod_string] = to_html(strip_tags(from_html($_POST[rhs_label]))); // must match encoding used in view.labels.php
+                        // STIC-Custom 20250603 ART - Undefined constants
+                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+                        // if (strpos($key_mod_string, strtoupper($_POST[relationship_name])) !== false) {
+                            // $mod_strings[$key_mod_string] = to_html(strip_tags(from_html($_POST[rhs_label]))); // must match encoding used in view.labels.php
+                        if (strpos($key_mod_string, strtoupper($_POST['relationship_name'])) !== false) {
+                            $mod_strings[$key_mod_string] = to_html(strip_tags(from_html($_POST['rhs_label']))); // must match encoding used in view.labels.php
+                            // END STIC-Custom
                             $changed_mod_strings = true;
                         }
                     }

--- a/modules/stic_Import_Validation/views/view.step4.php
+++ b/modules/stic_Import_Validation/views/view.step4.php
@@ -48,7 +48,11 @@ class stic_Import_ValidationViewStep4 extends SugarView
         // Check to be sure we are getting an import file that is in the right place
         $uploadFile = "upload://".basename((string) $_REQUEST['tmp_file']);
         if (!file_exists($uploadFile)) {
-            trigger_error($mod_strings['LBL_CANNOT_OPEN'], E_USER_ERROR);
+            // STIC-Custom 20250529 MHP - Replace the deprecated trigger_error function with sugar_die function
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+            // trigger_error($mod_strings['LBL_CANNOT_OPEN'], E_USER_ERROR);
+            sugar_die($mod_strings['LBL_CANNOT_OPEN']);
+            // END STIC-Custom
         }
 
         // Open the import file
@@ -56,11 +60,19 @@ class stic_Import_ValidationViewStep4 extends SugarView
 
         //Ensure we have a valid file.
         if (!$importSource->fileExists()) {
-            trigger_error($mod_strings['LBL_CANNOT_OPEN'], E_USER_ERROR);
+            // STIC-Custom 20250529 MHP - Replace the deprecated trigger_error function with sugar_die function
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+            // trigger_error($mod_strings['LBL_CANNOT_OPEN'], E_USER_ERROR);
+            sugar_die($mod_strings['LBL_CANNOT_OPEN']);
+            // END STIC-Custom
         }
 
         if (!ImportCacheFiles::ensureWritable()) {
-            trigger_error($mod_strings['LBL_ERROR_IMPORT_CACHE_NOT_WRITABLE'], E_USER_ERROR);
+            // STIC-Custom 20250529 MHP - Replace the deprecated trigger_error function with sugar_die function
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
+            // trigger_error($mod_strings['LBL_ERROR_IMPORT_CACHE_NOT_WRITABLE'], E_USER_ERROR);
+            sugar_die($mod_strings['LBL_ERROR_IMPORT_CACHE_NOT_WRITABLE']);
+            // END STIC-Custom
         }
 
         $importer = new Importer($importSource, $this->bean);

--- a/modules/stic_Import_Validation/views/view.step4.php
+++ b/modules/stic_Import_Validation/views/view.step4.php
@@ -48,11 +48,7 @@ class stic_Import_ValidationViewStep4 extends SugarView
         // Check to be sure we are getting an import file that is in the right place
         $uploadFile = "upload://".basename((string) $_REQUEST['tmp_file']);
         if (!file_exists($uploadFile)) {
-            // STIC-Custom 20250529 MHP - Replace the deprecated trigger_error function with sugar_die function
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
-            // trigger_error($mod_strings['LBL_CANNOT_OPEN'], E_USER_ERROR);
             sugar_die($mod_strings['LBL_CANNOT_OPEN']);
-            // END STIC-Custom
         }
 
         // Open the import file
@@ -60,19 +56,11 @@ class stic_Import_ValidationViewStep4 extends SugarView
 
         //Ensure we have a valid file.
         if (!$importSource->fileExists()) {
-            // STIC-Custom 20250529 MHP - Replace the deprecated trigger_error function with sugar_die function
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
-            // trigger_error($mod_strings['LBL_CANNOT_OPEN'], E_USER_ERROR);
             sugar_die($mod_strings['LBL_CANNOT_OPEN']);
-            // END STIC-Custom
         }
 
         if (!ImportCacheFiles::ensureWritable()) {
-            // STIC-Custom 20250529 MHP - Replace the deprecated trigger_error function with sugar_die function
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/661
-            // trigger_error($mod_strings['LBL_ERROR_IMPORT_CACHE_NOT_WRITABLE'], E_USER_ERROR);
             sugar_die($mod_strings['LBL_ERROR_IMPORT_CACHE_NOT_WRITABLE']);
-            // END STIC-Custom
         }
 
         $importer = new Importer($importSource, $this->bean);

--- a/modules/stic_Payments/stic_Payments.php
+++ b/modules/stic_Payments/stic_Payments.php
@@ -188,7 +188,14 @@ class stic_Payments extends Basic
             if (trim($payment_commitment_id) != trim($payment_commitment_id_before)) {
         // END STIC Custom
                 // Get new parent payment commitment bean
-                $PCBean = BeanFactory::getBean('stic_Payment_Commitments', $this->stic_paymebfe2itments_ida);
+                // $PCBean = BeanFactory::getBean('stic_Payment_Commitments', $this->stic_paymebfe2itments_ida);
+                if (isset($this->stic_paymebfe2itments_ida)) {
+                    if ($this->stic_paymebfe2itments_ida instanceof Link2) {
+                        $PCBean = SticUtils::getRelatedBeanObject($this, 'stic_payments_stic_payment_commitments');
+                    } else {
+                        $PCBean = BeanFactory::getBean('stic_Payment_Commitments', $this->stic_paymebfe2itments_ida);
+                    }
+                }
                 // Get payment commmitment related contact (usual case)
                 $contactId = SticUtils::getRelatedBeanObject($PCBean, 'stic_payment_commitments_contacts')->id ?? null; ; 
                 if (!empty($contactId)) {

--- a/modules/stic_Payments/stic_Payments.php
+++ b/modules/stic_Payments/stic_Payments.php
@@ -166,17 +166,18 @@ class stic_Payments extends Basic
     {
         include_once 'SticInclude/Utils.php';
 
-        // If parent payment commitment has changed...
-        // STIC Custom 20250416 JBL - Fix Warnings and TypeErrors
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/315
-        // if (!empty($this->stic_paymebfe2itments_ida) && (trim($this->stic_paymebfe2itments_ida) != trim($this->rel_fields_before_value['stic_paymebfe2itments_ida']))) {
         if (!empty($this->stic_paymebfe2itments_ida)) {
+            // Get actual Payment Commitment ID
             $payment_commitment_id = '';
-            if (is_string($this->stic_paymebfe2itments_ida) || 
-                (is_object($this->stic_paymebfe2itments_ida) && 
-                 method_exists($this->stic_paymebfe2itments_ida, '__toString'))) {
-                $payment_commitment_id = (string)$this->stic_paymebfe2itments_ida;
+            if (isset($this->stic_paymebfe2itments_ida)) {
+                if ($this->stic_paymebfe2itments_ida instanceof Link2) {
+                    $PCBean = SticUtils::getRelatedBeanObject($this, 'stic_payments_stic_payment_commitments');
+                } else {
+                    $PCBean = BeanFactory::getBean('stic_Payment_Commitments', $this->stic_paymebfe2itments_ida);
+                }
+                $payment_commitment_id = $PCBean->id;
             }
+            // Get past Payment Commintment ID
             $payment_commitment_id_before = '';
             if (isset($this->rel_fields_before_value['stic_paymebfe2itments_ida'])) {
                 if (is_string($this->rel_fields_before_value['stic_paymebfe2itments_ida']) ||
@@ -185,17 +186,8 @@ class stic_Payments extends Basic
                     $payment_commitment_id_before = (string)$this->rel_fields_before_value['stic_paymebfe2itments_ida'];
                 }
             }
+            // If parent Payment Commitment has changed...
             if (trim($payment_commitment_id) != trim($payment_commitment_id_before)) {
-        // END STIC Custom
-                // Get new parent payment commitment bean
-                // $PCBean = BeanFactory::getBean('stic_Payment_Commitments', $this->stic_paymebfe2itments_ida);
-                if (isset($this->stic_paymebfe2itments_ida)) {
-                    if ($this->stic_paymebfe2itments_ida instanceof Link2) {
-                        $PCBean = SticUtils::getRelatedBeanObject($this, 'stic_payments_stic_payment_commitments');
-                    } else {
-                        $PCBean = BeanFactory::getBean('stic_Payment_Commitments', $this->stic_paymebfe2itments_ida);
-                    }
-                }
                 // Get payment commmitment related contact (usual case)
                 $contactId = SticUtils::getRelatedBeanObject($PCBean, 'stic_payment_commitments_contacts')->id ?? null; ; 
                 if (!empty($contactId)) {

--- a/modules/stic_Payments/stic_Payments.php
+++ b/modules/stic_Payments/stic_Payments.php
@@ -166,18 +166,17 @@ class stic_Payments extends Basic
     {
         include_once 'SticInclude/Utils.php';
 
+        // If parent payment commitment has changed...
+        // STIC Custom 20250416 JBL - Fix Warnings and TypeErrors
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/315
+        // if (!empty($this->stic_paymebfe2itments_ida) && (trim($this->stic_paymebfe2itments_ida) != trim($this->rel_fields_before_value['stic_paymebfe2itments_ida']))) {
         if (!empty($this->stic_paymebfe2itments_ida)) {
-            // Get actual Payment Commitment ID
             $payment_commitment_id = '';
-            if (isset($this->stic_paymebfe2itments_ida)) {
-                if ($this->stic_paymebfe2itments_ida instanceof Link2) {
-                    $PCBean = SticUtils::getRelatedBeanObject($this, 'stic_payments_stic_payment_commitments');
-                } else {
-                    $PCBean = BeanFactory::getBean('stic_Payment_Commitments', $this->stic_paymebfe2itments_ida);
-                }
-                $payment_commitment_id = $PCBean->id;
+            if (is_string($this->stic_paymebfe2itments_ida) || 
+                (is_object($this->stic_paymebfe2itments_ida) && 
+                 method_exists($this->stic_paymebfe2itments_ida, '__toString'))) {
+                $payment_commitment_id = (string)$this->stic_paymebfe2itments_ida;
             }
-            // Get past Payment Commintment ID
             $payment_commitment_id_before = '';
             if (isset($this->rel_fields_before_value['stic_paymebfe2itments_ida'])) {
                 if (is_string($this->rel_fields_before_value['stic_paymebfe2itments_ida']) ||
@@ -186,8 +185,10 @@ class stic_Payments extends Basic
                     $payment_commitment_id_before = (string)$this->rel_fields_before_value['stic_paymebfe2itments_ida'];
                 }
             }
-            // If parent Payment Commitment has changed...
             if (trim($payment_commitment_id) != trim($payment_commitment_id_before)) {
+        // END STIC Custom
+                // Get new parent payment commitment bean
+                $PCBean = BeanFactory::getBean('stic_Payment_Commitments', $this->stic_paymebfe2itments_ida);
                 // Get payment commmitment related contact (usual case)
                 $contactId = SticUtils::getRelatedBeanObject($PCBean, 'stic_payment_commitments_contacts')->id ?? null; ; 
                 if (!empty($contactId)) {

--- a/modules/stic_Web_Forms/Catcher/Donation/DonationController.php
+++ b/modules/stic_Web_Forms/Catcher/Donation/DonationController.php
@@ -26,6 +26,7 @@ require_once __DIR__ . '/DonationPaymentController.php';
 /**
  * Class that controls the flow for donation forms
  */
+#[AllowDynamicProperties]
 class DonationController extends WebFormDataController
 {
     protected $version = 1; // Allows you to use the same logic for forms generated with different versions of the assistant

--- a/modules/stic_Web_Forms/Catcher/Donation/DonationPaymentBO.php
+++ b/modules/stic_Web_Forms/Catcher/Donation/DonationPaymentBO.php
@@ -23,6 +23,7 @@
 
 require_once __DIR__ . "/../Include/Payment/PaymentBO.php";
 
+#[AllowDynamicProperties]
 class DonationPaymentBO extends PaymentBO
 {
     /**


### PR DESCRIPTION
## Description
En este PR se incluyen algunas correcciones para evitar mensajes de error de PHP.

- Evitar un mensaje de PHP Deprecated en un objeto de los formularios (DonationPaymentBO)

- Evitar abrir ficheros que no existen (Manu)
  1. No consigo reproducir la incidencia. Esta aparenta ser que se abre un popup desde el módulo de HOME y da error ya que no existe el fichero:
  2. Commit con el cambio: 
      https://github.com/SinergiaTIC/SinergiaCRM/pull/661/commits/822b10691f38472d38cabfe787a392642a24f78a


- Sustituir la función obsoleta `trigger_error()` por `sugar_die()` en Importación y Validación de importación (Manu)

  1. No consigo reproducir la incidencia.  Aparenta ocurrir cuando no se puede abrir algún fichero de los que SuiteCRM crea durante la importación (Tb durante la validación de importación ya que es código heredado)
  2. Commits con el cambio: 
      https://github.com/SinergiaTIC/SinergiaCRM/pull/661/commits/2d9ade2d94478429c1e1222c82951d9849dc1daf
      https://github.com/SinergiaTIC/SinergiaCRM/pull/661/commits/414c6b5898bfa7f00fdf00f792f3237852e8ce85

- Evitar un mensaje de error al intentar cambiar la etiqueta de una relación desde Estudio. (Ainara)

- Evitar mensaje de error en Plantillas PDF. (Jordi)

## Motivation and Context
Corregir los errores PHP que se está revisando desde la implantación PHP8.

## How To Test This

- Para el mensaje deprecated, basta con probar un formulario de donación y comprobar que no aparece

- Evitar abrir ficheros que no existen --> Validar por inspección de código ya que no consigo reproducir la incidencia

- Sustituir la función obsoleta `trigger_error()` por `sugar_die()` en Importación y Validación de importación

  Simular la incidencia:

  1. Añadir la línea `trigger_error($mod_strings['LBL_CANNOT_OPEN'], E_USER_ERROR);` al principio de la función `public function display()` del fichero `modules/stic_Import_Validation/views/view.step4.php`
  2. Validar un fichero de importación de cualquier módulo y comprobar que en el paso 4 (Tras pulsar el botón de **Validar Ahora**) se muestra un error sin texto
  

        <img src="https://github.com/user-attachments/assets/927fb9f5-9b88-46c7-9a22-7c013414451c" width="60%" />

  Simular la solución:

  4. Añadir la línea `sugar_die($mod_strings['LBL_CANNOT_OPEN']);` al principio de la función `public function display()` del fichero `modules/stic_Import_Validation/views/view.step4.php`
  5. Validar un fichero de importación de cualquier módulo y comprobar que en el paso 4 (Tras pulsar el botón de **Validar Ahora**) se muestra un error con texto

        <img src="https://github.com/user-attachments/assets/f2d51171-c33c-456e-b1ed-158e76607555" width="60%" />

- Evitar un mensaje de error al intentar cambiar la etiqueta de una relación desde Estudio -> Cambiar el nombre de una etiqueta de una relación desde Estudio, ver que no sale ningún error al intentar guardarlo y comprobar que se ha guardado correctamente.
  1. Commit con el cambio: https://github.com/SinergiaTIC/SinergiaCRM/pull/661/commits/c2cfe08b0473e316b170a46e0cf714ce198708d9