### PR TITLE
Hotfix - KReport - Tratamiento de ACL_ALLOW_NONE en el rol

### DIFF
--- a/modules/KReports/KReportQuery.php
+++ b/modules/KReports/KReportQuery.php
@@ -909,6 +909,7 @@ class KReportQuery {
                   }
                }
                // STIC Custom 20251003 EPS - Fixing behaviour when Nothing selected in role
+               // https://github.com/SinergiaTIC/SinergiaCRM/pull/821
                $actionPermission = $_SESSION['ACL'][$current_user->id][$root_bean->module_dir]['module'][$access_check]['aclaccess'] ?? ACL_ALLOW_NONE; 
                if ($actionPermission == ACL_ALLOW_NONE) {
                    if (empty($this->whereString)) {


### PR DESCRIPTION
- Closes #746 
- 
## Description
Al construir la SQL y añadir las condiciones de los grupos de seguridad, se estaba revisando si era necesario aplicar GS a la query con la función userNeedsSecurityGroup. Esta función comprueba si para la acción seleccionada tiene el permiso asignado ACL_ALLOW_GROUP. Cuando el permiso es ACL_ALLOW_NONE, esta función devuelve falso pero KReports no está haciendo nada especial....cuando no habría que mostrar nada.
Se ha añadido una condición para el caso que el permiso sea ACL_ALLOW_NONE, en cuyo caso se añade la condición 0 = 1  al WHERE, con lo que no se recuperan registros.

## Motivation and Context
Evitar que utilizando KReports se pueda visualizar información que no debería ver el usuario.

## How To Test This
1.- Crear un rol y poner NADA al permiso de listado y/o exportación
2.- Crear un usuario y asignarle el rol creado y algún grupo de seguridad
3.- Crear alguna persona y añadirle el grupo de seguridad del usuario y alguna otra persona con un grupo distinto
4.- Crear un informe que muestre personas
5.- Conectarse con el usuario creado
6.- Comprobar que el listado no muestra ninguna Persona
7.- Modificar el rol para poner GRUPO en la acción de listado
8.- Volver a conectarnos con el usuario para que refresque la definición del rol
9.- Comprobar que ahora sí aparecen las personas que deben
10.- Si se ha configurado el NADA en la exportación, comprobar que no se exporta nada

