### PR TITLE
Hotfix - Vistas Personalizadas - Error al aplicar acciones sobre campos que ya no existen en la vista

### DIFF
--- a/modules/stic_Custom_Views/processor/js/sticCV_Element_Div.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Element_Div.js
@@ -30,6 +30,10 @@ var sticCV_Element_Div = class sticCV_Element_Div {
     this.$element = $element;
   }
 
+  exists() {
+    return (this.$element?.length??0) > 0;
+  }
+
   show(show = true) {
     return this.applyAction({ action: "visible", value: show });
   }

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Container.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Container.js
@@ -36,6 +36,10 @@ var sticCV_Record_Container = class sticCV_Record_Container {
     this.content = null;
   }
 
+  exists() {
+    return (this.container?.exists()??false) && (this.header?.exists()??false) && (this.content?.exists()??false);
+  }
+
   show(show = true, automatically = false) {
     if (automatically) {
       return this.applyAction({ action: "visible_auto", value: show, element_section: "container" });

--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Field_Content.js
@@ -69,7 +69,7 @@ var sticCV_Record_Field_Content = class sticCV_Record_Field_Content extends stic
     this.$fieldText = this.$element.find(".sugar_field");
 
     this.$readonlyLabel = this.$element.parent().find(".stic-ReadonlyInput");
-    if (this.field.customView.view == "editview" || this.field.customView.view == "quickcreate") {
+    if (this.exists() && (this.field.customView.view == "editview" || this.field.customView.view == "quickcreate")) {
       // Create $readonlyLabel
       var classes = this.$element.attr("class").replace(/\bhidden\b/g, "").replace(/\s+/g, " ").trim();
       if (this.$readonlyLabel.length == 0 && this.$element.length > 0) {

--- a/modules/stic_Custom_Views/processor/js/sticCV_View_Record_Base.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_View_Record_Base.js
@@ -122,11 +122,11 @@ var sticCV_View_Record_Base = class sticCV_View_Record_Base {
   applyAction(action) {
     switch (action.type) {
       case "field_modification":
-        return this.field(action.element).applyAction(action);
+        return this.field(action.element).exists() ? this.field(action.element).applyAction(action) : false;
       case "panel_modification":
-        return this.panel(action.element).applyAction(action);
+        return this.panel(action.element).exists() ? this.panel(action.element).applyAction(action) : false;
       case "tab_modification":
-        return this.tab(action.element).applyAction(action);
+        return this.tab(action.element).exists() ? this.tab(action.element).applyAction(action) : false;
     }
   }
 


### PR DESCRIPTION
- Closes #586 

## Descripción
Tal y como se describe en #586, si se aplicaba una acción de una Vista Personalizada sobre un campo que ya no está definido en la vista (se ha eliminado en Estudio), la Vista Personalizada producía un error y no se procesaba, dejando sin aplicar las otras acciones definidas en ella.

La solución implementada aporta funciones `exists()` a los elementos que representan los campos, paneles y pestañas, aplicando las acciones correspondientes únicamente si el elemento al cual se aplica existe.

## Pruebas
1. Ir a Estudio y modificar el diseño de la vista de edición de "Personas": Añadir el campo "Fax"
2. Crear una Vista Personalizada sobre el módulo de "Personas", vista de edición
3. Crear una Personalización sin condiciones que: 
    1. Modifique el color del campo "Fax"
    2. Modifique el color del campo "Fecha de Nacimiento"
4. Editar una persona y verificar que se han cambiado los colores a los campos
5. En Estudio, quitar el campo "Fax" de la vista de edición de "Personas"
6. Editar una persona
7. Verificar que se ha cambiado el color a la "Fecha de Nacimiento"
8. En la consola del navegador, verificar que no se ha producido ningñun error
