### PR TITLE
Hotfix - Importación - Importar correctamente valores con apostrofe asociados a una lista desplegable

### DIFF
--- a/modules/Import/Importer.php
+++ b/modules/Import/Importer.php
@@ -412,6 +412,10 @@ class Importer
             case 'enum':
             case 'dynamicenum':
             case 'multienum':
+                // STIC-Custom 20250620 MHP - Decode HTML entities to check if the value exists in the associated drop-down list
+                // 
+                $rowValue = html_entity_decode($rowValue, ENT_QUOTES);
+                // END STIC-Custom
                 $returnValue = $this->ifs->$fieldtype($rowValue, $fieldDef);
 
                 // try the default value on fail

--- a/modules/stic_Import_Validation/Importer.php
+++ b/modules/stic_Import_Validation/Importer.php
@@ -539,6 +539,10 @@ class Importer
             case 'enum':
             case 'dynamicenum':
             case 'multienum':
+                // STIC-Custom 20250620 MHP - Decode HTML entities to check if the value exists in the associated drop-down list
+                // 
+                $rowValue = html_entity_decode($rowValue, ENT_QUOTES);
+                // END STIC-Custom                
                 $returnValue = $this->ifs->$fieldtype($rowValue, $fieldDef);
 
                 // try the default value on fail


### PR DESCRIPTION
- Closes #706 

## Descripción

Se detecta que la línea 217 `$this->_currentRow[$key] = securexss($value);` del fichero **modules/Import/sources/ImportFile.php** modifica las cadenas de texto con apostrofe generando un fichero temporal donde los valores con apostrofe (`Pla de l'Estany`) se transforman a una cadena que contiene la entidad html asociada al apostrofe (`Pla de l&#039;Estany`) 

Este comportamiento no se daba en la versión 7.12.12 de SuiteCRM y provoca que más adelante, en la función `sanitizeFieldValueByType` del fichero **modules/Import/Importer.php** no se corresponda el valor transformado en el fichero temporal con ningún valor de la lista asociada, generando el error en la importación descrito en el issue #706 

## Pruebas

1. Editar en una lista desplegable asociada a un campo de tipo Enum e introducir un elemento cuya etiqueta contenga un apostrofe. 
2. Crear un registro y seleccionar dicho valor.
3. Exportar el registro y eliminar todas las columnas excepto las obligatorias y la columna relacionada con el campo anterior.
4. Importar el registro y comprobar que el fichero SÍ es importado debido a que el proceso reconoce que valor pertenece a la lista desplegable. 
5. Comprobar que ya se muestra el error en el fichero enriquecido que genera el proceso de Validación de importación. 
