### PR TITLE
Incidencia - Calendario Laboral - Evitar error JS al importar registros

### DIFF
--- a/modules/stic_Work_Calendar/stic_Work_Calendar.php
+++ b/modules/stic_Work_Calendar/stic_Work_Calendar.php
@@ -119,7 +119,7 @@ class stic_Work_Calendar extends Basic
         }      
 
         // Set weekday field
-        if ($this->start_date != $this->fetched_row['start_date']) {
+        if (isset($this->fetched_row['start_date']) && $this->start_date != $this->fetched_row['start_date']) {
             $this->weekday = date('w', strtotime($startDateInTZ));
         }
 


### PR DESCRIPTION
- Closes #681 

## Descripción
El PR comprueba que exista un elemento en un array asociativo antes de intentar acceder al elemento.

## Pruebas
1. Indicar `error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED` en **php-ini-overrides.ini** o probar en nuestra instancia de develop
2. Exportar X registros de calendario laboral
3. Importar el fichero exportado indicando en el paso 3 (mapeo de columnas y campos) que no se asocie el campo ID 
4. Comprobar que en el paso 4 ya no ocurre el error JS mostrado en el issue asociado
