### PR TITLE
Hotfix - Ventas - Tratar correctamente el campo Imagen de un Producto

### DIFF
--- a/modules/AOS_Products/metadata/detailviewdefs.php
+++ b/modules/AOS_Products/metadata/detailviewdefs.php
@@ -217,7 +217,10 @@ array(
                     0 => array(
                         'name' => 'product_image',
                         'label' => 'LBL_PRODUCT_IMAGE',
-                        'customCode' => '<img src="{$fields.product_image.value}" style="max-width: 160px;" height="160"/>',
+                        // STIC Custom 20250722 JBL - Tratar Imagen de producto como imagen
+                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+                        // 'customCode' => '<img src="{$fields.product_image.value}" style="max-width: 160px;" height="160"/>',
+                        // END STIC Custom
                     ),
                     1 => array(
                         'name' => 'assigned_user_name',

--- a/modules/AOS_Products/metadata/editviewdefs.php
+++ b/modules/AOS_Products/metadata/editviewdefs.php
@@ -213,7 +213,11 @@ array(
                 0 => array(
                     0 => array(
                         'name' => 'product_image',
-                        'customCode' => '{$PRODUCT_IMAGE}',
+                        // STIC Custom 20250722 JBL - Tratar Imagen de producto como imagen
+                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+                        // 'customCode' => '{$PRODUCT_IMAGE}',
+                        'label' => 'LBL_PRODUCT_IMAGE',
+                        // END STIC Custom
                     ),
                     1 => array(
                         'name' => 'assigned_user_name',

--- a/modules/AOS_Products/vardefs.php
+++ b/modules/AOS_Products/vardefs.php
@@ -278,11 +278,25 @@ $dictionary['AOS_Products'] = array(
             array(
                 'name' => 'product_image',
                 'vname' => 'LBL_PRODUCT_IMAGE',
-                'type' => 'varchar',
-                'len' => '255',
+                // STIC Custom 20250722 JBL - Tratar Imagen de producto como imagen
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+                // 'type' => 'varchar',
+                // 'len' => '255',
+                // 'reportable' => true,
+                // 'inline_edit' => false,
+                // 'comment' => 'File name associated with the note (attachment)'
+                'type' => 'image',
+                'massupdate' => false,
+                'comments' => '',
+                'help' => '',
+                'importable' => false,
                 'reportable' => true,
-                'inline_edit' => false,
-                'comment' => 'File name associated with the note (attachment)'
+                'len' => 255,
+                'dbType' => 'varchar',
+                'width' => '160',
+                'height' => '160',
+                'studio' => array('listview' => true),
+                // END STIC Custom
             ),
         'file_url' =>
             array(

--- a/modules/AOS_Products/views/view.edit.php
+++ b/modules/AOS_Products/views/view.edit.php
@@ -14,31 +14,33 @@ class AOS_ProductsViewEdit extends ViewEdit
 
 
 
+    // STIC Custom 20250722 JBL - Tratar Imagen de producto como imagen
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+    // public function display()
+    // {
+    //     global $app_strings,$sugar_config;
 
-    public function display()
-    {
-        global $app_strings,$sugar_config;
-
-        isset($this->bean->product_image) ? $image = $this->bean->product_image : $image = '';
+    //     isset($this->bean->product_image) ? $image = $this->bean->product_image : $image = '';
 
 
-        $temp = str_replace($sugar_config['site_url'].'/'.$sugar_config['upload_dir'], "", (string) $image);
-        $html = '<span id=\'new_attachment\' style=\'display:';
-        if (!empty($this->bean->product_image)) {
-            $html .= 'none';
-        }
-        $html .= '\'><input name="uploadimage" tabindex="3" type="file" size="60"/>
-        	</span>
-		<span id=\'old_attachment\' style=\'display:';
-        if (empty($image)) {
-            $html .= 'none';
-        }
-        $html .= '\'><input type=\'hidden\' id=\'deleteAttachment\' name=\'deleteAttachment\' value=\'0\'>
-		'.$temp.'<input type=\'hidden\' name=\'old_product_image\' value=\''.$image.'\'/>
-		<input type=\'button\' class=\'button\' value=\''.$app_strings['LBL_REMOVE'].'\' onclick=\'deleteProductImage();\' >
-		</span>';
+    //     $temp = str_replace($sugar_config['site_url'].'/'.$sugar_config['upload_dir'], "", (string) $image);
+    //     $html = '<span id=\'new_attachment\' style=\'display:';
+    //     if (!empty($this->bean->product_image)) {
+    //         $html .= 'none';
+    //     }
+    //     $html .= '\'><input name="uploadimage" tabindex="3" type="file" size="60"/>
+    //     	</span>
+	// 	<span id=\'old_attachment\' style=\'display:';
+    //     if (empty($image)) {
+    //         $html .= 'none';
+    //     }
+    //     $html .= '\'><input type=\'hidden\' id=\'deleteAttachment\' name=\'deleteAttachment\' value=\'0\'>
+	// 	'.$temp.'<input type=\'hidden\' name=\'old_product_image\' value=\''.$image.'\'/>
+	// 	<input type=\'button\' class=\'button\' value=\''.$app_strings['LBL_REMOVE'].'\' onclick=\'deleteProductImage();\' >
+	// 	</span>';
 
-        $this->ss->assign('PRODUCT_IMAGE', $html);
-        parent::display();
-    }
+    //     $this->ss->assign('PRODUCT_IMAGE', $html);
+    //     parent::display();
+    // }
+    // END STIC Custom
 }


### PR DESCRIPTION
- Closes #738 

## Descripción
Tal y como se describe en #738, el campo imagen del módulo Productos (`product_image`) no se visualiza correctamente en todos los entornos publicados a internet. En local funciona correctamente.

Esto es debido a que el campo estaba definido como tipo texto en vez de imagen. Su contenido era la url al fichero de la imagen (en la carpeta /upload). Si el servidor web tiene configuradas reglas de acceso a la carpeta, éste podía bloquear la visualización de la imagen del producto.

## Solución implementada
Se ha optado por convertir el campo `product_image` en campo de imagen. Para ello se ha eliminado el código personalizado del campo que mostraba el campo de tipo texto como una imagen.

## Pruebas
1. Ir al módulo Productos y crear un nuevo producto, añadiéndole una imagen
2. Ir a la vista detalle de nuevo producto
3. Verificar que se visualiza la imagen
4. Inspeccionar el campo imagen del producto
5. Verificar que la url de la imagen empieza por `index.php?entryPoint=download`, sin información del domino

