### PR TITLE
Hotfix - Flujos de Trabajo - Interpretación correcta de la fecha en acciones de flujo de trabajo

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2609,6 +2609,14 @@ class SugarBean
                                 $this->$field = '';
                                 break;
                             }
+                            // STIC Custom 20250702 JBL - Fix passing DateTime to a Date
+                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+                            if (preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/', (string) $this->$field)) {
+                                // If format is YYYY-MM-DD HH:MM:SS, take only data (YYYY-MM-DD)
+                                $this->$field = substr((string) $this->$field, 0, 10);
+                                $reformatted = true;
+                            }
+                            // END STIC Custom
                             if (!preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', (string) $this->$field)) {
                                 $this->$field = $timedate->to_db_date($this->$field, false);
                                 $reformatted = true;

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2609,14 +2609,6 @@ class SugarBean
                                 $this->$field = '';
                                 break;
                             }
-                            // STIC Custom 20250702 JBL - Fix passing DateTime to a Date
-                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/713
-                            if (preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/', (string) $this->$field)) {
-                                // If format is YYYY-MM-DD HH:MM:SS, take only data (YYYY-MM-DD)
-                                $this->$field = substr((string) $this->$field, 0, 10);
-                                $reformatted = true;
-                            }
-                            // END STIC Custom
                             if (!preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', (string) $this->$field)) {
                                 $this->$field = $timedate->to_db_date($this->$field, false);
                                 $reformatted = true;

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2610,7 +2610,7 @@ class SugarBean
                                 break;
                             }
                             // STIC Custom 20250702 JBL - Fix passing DateTime to a Date
-                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/713
                             if (preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/', (string) $this->$field)) {
                                 // If format is YYYY-MM-DD HH:MM:SS, take only data (YYYY-MM-DD)
                                 $this->$field = substr((string) $this->$field, 0, 10);

--- a/modules/AOW_Actions/actions/actionCreateRecord.php
+++ b/modules/AOW_Actions/actions/actionCreateRecord.php
@@ -265,6 +265,13 @@ class actionCreateRecord extends actionBase
                                 $value = $bean->$fieldName;
                                 break;
                         }
+                        // STIC Custom 20250703 JBL - Fix passing DateTime to a Date
+                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/713
+                        $destData = $bean->field_defs[$params['field'][$key]];
+                        if ($destData['type'] == "date" && preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/', (string)$value)) {
+                            $value = substr((string)$value, 0, 10);
+                        }
+                        // END STIC Custom
                         break;
                     case 'Date':
                         $dformat = 'Y-m-d H:i:s';
@@ -300,6 +307,11 @@ class actionCreateRecord extends actionBase
                                 } elseif ($params['value'][$key][0] === 'field') {
                                     $dateToUse = $params['field'][$key];
                                     $date = $record->$dateToUse;
+                                // STIC Custom 20250703 JBL - Fix passing DateTime to a Date
+                                // https://github.com/SinergiaTIC/SinergiaCRM/pull/713
+                                } elseif (property_exists($record, $params['value'][$key][0])) {
+                                    $date = $record->{$params['value'][$key][0]};
+                                // END STIC Custom
                                 } elseif ($params['value'][$key][0] === 'today') {
                                     $date = $params['value'][$key][0];
                                 } else {


### PR DESCRIPTION
- Closes #712

## Descripción
Tal y como se describe en #712, si en una acción de un Flujo de Trabajo se definía que se volcase el valor de un campo del tipo Fecha y Hora en otro del tipo Fecha, no se interpretaba correctamente.

El problema estaba en dos casos distintos: 
1. Si el valor era adquirido como el valor de otro campo: El valor era interpretado como `NULL`
2. Si el valor era fruto del calculo de fecha partiendo de otro campo: El valor resultante era `01/01/1970`

## Pruebas
1. Crear dos campos de tipo Fecha en el módulo Personas (fecha1 y fecha2)
2. Definir un FdT sobre Personas, "Sólo al guardar", sobre "Todos los registros" y "Ejecuciones reiteradas":
    1. Añadir las acciones de modificar registro Personas: 
        1. Campo fecha1 - Fecha - Fecha de modificación
        2. Campo fecha2 - Campo - Fecha de modificación
4. Editar una persona
5. Verificar que fecha1 y fecha2  contienen la fecha actual