### PR TITLE
Hotfix - Flujos de trabajo - Evitar espacios en blanco que pueden provocar error en acción "Modificar campos".

### DIFF
--- a/modules/AOW_Actions/actions/actionCreateRecord.js
+++ b/modules/AOW_Actions/actions/actionCreateRecord.js
@@ -293,7 +293,7 @@ function show_mrModuleFields(ln){
 
         var callback = {
             success: function(result) {
-                cr_module[ln] = result.responseText;
+                cr_module[ln] = result.responseText.trim();
             }
         };
 


### PR DESCRIPTION
- Closes #727 
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Descripción
Al crear una acción de tipo "Modificar campos" dentro de un Flujo de Trabajo (FdT), seleccionar un módulo relacionado y posteriormente un campo hacía que el sistema lanzara un fatal error de PHP.

Se ha detectado que el nombre del módulo relacionado contenía un espacio en blanco inicial (" Accounts" en lugar de "Accounts"), lo que provocaba un fallo al buscar la clave en el array de módulos.

No se ha localizado exactamente el punto donde se introduce el espacio en blanco, creemos que se debe a un `echo` en otra parte del código que devuelve el nombre del módulo con espacios. Se ha optado por solventarlo directamente en la parte donde se usa el valor, garantizando así la estabilidad del sistema.

## Solución aplicada:

Se ha modificado la función `show_mrModuleFields(ln)` de modules/AOW_Actions/actions/actionCreateRecord.js. Concretamente, se ha añadido un .trim() en la función de callback.success para eliminar posibles espacios en blanco:

```
success: function(result) {
    cr_module[ln] = result.responseText.trim(); // Se eliminan espacios al inicio/fin
}

```
