### PR TITLE
Enhancement - General - Mejoras en el sistema de Logs con Loki

### DIFF
--- a/SticInclude/SticRemoteLogLogicHooksCode.php
+++ b/SticInclude/SticRemoteLogLogicHooksCode.php
@@ -119,8 +119,8 @@ class SticRemoteLogLogicHooks
                         'user_admin' => is_admin($current_user),
                     ],
                     'curl_options' => [
-                        CURLOPT_CONNECTTIMEOUT_MS => 500,
-                        CURLOPT_TIMEOUT_MS => 600,
+                        CURLOPT_CONNECTTIMEOUT_MS => 10,
+                        CURLOPT_TIMEOUT_MS => 20,
                     ]
                 ])
             ])

--- a/SticInclude/SticRemoteLogLogicHooksCode.php
+++ b/SticInclude/SticRemoteLogLogicHooksCode.php
@@ -105,7 +105,6 @@ class SticRemoteLogLogicHooks
                         'crm_action' => $_REQUEST['action'] ?? 'N/A',
 
                         'user_admin' => is_admin($current_user),
-                        'user_name' => $current_user->user_name ?? 'unknown',
                     ],
                     'curl_options' => [
                         CURLOPT_CONNECTTIMEOUT_MS => 500,
@@ -141,6 +140,7 @@ class SticRemoteLogLogicHooks
             'url_request_uri' => $_SERVER['REQUEST_URI'],
 
             'user_id' => $current_user->id ?? 'unknown',
+            'user_name' => $current_user->user_name ?? 'unknown',
             'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? 'unknown',
         ]);
 

--- a/SticInclude/SticRemoteLogLogicHooksCode.php
+++ b/SticInclude/SticRemoteLogLogicHooksCode.php
@@ -91,10 +91,15 @@ class SticRemoteLogLogicHooks
                     'context' => [],
                     'labels' => [
                         'app' => 'SinergiaCRM',
+                        'app_version' => $sugar_config['sinergiacrm_version'] ?? 'unknown', 
                         'environment' => $sugar_config['stic_environment'] ?? 'production',
                         'host_name' => $hostname,
                         'error_type' => $error['type'] ?? null,
                         'detected_level' => $messageType,
+
+                        'http_method' => $_SERVER['REQUEST_METHOD'],
+                        'http_status_code' => http_response_code(),
+                        'is_ajax_request' => (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest'),
 
                         'crm_module' => $_REQUEST['module'] ?? 'N/A',
                         'crm_action' => $_REQUEST['action'] ?? 'N/A',
@@ -136,6 +141,7 @@ class SticRemoteLogLogicHooks
             'url_request_uri' => $_SERVER['REQUEST_URI'],
 
             'user_id' => $current_user->id ?? 'unknown',
+            'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? 'unknown',
         ]);
 
     }

--- a/SticInclude/SticRemoteLogLogicHooksCode.php
+++ b/SticInclude/SticRemoteLogLogicHooksCode.php
@@ -77,8 +77,10 @@ class SticRemoteLogLogicHooks
         $entryPoint = 'N/A';
         $module = 'N/A';
         if (str_starts_with($request_uri, '/index.php?entryPoint=')) {
-            $entryPoint = substr($request_uri, strlen('/index.php?entryPoint='));
-            $action = 'entryPoint';
+            $action = 'EntryPoint';
+            $entryPointWithParams = substr($request_uri, strlen('/index.php?entryPoint='));
+            $entryPontParts = explode('&', $entryPointWithParams, 2);
+            $entryPoint = $entryPontParts[0];
         } else if(str_starts_with($request_uri, '/SticMonitor.php')) {
             $action = 'SticMonitor';
         } else {
@@ -112,7 +114,7 @@ class SticRemoteLogLogicHooks
 
                         'crm_module' => $module,
                         'crm_action' => $action,
-                        'crm_entryPoint' => $entryPoint,
+                        'crm_entrypoint' => $entryPoint,
 
                         'user_admin' => is_admin($current_user),
                     ],

