### PR TITLE
Hotfix - Usuarios - Evitar reseteo de preferencias de usuario al realizar una actualización masiva

### DIFF
--- a/modules/Users/User.php
+++ b/modules/Users/User.php
@@ -1023,7 +1023,7 @@ class User extends Person implements EmailInterface
                 // END STIC Custom
             }
             // STIC Custom 20251024 JBL - Fix Reset User Preferences 
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/848
             // if (isset($_POST['ut'])) {
             //     $this->setPreference('ut', '0', 0, 'global');
             // } else {
@@ -1169,7 +1169,7 @@ class User extends Person implements EmailInterface
                 $this->setPreference('email_show_counts', $_REQUEST['email_show_counts'], 0, 'global');
             } else {
                 // STIC Custom 20251024 JBL - Fix Reset User Preferences 
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/848
                 // $this->setPreference('email_show_counts', 0, 0, 'global');
                 $emailShowCounts = $this->getCurrentPreference('email_show_counts');
                 $this->setPreference('email_show_counts', $emailShowCounts ?? 0, 0, 'global');

--- a/modules/Users/UserViewHelper.php
+++ b/modules/Users/UserViewHelper.php
@@ -674,7 +674,7 @@ class UserViewHelper
         }
 
         // STIC Custom 20251024 JBL - Fix Reset User Preferences 
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/848
         // if (!$this->bean->getPreference('ut')) {
         $ut = $this->bean->getPreference('ut');
 

--- a/modules/Users/tpls/EditViewFooter.tpl
+++ b/modules/Users/tpls/EditViewFooter.tpl
@@ -373,7 +373,7 @@
                     </td>
                     <td>
                         {{* STIC Custom 20251024 JBL - Fix Reset User Preferences  *}}
-                        {{* https://github.com/SinergiaTIC/SinergiaCRM/pull/??? *}}
+                        {{* https://github.com/SinergiaTIC/SinergiaCRM/pull/848 *}}
                         {{* <slot><input type="checkbox" tabindex='14' class="checkbox" name="ut" value="0" {$PROMPTTZ}> *}}
                         <slot><input type="checkbox" tabindex='14' class="checkbox" name="ut" {$PROMPTTZ}>
                         {{* End STIC Custom 20251024 JBL *}}


### PR DESCRIPTION
- Closes #844 


## Descripción
Se ha observado que **en ocasiones** al modificar las preferencias de un usuario, realizar una importación de usuarios o realizar alguna actualización masiva sobre usuarios, al logearse de nuevo alguno de los usuarios afectados, les aparecía el wizard inicial de configuración de las preferencias de usuario. 
Este error no siempre ha sido posible reproducirlo.

Es muy probable que tenga relación con https://github.com/SuiteCRM/SuiteCRM/issues/6869

Como se comenta en el issue #844, este comportamiento se detectó durante la actualización del core y se integró su solución en la [release 2.0.0](https://github.com/SinergiaTIC/SinergiaCRM/releases/tag/2.0.0), concretamente en el commit https://github.com/SinergiaTIC/SinergiaCRM/pull/315/commits/a97d282cfdb02c98f275af5e945111074299224a.

Se ha podido reproducir el error en alguna instancia, pero si en cierto momento dejaba de reproducirse, ya no había manera de volverlo a reproducir

## Análisis realizado
Para solventar el problema se ha analizado el reseteo de las preferencias de usuario:
- La función `saveFormPreferences` es la encargada de guardar las preferencias de usuario al guardar un usuario. Estas preferencias en un inicio se reseteaban cuando no venían informadas por POST (no se guardaba el usuario desde el formulario de edición de usuarios). Este error en su mayor parte fue solucinado en https://github.com/SinergiaTIC/SinergiaCRM/pull/315/commits/a97d282cfdb02c98f275af5e945111074299224a
https://github.com/SinergiaTIC/SinergiaCRM/blob/a5d9df710ac598772be1b84434113a8385def1c6/modules/Users/User.php#L853

- El wizard de usuario se muestra si la configuración `ut` no está informada:
https://github.com/SinergiaTIC/SinergiaCRM/blob/a5d9df710ac598772be1b84434113a8385def1c6/modules/Users/authentication/AuthenticationController.php#L174-L185

- Se observa que al guardar las preferencias de usuario, no se asigna correctamente el valor de `ut`:
https://github.com/SinergiaTIC/SinergiaCRM/blob/a5d9df710ac598772be1b84434113a8385def1c6/modules/Users/User.php#L1025-L1026

- Analizando el código más actual de SuiteCRM (v 7.14.7), se observa que en el commit https://github.com/SuiteCRM/SuiteCRM/commit/42b1bb875c95a35add12db1928190e6f8318e541 se corrigió la aparición del wizard de Usuario

## Cambios realizados
Se han aplicado los cambios implementados en SuiteCRM, concretamente en el commit https://github.com/SuiteCRM/SuiteCRM/commit/42b1bb875c95a35add12db1928190e6f8318e541
## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Pruebas
0. Verificar el código
1. Crear un usuario 
2. Hacer login con el nuevo usuario (aparecerá el wizard inicial)
3. Volver a hacer login para asegurarse que ya no aparece
4. Modificar alguna preferencia del usuario 
5. Hacer login con el usuario: NO vuelve a aparecer el login inicial.
6. Realizar la misma comprobación modificando cualquier propiedad del usuario mediante actualización masiva.
7. Realizar la misma comprobación importando el usuario.