### PR TITLE
change type to authenticate

### DIFF
--- a/vendor/javanile/php-imap2/src/Roundcube/ImapClient.php
+++ b/vendor/javanile/php-imap2/src/Roundcube/ImapClient.php
@@ -575,8 +575,12 @@ class ImapClient
     {
         if ($type == 'CRAM-MD5' || $type == 'DIGEST-MD5') {
             if ($type == 'DIGEST-MD5' && !class_exists('Auth_SASL')) {
-                return $this->setError(self::ERROR_BYE,
-                    "The Auth_SASL package is required for DIGEST-MD5 authentication");
+                // STIC-Custom 20250724 ART - Bounce Email Error With Roundcube
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // return $this->setError(self::ERROR_BYE,
+                //     "The Auth_SASL package is required for DIGEST-MD5 authentication");
+                $type = 'CRAM-MD5';
+                // END STIC Custom
             }
 
             $this->putLine($this->nextTag() . " AUTHENTICATE $type");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/741

Como se describe en el issue, se ha detectado que al intentar configurar una cuenta de rebotes con IMAP que funciona con Roundcube y seleccionando la carpeta Monitorizada, daba el siguiente error:

<img width="410" height="436" alt="image" src="https://github.com/user-attachments/assets/dc6fdccc-aa25-4705-b06b-8a4e7d02092d" />

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Se ha quitado el return con el error que había cuando detectaba que la clase Auth_SASL no existía, haciendo que recoja directamente `$type = 'CRAM-MD5'` para que no provocase el error.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Configurar una cuenta de rebotes con IMAP que funciona con Roundcube.
2. Intentar seleccionar una Carpeta Monitorizada.
3. Ver que ya no sale el error de la imagen adjunta y sale una lista de carpetas a seleccionar.

## Additional
Se puede ver si queremos implementar esta solución o podemos investigar más sobre ello con los siguientes enlaces:
https://community.suitecrm.com/t/import-of-e-mail-fail/90006/53?page=3

https://github.com/SuiteCRM/SuiteCRM-Core/issues/419