### PR TITLE
Hotfix - Vistas Personalizadas - Aplicar correctamente las personalizaciones a pestañas

### DIFF
--- a/modules/stic_Custom_Views/processor/js/sticCV_Record_Tab.js
+++ b/modules/stic_Custom_Views/processor/js/sticCV_Record_Tab.js
@@ -32,4 +32,8 @@ var sticCV_Record_Tab = class sticCV_Record_Tab extends sticCV_Record_Container 
     this.header = new sticCV_Record_Tab_Header(this);
     this.content = new sticCV_Record_Tab_Content(this);
   }
+
+  exists() {
+    return (this.header?.exists()??false) && (this.content?.exists()??false);
+  }
 };


### PR DESCRIPTION
- Closes #756 
## Descripción
Tal y como se describe en #756, el PR #705 introduce un error en las Vistas Personalizadas provocando que no se apliquen las acciones de personalización sobre pestañas, sea cual sea la vista.

El problema radicaba en la comprobación que se realizaba para verificar que el elemento a modificar esté definido en la vista. Esta comprobación en el caso de las pestañas (tabs) no funcionaba correctamente.
Concretamente, se aplicaba la verificación general:
https://github.com/SinergiaTIC/SinergiaCRM/blob/ef7442fd30745ab6f225f0a84ebe3469b4ae3e53/modules/stic_Custom_Views/processor/js/sticCV_Record_Container.js#L39-L41
(El objeto `sticCV_Record_Tab` que representa una pestaña, hereda de `sticCV_Record_Container` y no sobreescribía su comportamiento)

En el caso concreto de las pestañas (`sticCV_Record_Tab`), `this.container` es nulo, ya que su representación como pestaña no activa no tiene contenedor.

La solución implementada sobreescribe la función `exists()` para los objetos `sticCV_Record_Tab`

## Pruebas
1. Crear una vista personalizada sobre cualquier módulo - vista, que tenga alguna pestaña (ej: Personas-vista detalle)
2. Crear una personalización sin condiciones con una acción que modifique una pestaña (ej: Ocultar pestaña SEPE)
3. Acceder al modulo en cuestión 
4. Verificar que SÍ se ha aplicado la Vista Personalizada
5. Inspeccionar la página
6. Verificar que no hay errores en la consola
