### PR TITLE
Hotfix - Inscripciones - Asegurar formato en el campo Importe de la sesión

### DIFF
--- a/modules/stic_Registrations/stic_Registrations.php
+++ b/modules/stic_Registrations/stic_Registrations.php
@@ -90,7 +90,8 @@ class stic_Registrations extends Basic
                 // On new records, inherit amount from related event
                 if (empty($this->session_amount) && !$is_update) {
                     $eventBean = BeanFactory::getBean('stic_Events', $this->stic_registrations_stic_eventsstic_events_ida);
-                    $this->session_amount = $eventBean->session_amount;
+                    require_once 'SticInclude/Utils.php';
+                    $this->session_amount = SticUtils::formatDecimalInConfigSettings($eventBean->session_amount, true);
                 }
             }
         }


### PR DESCRIPTION
- Closes #792  

## Description
La manera en que se trasladaba el campo **Importe de la sesión** del evento a la inscripción no aseguraba el formato correcto. Ahora se utiliza la función `formatDecimalInConfigSettings` para garantizar el formato adecuado y evitar errores en procesamientos posteriores del campo, como puede ser un FdT.

## How To Test This

1. Crear un FdT sobre Inscripciones con una acción de campos calculados que utilice un campo de relación (por ejemplo, móvil de Personas) y la fórmula: descripción: {R0}.
2. Crear una Inscripción.
3. Verificar que el campo Importe de la sesión se ha trasladado correctamente.
4. Probar la creación de una Inscripción sin FdT activos.
