### PR TITLE
Hotfix - SinergiaDA - Optimización de rendimiento en vistas SinergiaDA por eliminación de CAST

### DIFF
--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -628,7 +628,7 @@ class ExternalReporting
                         // Create listViewName for use in metadata & view creation
                         $listViewName = substr(join('_', [$tableName, $fieldV['name'], $listName]), 0, 58);
 
-                        $fieldSrc = " IFNULL(CAST({$fieldPrefix}.{$fieldV['name']} AS CHAR),'') AS {$fieldName}";
+                        $fieldSrc = " IFNULL({$fieldPrefix}.{$fieldV['name']} ,'') AS {$fieldName}";
 
                         $createdListView = $this->createEnumView($listName, $listViewName);
 


### PR DESCRIPTION
- resolve #690 
### Descripción

Se ha identificado que el uso de la función `CAST()` para forzar la conversión de columnas de texto en las vistas de SinergiaDA está generando un impacto significativo en el rendimiento de las consultas. Esta conversión anula la capacidad del optimizador de MariaDB para utilizar índices en las columnas afectadas, lo que resulta en escaneos completos de tablas en lugar de búsquedas indexadas. El problema se agrava en el contexto de las vistas de MariaDB debido al número de relaciones entre las diferentes vistas.

Las pruebas realizadas con la consulta mencionada en el issue #690 han demostrado una mejora sustancial en los tiempos de respuesta, pasando de más de 60 segundos a 2.2 segundos para el mismo conjunto de datos.

### Solución aplicada

Este Pull Request elimina la conversión explícita mediante `CAST()` de las columnas de tipo `enum`, `dynamicenum`, `bool` y `radioenum` en las vistas de SinergiaDA. Se ha evaluado el posible impacto de este cambio en otras áreas del sistema y no se han encontrado efectos no previstos.

El cambio es perceptible en instancias con un volumen considerable de datos. Se recomienda realizar pruebas en entornos con aproximadamente 20,000 personas y un número similar de inscripciones, ya que las pruebas en entornos locales pueden no reflejar la mejora de rendimiento.

### Cómo Reproducirlo

Para verificar la mejora de rendimiento y el correcto funcionamiento tras la aplicación de este cambio, usar la siguiente query:
```sql
SELECT
    `sda_contacts`.`full_name` as `Nom complet`,
    count( distinct `sda_stic_registrations`.`id`) as `Nº Inscripciones`
FROM
    sda_contacts
LEFT JOIN `sda_stic_registrations` ON     `sda_contacts`.`id` =  sda_stic_registrations.stic_registrations_contactscontacts_ida
group by
    `sda_contacts`.`full_name`
```

1.  **Ejecutar la consulta del issue**
    * Ejecutar la consulta *antes* de aplicar los cambios de este PR. Anota el tiempo de respuesta.
    * Aplicar los cambios propuestos en este PR.
    * Ejecutar la misma consulta *después* de aplicar los cambios y realizar un `rebuild` para que los cambios en la estructura de las vistas surtan efecto. Comparar los tiempos de respuesta.

3.  **Revisar el funcionamiento en SinergiaDA:**
    * Navegar por la interfaz de SinergiaDA y verificar el correcto funcionamiento de los campos de tipo `enum`, `dynamicenum`, `bool` y `radioenum`.
    * Prestar especial atención a la funcionalidad de los filtros asociados a estos tipos de campos para asegurar que continúan operando como se espera.