### PR TITLE
Hotfix - Mensajes - Mostrar los botones de las vistas de detalle sólo si hay permiso

### DIFF
--- a/custom/include/generic/SugarWidgets/SugarWidgetSubPanelEditMessagesButton.php
+++ b/custom/include/generic/SugarWidgets/SugarWidgetSubPanelEditMessagesButton.php
@@ -73,16 +73,19 @@ class SugarWidgetSubPanelEditMessagesButton extends SugarWidgetSubPanelTopButton
 
     public function display($defines, $additionalFormFields = null, $nonbutton = false)
     {
-        require_once 'modules/MySettings/TabController.php';
-        $controller = new TabController();
-        $currentTabs = $controller->get_system_tabs();
-
-        if (!isset($currentTabs['stic_Messages']) || !$currentTabs['stic_Messages']){
-            return '';
+        if (ACLController::checkAccess('stic_Messages', 'edit', true)) {
+            require_once 'modules/MySettings/TabController.php';
+            $controller = new TabController();
+            $currentTabs = $controller->get_system_tabs();
+    
+            if (!isset($currentTabs['stic_Messages']) || !$currentTabs['stic_Messages']){
+                return '';
+            }
+    
+            $button = $this->_get_form($defines, $additionalFormFields);
+            
+            return $button;
         }
-
-        $button = $this->_get_form($defines, $additionalFormFields);
-        
-        return $button;
+        return '';
     }
 }

--- a/modules/stic_Messages/Utils.php
+++ b/modules/stic_Messages/Utils.php
@@ -178,11 +178,13 @@ class stic_MessagesUtils {
         require_once 'modules/MySettings/TabController.php';
         $controller = new TabController();
         $currentTabs = $controller->get_system_tabs();
+        $active = 'false';
         if (!($currentTabs['stic_Messages'] ?? false)){
-            $active = 'false';
         }
         else {
-            $active = 'true';
+            if (ACLController::checkAccess('stic_Messages', 'edit', true)) {
+                $active = 'true';
+            }
         }
 
         $messagesLimit = stic_SettingsUtils::getSetting('MESSAGES_LIMIT');


### PR DESCRIPTION

## Description
Los botones para crear nuevos mensajes desde las vistas de detalle de Contacts/Leads/Accounts se estaban motrando siempre que el usuario tenía acceso al módulo de Mensajes.
Se cambia para que sólo se muestren si tiene permiso de edición sobre el módulo de mensajes.

## Motivation and Context
Aparecían los botones cuando el usuario no podía usarlos, lo que generaba un panel de error vacío.

## How To Test This
1. Activar el módulo de mensajes
2. Crear un usuario
3. Conectar al CRM con el usuario
4. Comprobar que los botones aparecen (al lado de los teléfonos y en lso subpaneles de actividades e historial)
5. Asignar al usuario un rol que tenga NADA como permiso de edición en mensajes
6. Reconectar con el usuario
7. Comrpobar que no aparecen los botones
8. Modificar el rol para que el permiso de edición sea GRUPO
9. Reconectar con el usuario
10. Comprobar que vuelven a aparecer los botones

