### PR TITLE
Hotfix - General - Error al importar usuarios

### DIFF
--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -766,6 +766,7 @@ class User extends Person implements EmailInterface
         // ) 
         
         // STIC-Custom EPS 20250528 Error importing users
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/662
         // $saveUserAndPassword = $_REQUEST['LDAP_user'] ?: false;
         $ldapUser = $_REQUEST['LDAP_user'] ?? null;
         $saveUserAndPassword = $ldapUser ?: false;

--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -765,7 +765,11 @@ class User extends Person implements EmailInterface
         //     )
         // ) 
         
-        $saveUserAndPassword = $_REQUEST['LDAP_user'] ?: false;
+        // STIC-Custom EPS 20250528 Error importing users
+        // $saveUserAndPassword = $_REQUEST['LDAP_user'] ?: false;
+        $ldapUser = $_REQUEST['LDAP_user'] ?? null;
+        $saveUserAndPassword = $ldapUser ?: false;
+        // END STIC-Custom 
 
         // We won't be validating the password in these two cases:
         // 1- The user didn't fill the required password fields, or one of them


### PR DESCRIPTION
## Description
Se detecta que en el momento de importar usuarios se genera un error por no estar disponible en la REQUEST la variable LDAP. Este error, al producirse dentro de la importación genera un mensaje en pantalla que impide la correcta importación.
Se protege el uso de este parámetro para tratarlo como false en caso que no esté disponible.

## Motivation and Context
No se podía realizar la importación de usaurios.

## How To Test This
1. Crear un fichero para actualizar usuarios
2. Ejecutar la importación y comprobar que no se genera el error