### PR TITLE
Hotfix - Sesiones y Asistencias - Unificar el algoritmo de generación del nombre

### DIFF
--- a/modules/stic_Attendances/LogicHooksCode.php
+++ b/modules/stic_Attendances/LogicHooksCode.php
@@ -87,9 +87,8 @@ class stic_AttendancesLogicHooks
             
             // Attendance's name includes registration's and session's names, both of them potentially including event's name.
             // Let's check it in order to avoid repeating event's name in attendance's name.
-            $registrationNameEnd = trim(explode('-', $registrationBean->name)[1]);
             $sessionNameStart = trim(explode('|', $sessionBean->name)[0]);
-            if ($registrationNameEnd == $sessionNameStart) {
+            if (strpos($registrationBean->name, $sessionNameStart) !== false) {
                 // If event's name exists in both session's and registration's names, let's exclude it from session's name.
                 $cleanSessionName = str_replace($sessionNameStart, '', $sessionBean->name);
                 $cleanSessionName = trim(str_replace('|', '', $cleanSessionName));

--- a/modules/stic_Attendances/Utils.php
+++ b/modules/stic_Attendances/Utils.php
@@ -144,9 +144,17 @@ class stic_AttendancesUtils
             $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ':  Creating attendance: ' . ($row['attendance_name'] ?? 'undefined'). ' for session: ' . $row['session_id'] . ' and registration: ' . $row['registration_id']);
             $attendance = BeanFactory::newBean('stic_Attendances');
 
+            // Set attendance name, avoiding to duplicate event name
+            $sessionNameStart = trim(explode('|', $row['session_name'])[0]);
+            if (strpos($row['registration_name'], $sessionNameStart) !== false) {
+                $cleanSessionName = str_replace($sessionNameStart, '', $row['session_name']);
+                $cleanSessionName = trim(str_replace('|', '', $cleanSessionName));
+            } else {
+                $cleanSessionName = $row['session_name'];
+            }
+            $attendance->name = $row['registration_name'] . ' | ' . $cleanSessionName;
             // Set basic data
             $attendance->assigned_user_id = $row['session_assigned_user_id'];
-            $attendance->name = $row['registration_name'] . ' | ' . $timedate->to_display_date_time($row['start_date'], true, true) . 'h';
             $attendance->start_date = $row['start_date'];
 
             // Prepare duration if it is null


### PR DESCRIPTION
- Closes #589 

## Description
La manera de generar los nombres de asistencia no era coherente entre la generación automática de asistencia (en el Utils) y la generación manual de una asistencia (LH).

En el LH se estaba intentando generar <nombre inscripción> + <nombre sesión>, intentando que no se repitiera el nombre del evento.
En el Utils se generaba como <nombre inscripción> | <fecha hora de inicio de sesión>

Se intenta coger lo mejor de ambos mundos y cambiar la manera (la actual fallaba cuando el proyecto contenía un guión) de evitar la repetición del nombre del evento.

El nombre se generará como <nombre inscripción> + <nombre sesión>. Previamente se recogerá la parte inicial del nombre de la sesión (los nombres de sesión suelen ser XXXXX | dd/mm/yyyy hh:mm) y se comprobará si existe dentro del nombre de la inscripción para no repetirla.

## Motivation and Context
Corregir una pequeña incoherencia en la generación del nombre de las asistencias y un error a la hora de identificar partes repetidas en el nombre.

## How To Test This
1. Crear un par de eventos (uno de ellos debe llevar guión en el nombre)
2. Crear varias sesiones en distintas fechas para cada evento
3. Crear inscripciones en cada evento en una fecha intermedia (de manera que se generarán algunas asistencias de forma automática)
4. [Opcional] Cambiar el nombre de alguna inscripción.... según como hagamos los nombres, puede ser que la propia inscripción ya tenga una parte duplicada
5. Crear asistencias para algunas inscripciones y sesiones futuras
6. Comprobar que los nombres de las asistencias ya generadas anteriormente y las nuevas son coherentes en formato.


