### PR TITLE
Hotfix -  Economía -  Error en los mensajes  informativos de las remesas.

### DIFF
--- a/modules/stic_Remittances/GenerateSEPADirectDebits.php
+++ b/modules/stic_Remittances/GenerateSEPADirectDebits.php
@@ -129,7 +129,11 @@ function generateSEPADirectDebits($remittance)
             and pr.deleted = 0
             and p.deleted = 0";
     $result = $db->query($sqlPayments);
-
+        
+    // Error and warning messages
+    $errorMsg = '';
+    $warningMsg = '';
+    
     // We process the payments obtained and prepare them for the remittance
     while ($paymentResult = $db->fetchByAssoc($result)) {
 
@@ -179,10 +183,6 @@ function generateSEPADirectDebits($remittance)
         // 1) That the person / organization exists and has a name / surname
         $debtorName = '';
         
-        // Error and warning messages
-        $errorMsg = '';
-        $warningMsg = '';
-
         // If the debtor is a person
         if ($contact) {
             $debtorName = SticUtils::cleanText(trim($contact['first_name'] . ' ' . $contact['last_name']));


### PR DESCRIPTION
## Descripción
En la actualización del core a la versión 7.14.6 de SuiteCRM, se introdujo un error en el código de la generación de remesas de recibos. Con el fin de evitar los mensajes de warnings generados debido al uso de ".=" sobre `$errorMsg` y `$warningMsg`, se inicializaron estos antes de su uso, pero se hizo en un lugar incorrecto, dentro del bucle `while` que procesa los diferentes pagos incluidos, en lugar de hacerlo fuera como es necesario. Esto provoca que si después de detectarse un error o un warning en un pago, se encuentra otro que no lo tiene, la cadena almacenada en `$errorMsg` o en `$warningMsg` quedaban vacías, interpretándose posteriormente la no existencia de errores y provocando el fallo descrito.

Ahora se corrige este código y se mueve la inicialización de estas variables fuera del bucle `while`. La misma solución se aplica en la creación de las remesas de transferencias, a pesar de que en estas últimas no se aplicó el mismo código para prevenir los mensajes de tipo warning de PHP.

## Cómo probarlo

**Remesas de Recibos:**
**NOTA: es necesario incluir varios errores en cada una de las pruebas, no es suficiente un solo error.**
1.  Crear una remesa que contenga pagos con varios errores bloqueantes (por ejemplo, pagos sin persona ni organización  o sin compromiso de pago, o importes en negativo).
2.  Comprobar que no se genera el XML de la remesa y que se informa de todos los errores detectados.
3.  Crear una remesa que contenga pagos cuyas personas no tengan número de identificación y/o pagos que tengan el estado como pagado.
4.  Comprobar que se genera el XML de la remesa y que se muestran los avisos correspondientes (personas sin número de identificación, pagos ya pagados).

**Remesas de Transferencias:**

1. Crear una remesa que contenga varios pagos in Persona ni Organización.
2. Verificar que no se crea el fichero XML y que se informa correcatmente de todos los pagos con error
3. Crear una remesa de transferencias que contenga pagos que ya estén marcados como pagados.
4. Comprobar que se genera el XML de la remesa y que se muestran los avisos correspondientes (pagos ya pagados).
