### PR TITLE
Hotfix - General - Filtros en vista lista: Cargar correctamente listados en los campos "Creado por" / "Modificado por"

### DIFF
--- a/include/SearchForm/SearchForm2.php
+++ b/include/SearchForm/SearchForm2.php
@@ -127,6 +127,24 @@ class SearchForm
     public function setup($searchdefs, $searchFields = array(), $tpl = 'SubpanelSearchFormGeneric.tpl', $displayView = 'basic_search', $listViewDefs = array())
     {
         $this->searchdefs = isset($searchdefs[$this->module]) ? $searchdefs[$this->module] : null;
+
+        // STIC Custom 20250528 JBL - Show options list in "Modified By" and "Created By" filters 
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/??
+        if (isset($this->searchdefs['layout'])) {
+            foreach ($this->searchdefs['layout'] as $layoutType => $fields) {
+                foreach ($fields as $key => $field) {
+                    if (isset($field['type']) && $field['type'] == "assigned_user_name") {
+                        $this->searchdefs['layout'][$layoutType][$key]['type'] = "enum";
+                        $this->searchdefs['layout'][$layoutType][$key]['function'] = array (
+                            'name' => 'get_user_array',
+                            'params' => array(false),
+                        );
+                    }
+                }
+            }
+        }
+        // END STIC Custom
+
         $this->tpl = $tpl;
         //used by advanced search
         $this->listViewDefs = $listViewDefs;


### PR DESCRIPTION
- Closes #660 

## Descripción
Como se describe en #660, en los  campos "Creado por" y "Modificado por" de los filtros de cualquier vista de Lista, no se cargaban los listados de valores posibles. 
Este error se producía en cualquier módulo.

## Solución implementada
Se o

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->