--- a/SticInclude/SticRemoteLogLogicHooksCode.php
+++ b/SticInclude/SticRemoteLogLogicHooksCode.php
@@ -95,6 +95,12 @@ class SticRemoteLogLogicHooks
                         'host_name' => $hostname,
                         'error_type' => $error['type'] ?? null,
                         'detected_level' => $messageType,
+
+                        'crm_module' => $_REQUEST['module'] ?? 'N/A',
+                        'crm_action' => $_REQUEST['action'] ?? 'N/A',
+
+                        'user_admin' => is_admin($current_user),
+                        'user_name' => $current_user->user_name ?? 'unknown',
                     ],
                     'curl_options' => [
                         CURLOPT_CONNECTTIMEOUT_MS => 500,
@@ -106,17 +112,23 @@ class SticRemoteLogLogicHooks
 
         // Send execution data and error (if any) to Loki
         $logger->$messageType($log_message, [
-            '_module' => $_REQUEST['module'] ?? 'N/A',
-            '_action' => $_REQUEST['action'] ?? 'N/A',
-            '_record' => $_REQUEST['record'] ?? 'N/A',
+            'crm_record' => $_REQUEST['record'] ?? 'N/A',
             
             'error_message' => $error['message'] ?? null,
             'error_file_full' => $error['file'] ?? null,
             'error_file' => str_replace(dirname(__DIR__, 1). '/', '', $error['file'] ?? ''),
             'error_line' => $error['line'] ?? null,
 
-            'memory_usage' => memory_get_usage(),
-            'memory_peak_usage' => memory_get_peak_usage(),
+            'memory_usage_bytes' => memory_get_usage(),
+            'memory_peak_usage_bytes' => memory_get_peak_usage(),
+
+            'php_pid' => getmypid(),
+            'php_session_id' => session_id(),
+
+            'time_duration_log' => round(microtime(true) - $this->startLogTime, 4),
+            'time_duration_script' => round($this->scriptDuration, 4),
+            'time_sent_log' => microtime(true),
+            'time_start' => $_SERVER['REQUEST_TIME_FLOAT'],
 
             'url_string' => $_SERVER['QUERY_STRING'],
             'url_full' => $full_url,
@@ -124,15 +136,6 @@ class SticRemoteLogLogicHooks
             'url_request_uri' => $_SERVER['REQUEST_URI'],
 
             'user_id' => $current_user->id ?? 'unknown',
-            'user_name' => $current_user->user_name ?? 'unknown',
-
-            'php_session_id' => session_id(),
-            'php_pid' => getmypid(),
-
-            'time_start' => $_SERVER['REQUEST_TIME_FLOAT'],
-            'time_duration_script' => round($this->scriptDuration, 4),
-            'time_duration_log' => round(microtime(true) - $this->startLogTime, 4),
-            'time_sent_log' => microtime(true),
         ]);
 
     }

--- a/SticInclude/SticRemoteLogLogicHooksCode.php
+++ b/SticInclude/SticRemoteLogLogicHooksCode.php
@@ -26,8 +26,15 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 class SticRemoteLogLogicHooks
 {
+    private $scriptDuration = -1;
+    private $startLogTime = -1;
+
     public function server_round_trip($event, $arguments)
     {
+        // Calculate execution time
+        $this->startLogTime = microtime(true);
+        $this->scriptDuration = $this->startLogTime - $_SERVER['REQUEST_TIME_FLOAT'];
+
         global $sugar_config;
         if (
             isset($sugar_config['stic_remote_monitor_enabled']) && $sugar_config['stic_remote_monitor_enabled']
@@ -39,115 +46,126 @@ class SticRemoteLogLogicHooks
             && (!isset($_REQUEST['module']) || (isset($_REQUEST['module']) 
                 && $_REQUEST['module'] != 'Alerts' && $_REQUEST['module'] != 'stic_Time_Tracker') && $_REQUEST['module'] != 'Favorites')
         ) {
-            sticShutdownHandler();
+            $this->sticShutdownHandler();
         }
     }
-}
 
