### PR TITLE
Hotfix - Grupos de Seguridad - Permitir valores nulos en campos no heredables de grupos de seguridad

### DIFF
--- a/modules/stic_Security_Groups_Rules/Utils.php
+++ b/modules/stic_Security_Groups_Rules/Utils.php
@@ -299,11 +299,11 @@ class stic_Security_Groups_RulesUtils
               INNER JOIN securitygroups ON
                 securitygroups_users.securitygroup_id = securitygroups.id
                 AND securitygroups.deleted = 0
-                AND securitygroups.noninheritable = 0
+                AND (securitygroups.noninheritable = 0 OR securitygroups.noninheritable IS NULL)
               WHERE
                 securitygroups_users.user_id = '{$userId}'
                 AND securitygroups_users.deleted = 0
-                AND securitygroups_users.noninheritable = 0
+                AND (securitygroups_users.noninheritable = 0 OR securitygroups_users.noninheritable IS NULL)
               ORDER BY
                 securitygroups.name ASC";
 

--- a/modules/stic_Security_Groups_Rules/Utils.php
+++ b/modules/stic_Security_Groups_Rules/Utils.php
@@ -239,7 +239,7 @@ class stic_Security_Groups_RulesUtils
                                                LEFT JOIN securitygroups ON securitygroups_records.securitygroup_id = securitygroups.id
                                                WHERE securitygroups_records.record_id = '{$relatedRecordID}'
                                                AND securitygroups_records.deleted = 0
-                                               AND securitygroups.noninheritable = 0
+                                               AND (securitygroups.noninheritable = 0 OR securitygroups.noninheritable IS NULL)
                                                AND securitygroups.deleted=0");
 
         foreach ($queryResult as $row) {


### PR DESCRIPTION
resolve #733

## Descripción
En el issue #733 se vio que cuando el campo `noninheritable` de la tabla _securitygroups_users_ tiene el valor NULL quedaba fuera de la lista de Grupos de Seguridad heredables por el usuario mediante el módulo "Grupos de seguridad -  Reglas por módulos' cuando estaba activado para el usuario creador o el usuario asignado. 

En este PR se modifica la query SQL que recupera los Grupos de Seguridad heredables del usuario, contemplando de manera expresa que estos puedan tener el valor NULL en el campo noninheritable en la tabla *securitygroups* o en la tabla *securitygroups_users*.

## Cómo probarlo
- En un usuario que tenga varios Grupos de seguridad asignados, establecer  mediante base de datos el valor NULL en el campo noninheritable de la tabla securitygroups y en la tabla securitygroups_users.
- Activar la reglas por módulos de Grupos de Seguridad y activar (exclusivamente) la herencia del usuario creador y del usuario asignado en el módulo Personas. 
- Crear registros de Personas y verificar que en todos los casos se produce la herencia de los grupos de seguridad del usuario creador y del usuario asignado, independientemente de que en base de datos aparezca 0 o NULL.
 