### PR TITLE
Hotfix - Encuestas - Visualización correcta de encuestas con logos grandes

### DIFF
--- a/modules/Surveys/Entry/Survey.php
+++ b/modules/Surveys/Entry/Survey.php
@@ -98,7 +98,7 @@ EOF;
         <div class="row">
             <div class="col-md-offset-3 col-md-6">
                 <!-- STIC-Custom 20250922 - JBL - Adapt image size -->
-                <!-- https://github.com/SinergiaTIC/SinergiaCRM/pull/??? -->
+                <!-- https://github.com/SinergiaTIC/SinergiaCRM/pull/800 -->
                 <!-- <img src="<?php echo $companyLogoURL ?>"/> -->
                 <img class="center-block" style="max-width: 450px; max-height: 250px;" src="<?php echo $companyLogoURL ?>"/>
                 <!-- END STIC-Custom -->

--- a/modules/Surveys/tpls/closeSurvey.tpl
+++ b/modules/Surveys/tpls/closeSurvey.tpl
@@ -3,7 +3,7 @@
     <div class="row">
         <div class="col-md-offset-3 col-md-6">
             {* STIC-Custom 20250922 - JBL - Adapt image size *}
-            {* https://github.com/SinergiaTIC/SinergiaCRM/pull/??? *}
+            {* https://github.com/SinergiaTIC/SinergiaCRM/pull/800 *}
             {* <img src="{$LOGO}"/> *}
             <img class="center-block" style="max-width: 450px; max-height: 250px;" src="{$LOGO}" />
             {* END STIC-Custom *}


### PR DESCRIPTION
- Closes #798 
## Descripción del problema
Las encuestas creadas muestraban el logo de la compañía sin escalar. Esto hacía que si el logo  de la compañía es grande, no se visualice correctamente la encuesta.

Concretamente, el logo se muestra en:
- Las encuestas públicas
- La página de para encuestas cerradas

## Solución propuesta
Se ha escalado y centrado la imagen, asignándole un tamaña máximo

## Pruebas
1. Definir una imágen grande como logotipo: Administración > Configuración > Seleccionar logo
2. Crear una encuesta con una pregunta
3. Asignar estado "Público"
4. Acceder a la url y verificar que la imagen se ha escalado
5. En la encuesta, asignar estado "Cerrado"
6. Acceder a la url y verificar que la imagen se ha escalado

