### PR TITLE
Hotfix - Plantillas de email - Relacionar “Asignado a” y actualizar campos de Remitente con la info del SMTP

### DIFF
--- a/custom/modules/Campaigns/SticUtils.js
+++ b/custom/modules/Campaigns/SticUtils.js
@@ -96,7 +96,6 @@ $(document).ready(function() {
       ).prependTo("[data-id='LBL_NOTIFICATION_INFORMATION_PANEL'] .tab-content .row");
 
       $("#notification_outbound_email_id").on("change paste keyup", mail_change);
-      $("#notification_inbound_email_id").on("change paste keyup", mail_change);
       $("#notification_template_id").on("change paste keyup", template_change);
     }
 
@@ -138,10 +137,10 @@ function type_change() {
 }
 
 function mail_change() {
-  if (STIC && STIC.campaignEmails && STIC.campaignEmails.inbound) {
-    var inbound = STIC.campaignEmails.inbound.find(item => item.id === $("#notification_inbound_email_id").val());
-    $("#notification_from_name").val(inbound ? inbound.name : "");
-    $("#notification_from_addr").val(inbound ? inbound.addr : "");
+  if (STIC && STIC.campaignEmails && STIC.campaignEmails.outbound) {
+    var outbound = STIC.campaignEmails.outbound.find(item => item.id === $("#notification_outbound_email_id").val());
+    $("#notification_from_name").val(outbound ? outbound.name : "");
+    $("#notification_from_addr").val(outbound ? outbound.addr : "");
   }
 }
 

--- a/custom/modules/EmailTemplates/EditView.html
+++ b/custom/modules/EmailTemplates/EditView.html
@@ -130,10 +130,17 @@ STIC#368 -->
 						</td>
 					</tr>
 					<tr>
-						<td colspan="4">
-							&nbsp;
+						<td width="15%" scope="row">
+							{MOD.LBL_ASSIGNED_TO_ID}
+						</td>
+						<td>
+							<input type="hidden" name="assigned_user_id" id="assigned_user_id" value="{ASSIGNED_USER_ID}">
+							<input class="sqsEnabled" autocomplete="off" type="text" name="assigned_user_name" id="assigned_user_name" value="{ASSIGNED_USER_NAME}">
+							<button type="button" name="btn_assigned_user_name" id="btn_assigned_user_name" tabindex="0" class="button firstChild" style="line-height:0" onclick='open_popup("Users", 600, 400, "", true, false, {"call_back_function":"set_return","form_name":"EditView","field_to_name_array":{"id":"assigned_user_id","user_name":"assigned_user_name"}}, "single", true);'><span class="suitepicon suitepicon-action-select"></span></button>
+							<button type="button" name="btn_clr_assigned_user_name" id="btn_clr_assigned_user_name" tabindex="0" title="{LBL_ACCESSKEY_CLEAR_USERS_TITLE}" class="button lastChild" style="line-height:0" onclick="SUGAR.clearRelateField(this.form, 'assigned_user_name', 'assigned_user_id');" value="{LBL_ACCESSKEY_CLEAR_USERS_TITLE}"><span class="suitepicon suitepicon-action-clear"></span></button>
 						</td>
 					</tr>
+					
 <!-- BEGIN: NoInbound -->
 					<tr>
 						<td width="15%" scope="row" align='left'>


### PR DESCRIPTION
- Closes #697 

## Descripción

El PR modifica el archivo html que renderiza la vista de popup de las plantillas de correo para añadir el campo “Asignado a” y la operativa asociada a dicho campo. 

Por otro lado, se modifica que en el subpanel de Notificaciones mostrado en la vista de detalle de una Subvención o un Evento, o en la vista de edición clásica de una campaña de tipo Notificación, se cargue la información de los campos de Remitente del SMTP seleccionado en el registro. 

## Pruebas

**Asignado a**

1. Crear campaña de email 
2. Editar el email de marketing desde el subpanel de la campaña 
3. Crear una plantilla de email y comprobar que en el popup SÍ aparece el campo “Asignado a” 
4. comprobar que funciona la operativa asociada a un campo relacionado (seleccionar, escribir y que aparezca el autocompletado de opciones y eliminar lo indicado)
5. Crear la plantilla de correo y comprobar en el registro creado tiene el usuario que hemos asignado
6. Hacer lo propio desde el subpanel de Notificaciones mostrado en la vista de detalle de una Subvención o un Evento. 


**Copiar información de campos de “Remitente”**

1. Crear una cuenta saliente indicando los campos de Remitente y una cuenta entrante de tipo Rebotes
2. Crear una notificación nueva desde el subpanel de Notificaciones mostrado en la vista de detalle de una Subvención o un Evento.
3. Escribir cualquier cadena en los campos de Remitente (nombre) y Remitente (dirección)
4. Modificar el valor del campo Usar buzón y comprobar que NO se eliminan los valores escritos
5. Modificar el valor del campo Correo Saliente y comprobar que se copian los valores del SMTP a los campos Remitente (nombre) y Remitente (dirección)
6. Realizar la misma prueba desde la vista de edición clásica de una campaña de tipo Notificación