### PR TITLE
Hotfix - Usuarios - Añadir sentencias return para que funcione el login desde la API si está activada la autenticación OAuth

### DIFF
--- a/modules/Users/authentication/OAuthAuthenticate/OAuthAuthenticate.php
+++ b/modules/Users/authentication/OAuthAuthenticate/OAuthAuthenticate.php
@@ -214,14 +214,14 @@ class OAuthAuthenticate extends SugarAuthenticate
                 }
                 $this->userAuthenticate->loadUserOnSession($userBean->id);
 
-	            $this->postLoginAuthenticate();
+	            return $this->postLoginAuthenticate();
 
             } else {
                 $_SESSION['login_error'] = $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_TOKEN'];
                 return false;
             }
         } else {
-            parent::loginAuthenticate($username, $password, $fallback, $PARAMS);
+           return parent::loginAuthenticate($username, $password, $fallback, $PARAMS);
         }
     }
 }


### PR DESCRIPTION
- Closes #815

## Descripción
Se implementa la solución propuesta en el issue y se añaden las dos sentencias `return` para que la función `loginAuthenticate()` de la clase **OAuthAuthenticate** devuelva un resultado en vez de **null**

**[FYI]** Se investiga cual es el comportamiento del CRM cuando  está activada la autenticación LDAP y SAML y se observa que: 
1. Ambas métodos implementan el método **loadUserOnLogin()** que es llamado desde la función `loginAuthenticate()` de la clase **SugarAuthenticate**.
2. La función de `loginAuthenticate()` de **SugarAuthenticate** tiene dos fases. Una primera en la que intenta realizar la autenticación con el controlador de autenticación que esté configurado en la variable de configuración `$sugar_config['authenticationClass']`, cuyos valores pueden ser LDAP, SAML y OAuth. Y una segunda fase donde, en caso de no ser válida la autenticación con el controlador configurado en el CRM, se intenta autenticar al usuario a través del método `loginAuthenticate()` genérico definido en la clase **SugarAuthenticate**.
3. Como ya se ha indicado, en el caso de OAuth no se ha implementado el método **loadUserOnLogin()** en la clase **OAuthAuthenticateUser.php** si no que se ha implementado el método `loginAuthenticate()` en la clase **OAuthAuthenticate**, por lo que se podría valorar si merece la pena implementar la autenticación siguiendo el "estandar" ya aplicado en los otros dos métodos de autenticación. 

**Solución**
Se decide añadir los return en la función `loginAuthenticate()` de la clase **OAuthAuthenticate** para solucionar la incidencia y se deja para más adelante el valorar si merece la pena cambiar la forma en que se ha implementado la solución. 

## Pruebas
1. Ir a **Administración/Usuarios/Administración de contraseñas** y activar la casilla de **Activar autenticación OAuth**. 
3. Realizar una llamada al método login de la API (se puede usar el cliente API del repositorio https://github.com/SinergiaTIC/SinergiaCRM-API-Examples)
5. Comprobar que se realiza correctamente el proceso de login y que se obtiene un ID de sesión
