### PR TITLE
Hotfix - Campañas - Validación de campos requeridos de Notificaciones

### DIFF
--- a/custom/modules/Campaigns/SticUtils.js
+++ b/custom/modules/Campaigns/SticUtils.js
@@ -283,6 +283,8 @@ function updateViewNotificationType(isNotification) {
     $form.find('[data-field="parent_name"]').hide();
     $form.find(".panel-body[data-id='LBL_NOTIFICATION_INFORMATION_PANEL']").parent().hide();
     $form.find("[data-label='LBL_NAVIGATION_MENU_GEN2']").show();
+    removeFromValidate(getFormName(), 'notification_from_addr');
+    removeFromValidate(getFormName(), 'notification_reply_to_addr');
   }
 }
 

--- a/custom/modules/Campaigns/SticUtils.js
+++ b/custom/modules/Campaigns/SticUtils.js
@@ -277,7 +277,6 @@ function updateViewNotificationType(isNotification) {
     $form.find("#parent_type").val("");
     $form.find("#parent_name").val("");
     $form.find("#parent_id").val("");
-    $form.find("#status").val("");
     $form.find('[data-field="status"]').show();
     $form.find('[data-field="end_date"]').show();
     $form.find('[data-field="parent_name"]').hide();

--- a/custom/modules/Campaigns/SticUtils.js
+++ b/custom/modules/Campaigns/SticUtils.js
@@ -56,23 +56,6 @@ if ($('[data-field="end_date"]').length > 0 && $('[data-field="start_date"]').le
   );
 }
 
-if ($('#notification_from_addr').length > 0 && $('#notification_reply_to_addr').length > 0) {
-  /* VALIDATION CALLBACKS */
-  addToValidate(
-    getFormName(), 
-    'notification_from_addr',
-    'email', 
-    true,
-    SUGAR.language.get('app_strings', 'ERR_INVALID_EMAIL_ADDRESS')
-  );
-  addToValidate(
-    getFormName(),
-    'notification_reply_to_addr',
-    'email',
-    false,
-    SUGAR.language.get('app_strings', 'ERR_INVALID_EMAIL_ADDRESS')
-  );
-}
 /* VIEWS CUSTOM CODE */
 switch (viewType()) {
   case "quickcreate":
@@ -253,6 +236,7 @@ function updateViewNotificationType(isNotification) {
   setRequired(isNotification, "notification_template_id");
   setRequired(isNotification, "notification_from_name");
   addRequiredMark("notification_from_addr");
+  
 
   var $form = $("form#" + getFormName());
 
@@ -271,6 +255,23 @@ function updateViewNotificationType(isNotification) {
       if (formatDate != "") {
         $form.find("#start_date").val(moment().format(formatDate));
       }
+    }
+    if ($('#notification_from_addr').length > 0 && $('#notification_reply_to_addr').length > 0) {
+      /* VALIDATION CALLBACKS */
+      addToValidate(
+        getFormName(), 
+        'notification_from_addr',
+        'email', 
+        true,
+        SUGAR.language.get('app_strings', 'ERR_INVALID_EMAIL_ADDRESS')
+      );
+      addToValidate(
+        getFormName(),
+        'notification_reply_to_addr',
+        'email',
+        false,
+        SUGAR.language.get('app_strings', 'ERR_INVALID_EMAIL_ADDRESS')
+      );
     }
   } else {
     $form.find("#parent_type").val("");


### PR DESCRIPTION
- Closes #760

En el PR #710 se incluyeron unos cambios para añadir validaciones de algunos campos en las vistas de Campañas. Esto ha provocado que ahora no se puedan crear Campañas nuevas con el método clásico si el tipo no es de Notificación. Esto es debido a que se están añadiendo validaciones a campos que siempre existen en la vista aunque estos no se muestren, ya que se esconden por Javascript.

Se han movido las validaciones de esos campos a la sección donde se compruba que es una Campaña del tipo Notificación.
Pruebas:
- Comprobar que se pueden crear, editar y duplicar Campañas en todos los contextos. Tanto en vista Clásica, como Asistente, como Notificación.