+    /**
+     * Handles logging to SuiteCRM and Loki, even when no errors occur.
+     */
+    protected function sticShutdownHandler() {
+        global $current_user, $sugar_config;
+        
+        $site_url = $sugar_config['site_url'] ?? '';
+        // Clean site URL (removing http/https)
+        $instanceClean = preg_replace('/^https?:\/\//', '', $site_url);
 
-/**
- * Handles logging to SuiteCRM and Loki, even when no errors occur.
- */
-function sticShutdownHandler() {
-    global $current_user, $sugar_config;
-    
-    // Clean site URL (removing http/https)
-    $instanceClean = preg_replace('/^https?:\/\//', '', $sugar_config['site_url'] ?? '');
-    $hostname = $sugar_config['host_name'] ?? 'unknown';
+        $hostname = $sugar_config['host_name'] ?? 'unknown';
+        $full_url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 
-    // Get last error, if any
-    $error = error_get_last();
-    $log_message = "Script executed successfully."; // Default log message
+        // Get last error, if any
+        $error = error_get_last();
+        $log_message = "Script executed successfully."; // Default log message
 
-    // If there's an error, extract details
-    if ($error !== null) {
-        [$errno, $errstr, $errfile, $errline] = [$error['type'], $error['message'], $error['file'], $error['line']];
-        $log_message = "[SuiteCRM Error $errno] $errstr in $errfile on line $errline";
-        // Log to SuiteCRM built-in logger
-        $GLOBALS['log']->fatal($log_message);
+        // If there's an error, extract details
+        if ($error !== null) {
+            [$errno, $errstr, $errfile, $errline] = [$error['type'], $error['message'], $error['file'], $error['line']];
+            $log_message = "[SuiteCRM Error $errno] $errstr in $errfile on line $errline";
+            // Log to SuiteCRM built-in logger
+            $GLOBALS['log']->fatal($log_message);
 
-    }
+        }
 
-    $messageType = $error ? mapPhpErrorToMonologLevel($error['type']) : 'info';
+        $messageType = $error ? $this->mapPhpErrorToMonologLevel($error['type']) : 'info';
 
-    // Calculate execution time
+        if (!class_exists(\Itspire\MonologLoki\Handler\LokiHandler::class)) {
+            require_once 'vendor/autoload.php';
+            require_once 'SticInclude/vendor/monolog-loki/src/main/php/Handler/LokiHandler.php';
+            require_once 'SticInclude/vendor/monolog-loki/src/main/php/Formatter/LokiFormatter.php';
+        }
 
-    if (!class_exists(\Itspire\MonologLoki\Handler\LokiHandler::class)) {
-        require_once 'vendor/autoload.php';
-        require_once 'SticInclude/vendor/monolog-loki/src/main/php/Handler/LokiHandler.php';
-        require_once 'SticInclude/vendor/monolog-loki/src/main/php/Formatter/LokiFormatter.php';
-    }
-
-    $logger = new \Monolog\Logger('loki-no-failure', [
-        new \Monolog\Handler\WhatFailureGroupHandler([
-            new \Itspire\MonologLoki\Handler\LokiHandler([
-                'entrypoint' => $sugar_config['stic_remote_monitor_url'],
-                'context' => [],
-                'labels' => [
-                    'action' => $_REQUEST['action'] ?? 'N/A',
-                    'app' => 'SinergiaCRM',
-                    'environment' => 'production',
-                    'host_name' => $hostname,
-                    'instance' => $instanceClean,
-                    'module' => $_REQUEST['module'] ?? 'N/A',
-                    'site_url' => $instanceClean,
-                ],
-                'client_name' => $instanceClean,
-                'tenant_id' => 'some-tenant',
-                'auth' => ['basic' => ['user', 'password']],
-                'contextPrefix' => 'blabla_',
-                'curl_options' => [
-                    CURLOPT_CONNECTTIMEOUT_MS => 500,
-                    CURLOPT_TIMEOUT_MS => 600,
-                ]
+        $logger = new \Monolog\Logger('loki-no-failure', [
+            new \Monolog\Handler\WhatFailureGroupHandler([
+                new \Itspire\MonologLoki\Handler\LokiHandler([
+                    'entrypoint' => $sugar_config['stic_remote_monitor_url'],
+                    'context' => [],
+                    'labels' => [
+                        'app' => 'SinergiaCRM',
+                        'environment' => $sugar_config['stic_environment'] ?? 'production',
+                        'host_name' => $hostname,
+                        'error_type' => $error['type'] ?? null,
+                        'detected_level' => $messageType,
+                    ],
+                    'curl_options' => [
+                        CURLOPT_CONNECTTIMEOUT_MS => 500,
+                        CURLOPT_TIMEOUT_MS => 600,
+                    ]
+                ])
             ])
-        ])
-    ]);
+        ]);
 
-    // Send execution data and error (if any) to Loki
-    $logger->$messageType($log_message, [
-        'error_type' => $error['type'] ?? null,
-        'error_message' => $error['message'] ?? null,
-        'error_file' => $error['file'] ?? null,
-        'error_line' => $error['line'] ?? null,
-        'memory_usage' => memory_get_usage(),
-        'memory_peak_usage' => memory_get_peak_usage(),
-        'record' => $_REQUEST['record'] ?? 'N/A',
-        'url_string' => $_SERVER['QUERY_STRING'],
-        'request_uri' => $_SERVER['REQUEST_URI'],
-        'user_id' => $current_user->id ?? 'unknown',
-        'user_name' => $current_user->user_name ?? 'unknown',
-        'php_session_id' => session_id(),
-        'php_pid' => getmypid(),
-        'start_time' => $_SERVER['REQUEST_TIME_FLOAT'],
-        'duration' => microtime(true) - $_SERVER['REQUEST_TIME_FLOAT'],
-    ]);
+        // Send execution data and error (if any) to Loki
+        $logger->$messageType($log_message, [
+            '_module' => $_REQUEST['module'] ?? 'N/A',
+            '_action' => $_REQUEST['action'] ?? 'N/A',
+            '_record' => $_REQUEST['record'] ?? 'N/A',
+            
+            'error_message' => $error['message'] ?? null,
+            'error_file_full' => $error['file'] ?? null,
+            'error_file' => str_replace(dirname(__DIR__, 1). '/', '', $error['file'] ?? ''),
+            'error_line' => $error['line'] ?? null,
 
-}
+            'memory_usage' => memory_get_usage(),
+            'memory_peak_usage' => memory_get_peak_usage(),
 
-function mapPhpErrorToMonologLevel(int $errno) {
-    switch ($errno) {
-        case E_ERROR:
-        case E_CORE_ERROR:
-        case E_COMPILE_ERROR:
-        case E_PARSE:
-            return 'critical';
-        case E_USER_ERROR:
-            return 'error';
-        case E_WARNING:
-        case E_CORE_WARNING:
-        case E_COMPILE_WARNING:
-        case E_USER_WARNING:
-            return 'warning';
-        case E_NOTICE:
-        case E_USER_NOTICE:
-        case E_STRICT:
-            return 'notice';
-        case E_DEPRECATED:
-        case E_USER_DEPRECATED:
-            return 'info';
-        default:
-            return 'error'; // fallback
+            'url_string' => $_SERVER['QUERY_STRING'],
+            'url_full' => $full_url,
+            'url_site' => $site_url,
+            'url_request_uri' => $_SERVER['REQUEST_URI'],
+
+            'user_id' => $current_user->id ?? 'unknown',
+            'user_name' => $current_user->user_name ?? 'unknown',
+
+            'php_session_id' => session_id(),
+            'php_pid' => getmypid(),
+
+            'time_start' => $_SERVER['REQUEST_TIME_FLOAT'],
+            'time_duration_script' => round($this->scriptDuration, 4),
+            'time_duration_log' => round(microtime(true) - $this->startLogTime, 4),
+            'time_sent_log' => microtime(true),
+        ]);
+
+    }
+
+    private function mapPhpErrorToMonologLevel(int $errno) {
+        switch ($errno) {
+            case E_ERROR:
+            case E_CORE_ERROR:
+            case E_COMPILE_ERROR:
+            case E_PARSE:
+            case E_RECOVERABLE_ERROR:
+                return 'critical';
+
+            case E_USER_ERROR:
+                return 'error';
+
+            case E_WARNING:
+            case E_CORE_WARNING:
+            case E_COMPILE_WARNING:
+            case E_USER_WARNING:
+                return 'warning';
+
+            case E_NOTICE:
+            case E_USER_NOTICE:
+                return 'notice';
+
+            case E_DEPRECATED:
+            case E_USER_DEPRECATED:
+                return 'info';
+
+            default:
+                return 'error'; // fallback
+        }
     }
 }
 

--- a/SticInclude/SticRemoteLogLogicHooksCode.php
+++ b/SticInclude/SticRemoteLogLogicHooksCode.php
@@ -71,6 +71,21 @@ class SticRemoteLogLogicHooks
             $GLOBALS['log']->{$errorInfo['SuitecrmLevel']}($errorInfo['LogMessage']);
         }
 
+        // Get info about call
+        $request_uri = $_SERVER['REQUEST_URI'] ?? '';
+        $queryString = $_SERVER['QUERY_STRING'] ?? '';
+        $entryPoint = 'N/A';
+        $module = 'N/A';
+        if (str_starts_with($request_uri, '/index.php?entryPoint=')) {
+            $entryPoint = substr($request_uri, strlen('/index.php?entryPoint='));
+            $action = 'entryPoint';
+        } else if(str_starts_with($request_uri, '/SticMonitor.php')) {
+            $action = 'SticMonitor';
+        } else {
+            $module = $_REQUEST['module'] ?? 'N/A';
+            $action = $_REQUEST['action'] ?? 'N/A';
+        }
+
 
         if (!class_exists(\Itspire\MonologLoki\Handler\LokiHandler::class)) {
             require_once 'vendor/autoload.php';
@@ -95,8 +110,9 @@ class SticRemoteLogLogicHooks
                         'http_status_code' => http_response_code(),
                         'is_ajax_request' => (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest'),
 
-                        'crm_module' => $_REQUEST['module'] ?? 'N/A',
-                        'crm_action' => $_REQUEST['action'] ?? 'N/A',
+                        'crm_module' => $module,
+                        'crm_action' => $action,
+                        'crm_entryPoint' => $entryPoint,
 
                         'user_admin' => is_admin($current_user),
                     ],
@@ -128,10 +144,10 @@ class SticRemoteLogLogicHooks
             'time_sent_log' => microtime(true),
             'time_start' => $_SERVER['REQUEST_TIME_FLOAT'],
 
-            'url_string' => $_SERVER['QUERY_STRING'],
+            'url_string' => $queryString, 
             'url_full' => $full_url,
             'url_site' => $site_url,
-            'url_request_uri' => $_SERVER['REQUEST_URI'],
+            'url_request_uri' => $request_uri,
 
             'user_id' => $current_user->id ?? 'unknown',
             'user_name' => $current_user->user_name ?? 'unknown',


### PR DESCRIPTION
## Descripción
Modificación del fichero para que se carguen de forma correcta las librerías de Monolog Loki para PHP (https://github.com/itspire/monolog-loki), que ha sido integrado en el código de SinergiaCRM.

Sin este cambio, se producen fatal errors de PHP al no poder cargar la librería.

También se han movido varios campos clave de tipo contexto a tipo label para mejorar la indexación en Loki.

## Pruebas
Para comprobar que este cambio funciona correctamente, se puede revisar el log de errrores de PHP y comprobar que no aparecen fatal error relacionados con Monolog.

Para probar que funciona la ingesta de log, se debe activar ésta mediante los parámetros:
  stic_remote_monitor_enabled=true
  stic_remote_monitor_url=<url_loki>

Más info: https://github.com/SinergiaTIC/DevOps/issues/6#issuecomment-2909811056