### PR TITLE
Hotfix - Flujos de Trabajo - Uso correcto de campos de tipo fecha en acciones de flujos de trabajo.

### DIFF
--- a/modules/AOW_Actions/actions/actionCreateRecord.php
+++ b/modules/AOW_Actions/actions/actionCreateRecord.php
@@ -308,6 +308,7 @@ class actionCreateRecord extends actionBase
                                     // https://github.com/SinergiaTIC/SinergiaCRM/pull/477
                                     // $date = $timedate->fromUser($bean->$dateToUse)->asDB();
                                     // STIC Custom 20250613 JBL - Fix Uncaught Error: Use correct date format.
+                                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/678
                                     // $date = $timedate->fromUser($bean->$dateToUse)?->asDB();
                                     $date = $timedate->fromUser($bean->$dateToUse)?->asDB();
                                     // Check for date (without time)

--- a/modules/AOW_Actions/actions/actionCreateRecord.php
+++ b/modules/AOW_Actions/actions/actionCreateRecord.php
@@ -308,7 +308,11 @@ class actionCreateRecord extends actionBase
                                     // STIC Custom 20250331 JBL - Fix Uncaught Error: Call to a member function asDB() on null
                                     // https://github.com/SinergiaTIC/SinergiaCRM/pull/477
                                     // $date = $timedate->fromUser($bean->$dateToUse)->asDB();
-                                    $date = $timedate->fromUser($bean->$dateToUse)?->asDB();
+                                    // STIC Custom 20250613 JBL - Fix Uncaught Error: Use correct date format.
+                                    // $date = $timedate->fromUser($bean->$dateToUse)?->asDB();
+                                    $date = $timedate->fromUser($bean->$dateToUse)?->asDB() ?? 
+                                            $timedate->fromUserDate($bean->$dateToUse)?->asDB();
+                                    // END STIC Custom 20250613
                                     // END STIC Custom
                                 }
 

--- a/modules/AOW_Actions/actions/actionCreateRecord.php
+++ b/modules/AOW_Actions/actions/actionCreateRecord.php
@@ -310,12 +310,22 @@ class actionCreateRecord extends actionBase
                                     // STIC Custom 20250613 JBL - Fix Uncaught Error: Use correct date format.
                                     // https://github.com/SinergiaTIC/SinergiaCRM/pull/678
                                     // $date = $timedate->fromUser($bean->$dateToUse)?->asDB();
-                                    $date = $timedate->fromUser($bean->$dateToUse)?->asDB();
-                                    // Check for date (without time)
-                                    if ($date == null) {
-                                        $res = $timedate->fromUserDate($bean->$dateToUse);
-                                        if($res !== false) {
-                                            $date = $res?->asDB();
+
+                                    // Check if date to use is in db format
+                                    $dateInDbFormat = DateTime::createFromFormat($dformat, $bean->$dateToUse);
+                                    if ($dateInDbFormat !== false) {
+                                        $date = $bean->$dateToUse;
+                                    } else {
+                                        // Date to use is in user format: Can be DateTime or Date
+
+                                        // Check for dateTime
+                                        $date = $timedate->fromUser($bean->$dateToUse)?->asDB();
+                                        // Check for date (without time)
+                                        if ($date == null) {
+                                            $res = $timedate->fromUserDate($bean->$dateToUse);
+                                            if($res !== false) {
+                                                $date = $res?->asDB();
+                                            }
                                         }
                                     }
                                     // END STIC Custom 20250613

--- a/modules/AOW_Actions/actions/actionCreateRecord.php
+++ b/modules/AOW_Actions/actions/actionCreateRecord.php
@@ -304,14 +304,19 @@ class actionCreateRecord extends actionBase
                                     $date = $params['value'][$key][0];
                                 } else {
                                     $dateToUse = $params['value'][$key][0];
-                                    $bean->retrieve($bean->id);
                                     // STIC Custom 20250331 JBL - Fix Uncaught Error: Call to a member function asDB() on null
                                     // https://github.com/SinergiaTIC/SinergiaCRM/pull/477
                                     // $date = $timedate->fromUser($bean->$dateToUse)->asDB();
                                     // STIC Custom 20250613 JBL - Fix Uncaught Error: Use correct date format.
                                     // $date = $timedate->fromUser($bean->$dateToUse)?->asDB();
-                                    $date = $timedate->fromUser($bean->$dateToUse)?->asDB() ?? 
-                                            $timedate->fromUserDate($bean->$dateToUse)?->asDB();
+                                    $date = $timedate->fromUser($bean->$dateToUse)?->asDB();
+                                    // Check for date (without time)
+                                    if ($date == null) {
+                                        $res = $timedate->fromUserDate($bean->$dateToUse);
+                                        if($res !== false) {
+                                            $date = $res?->asDB();
+                                        }
+                                    }
                                     // END STIC Custom 20250613
                                     // END STIC Custom
                                 }


### PR DESCRIPTION
### Descripción
Se ha detectado que los Flujos de Trabajo (FdT) que modificaban campos en función de un campo de fecha producían un error por el cual se tomaba la fecha actual como resultado en lugar del valor del campo de fecha seleccionado.

Este error se daba en campos de tipo date, ya que se intentaba evaluarlos como si fueran de tipo datetime, lo que devolvía null. En PHP 7 esto no ocurría debido a una mayor flexibilidad en el manejo de tipos.

Se ha modificado la función en el siguiente fragmento:
https://github.com/SinergiaTIC/SinergiaCRM/blob/78318863eff5a51d2c78d5f8689f2fdf1eb02b22/modules/AOW_Actions/actions/actionCreateRecord.php#L307-L313
para tratar específicamente los campos de tipo date y datetime de forma adecuada.

### Pruebas a realizar

1. Crear un Flujo de Trabajo (FdT) sobre el módulo Subvenciones.
2. Añadir una acción de tipo Modificar campos, configurando lo siguiente:
   Fecha de pago:  Fecha de presentación + 2 years
3. Comprobar que la fecha de pago se calcula y guarda correctamente.
Hacer pruebas al guardar, siempre, en el planificador



