### PR TITLE
Improvement - General - Incluir ficheros internos en gitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ sdaRebuildError.txt
 
 # Ignore STIC internal files
 SticRepair.php
+
+# Do not ignore cache vendor library
+!vendor/psr/cache/


### PR DESCRIPTION
## Descripción
Durante el desarrollo de otros PRs, se ha detectado que se pueden incluir de forma accidental ficheros de uso interno en el repositorio cuando éstos no deberían ser distribuidos. Concretamente, se detectó con el fichero SticRepair.php

Para evitar eso, se decidió incluirlo en el `.gitignore` del repositorio.

## Pruebas
Las pruebas se realizarán mediante evaluación en local:
1. Descargar la rama actual del PR
2. Crear un fichero en la raíz del proyecto con el nombre `SticRepair.php`
3. Verificar que el nuevo fichero se ignora por git y no está pendiente de "subir"
