### PR TITLE
Hotfix - General - Evitar que el nombre del fichero exportado esté repetido

### DIFF
--- a/export.php
+++ b/export.php
@@ -94,9 +94,8 @@ if (!empty($_REQUEST['members'])) {
 ///////////////////////////////////////////////////////////////////////////////
 ////	BUILD THE EXPORT FILE
 
-// Stic-Custom MHP 20250912 - 
-// Add a suffix that prevents files with possible names already existing in the file system from being exported, 
-// since in this case the browser adds a space between the name and the suffix it generates, which causes an error when importing the file.
+// Stic-Custom MHP 20250912 - https://github.com/SinergiaTIC/SinergiaCRM/pull/789
+// Add a suffix to the name of the exported file to prevent the export process from generating files with the same name as a previous export.
 $filename .= '_' . date("ymd_His");
 // END Stic-Custom 
 ob_clean();


### PR DESCRIPTION
- Closes #590 

## Descripción
Este PR evita que en el proceso de exportación se exporten ficheros con el mismo nombre de una exportación anterior. 

## Pruebas
1. Acceder a la vista de lista de cualquier módulo
2. Seleccionar uno o más registros y ejecutar la acción masiva de exportación más de una vez (sin borrar el primer fichero generado)
3. Comprobar que ninguna exportación contiene espacios ya que los nombres son diferentes