### PR TITLE
Hotfix - KReports - Tratamiento de operadores empty en campos multi-enum

### DIFF
--- a/modules/KReports/KReportQuery.php
+++ b/modules/KReports/KReportQuery.php
@@ -1900,7 +1900,7 @@ class KReportQuery {
             // STIC-Custom EPS 20250703 multienum fields are not evaluated correctly
             // https://github.com/SinergiaTIC/SinergiaCRM/pull/716
             if ($this->fieldNameMap[$fieldid]['type'] === 'multienum') {
-               $thisWhereString .= ' OR ' . $this->get_field_name($path, $fieldname, $fieldid) . '\'^^\'';
+               $thisWhereString .= ' OR ' . $this->get_field_name($path, $fieldname, $fieldid) . ' = \'^^\'';
             }
             // END STIC-Custom
             break;
@@ -1909,7 +1909,7 @@ class KReportQuery {
             // STIC-Custom EPS 20250703 multienum fields are not evaluated correctly
             // https://github.com/SinergiaTIC/SinergiaCRM/pull/716
             if ($this->fieldNameMap[$fieldid]['type'] === 'multienum') {
-               $thisWhereString .= ' OR ' . $this->get_field_name($path, $fieldname, $fieldid) . '\'^^\'';
+               $thisWhereString .= ' OR ' . $this->get_field_name($path, $fieldname, $fieldid) . ' = \'^^\'';
             }
             // END STIC-Custom
             break;


### PR DESCRIPTION
- Closes #715 
- 
## Description
Se modifican los operadores isempty, isemptyornull y isnotempty para tratar los campos multi-enum que pueden contener nulo, '' o bien '^^'.

## Motivation and Context
Corregir la incidencia detectada.

## How To Test This
1. Asegurarse que tenemos valores ^^ en un campo multi-enum (por ejemplo relaciones activas de Personas)
2. Crear un informe que filtre por ese campo con la condición "vacío o nul"
3. Comprobar que aparecen tanto las filas que tienen nulo o '' en el campo como las que tienen '^^'

