### PR TITLE
Añadir la propiedad help al resultado de get_module_fields  API

### DIFF
--- a/service/v4/SugarWebServiceUtilv4.php
+++ b/service/v4/SugarWebServiceUtilv4.php
@@ -227,6 +227,10 @@ class SugarWebServiceUtilv4 extends SugarWebServiceUtilv3_1
                 $entry['type'] = $var['type'];
                 $entry['group'] = isset($var['group']) ? $var['group'] : '';
                 $entry['id_name'] = isset($var['id_name']) ? $var['id_name'] : '';
+                // STIC-Custom 20251003 MHP - Add the help property to the result of the call to the API method: get_module_fields
+                // 
+                $entry['help'] = $var['help'];
+                // END STIC-Custom
                 if (isset($var['parentenum'])) {
                     $entry['parentenum'] = $var['parentenum'];
                 }


### PR DESCRIPTION
- Closes #818 

## Descripción
Este PR implementa la solución propuesta en el issue

## Pruebas
1. Llamar al método **get_module_fields** de la **API 4.1** pidiendo la información de un campo que tenga rellenado la propiedad **help** y comprobar que es devuelta en el resultado de la llamada.