### PR TITLE
Hotfix - Pagos - Evitar FATAL al recibir un Link2

### DIFF
--- a/modules/stic_Payments/stic_Payments.php
+++ b/modules/stic_Payments/stic_Payments.php
@@ -166,17 +166,18 @@ class stic_Payments extends Basic
     {
         include_once 'SticInclude/Utils.php';
 
-        // If parent payment commitment has changed...
-        // STIC Custom 20250416 JBL - Fix Warnings and TypeErrors
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/315
-        // if (!empty($this->stic_paymebfe2itments_ida) && (trim($this->stic_paymebfe2itments_ida) != trim($this->rel_fields_before_value['stic_paymebfe2itments_ida']))) {
         if (!empty($this->stic_paymebfe2itments_ida)) {
+            // Get actual Payment Commitment ID
             $payment_commitment_id = '';
-            if (is_string($this->stic_paymebfe2itments_ida) || 
-                (is_object($this->stic_paymebfe2itments_ida) && 
-                 method_exists($this->stic_paymebfe2itments_ida, '__toString'))) {
-                $payment_commitment_id = (string)$this->stic_paymebfe2itments_ida;
+            if (isset($this->stic_paymebfe2itments_ida)) {
+                if ($this->stic_paymebfe2itments_ida instanceof Link2) {
+                    $PCBean = SticUtils::getRelatedBeanObject($this, 'stic_payments_stic_payment_commitments');
+                } else {
+                    $PCBean = BeanFactory::getBean('stic_Payment_Commitments', $this->stic_paymebfe2itments_ida);
+                }
+                $payment_commitment_id = $PCBean->id;
             }
+            // Get past Payment Commintment ID
             $payment_commitment_id_before = '';
             if (isset($this->rel_fields_before_value['stic_paymebfe2itments_ida'])) {
                 if (is_string($this->rel_fields_before_value['stic_paymebfe2itments_ida']) ||
@@ -185,10 +186,8 @@ class stic_Payments extends Basic
                     $payment_commitment_id_before = (string)$this->rel_fields_before_value['stic_paymebfe2itments_ida'];
                 }
             }
+            // If parent Payment Commitment has changed...
             if (trim($payment_commitment_id) != trim($payment_commitment_id_before)) {
-        // END STIC Custom
-                // Get new parent payment commitment bean
-                $PCBean = BeanFactory::getBean('stic_Payment_Commitments', $this->stic_paymebfe2itments_ida);
                 // Get payment commmitment related contact (usual case)
                 $contactId = SticUtils::getRelatedBeanObject($PCBean, 'stic_payment_commitments_contacts')->id ?? null; ; 
                 if (!empty($contactId)) {


### PR DESCRIPTION
## Description
Se incluye en este PR una modificación para evitar un Fatal dentro de stic_Payments cuando se recibe un objeto Link2 en lugar de un id.


## How To Test This
Para replicar el Fatal de stic_Payments:
  1.- Crear un FdT sobre Payments con condición estado pagado, acción calcular campos
  2.- Crear un CdP, que creará un pago "pendiente"
  4.- Desde el subpanel de CdP, editar el pago y cambiar el estado a Pagado

Se recomienda comprobar el error sobre la rama develop y repetir la prueba una vez aplicado el PR.
Así mismo, se recomienda hacer pruebas no previstas para verificar que no se encuentra ningún escenario en el que el cambio introducido genere error.


