### PR TITLE
Hotfix - Eventos - Construir el nombre del módulo correctamente

### DIFF
--- a/modules/EmailTemplates/EmailTemplateParser.php
+++ b/modules/EmailTemplates/EmailTemplateParser.php
@@ -195,10 +195,12 @@ class EmailTemplateParser
 
         // STIC-Custom 20250624 MHP - Get the module name correctly
         // https://github.com/SinergiaTIC/SinergiaCRM/pull/696
-        if ($this->campaign->campaign_type == 'Notification' && $this->module->module_name == 'stic_Events') 
+        // $parts = explode($charUnderscore, ltrim($variable, $charVariable));
+        // list($moduleName, $attribute) = [array_shift($parts), implode($charUnderscore, $parts)];
+        if ($this->campaign->campaign_type == 'Notification')
         {
             $variable = ltrim($variable, $charVariable);
-            $moduleName = 'stic_events';
+            $moduleName = strtolower($this->module->object_name);
             $attribute = substr($variable, strlen($moduleName . '_'));
         } else {
             $parts = explode($charUnderscore, ltrim($variable, $charVariable));


### PR DESCRIPTION
- Closes #695 

## Descripción
El PR soluciona, para campañas de notificación de eventos, que el nombre del módulo se construya correctamente y así poder parsear los campos de Eventos indicados en la plantilla


## Pruebas
1. Crear un evento con datos en los campos: Nombre, Fecha de inicio, Fecha de finalización y Ubicación
2. Crear una campaña de notificación de Eventos desde la creación clásica de Campañas. Seleccionar la plantilla de Email: Ejemplo - Nuevo Evento
3. Realizar el envió de la campaña
4. Comprobar que en el email Sí aparece la información del evento. 