### PR TITLE
Hotfix - Ventas - Formato correcto del descuento si éste supera el precio del producto

### DIFF
--- a/modules/AOS_Products_Quotes/line_items.js
+++ b/modules/AOS_Products_Quotes/line_items.js
@@ -660,7 +660,7 @@ function calculateLine(ln, key){
       if(discount > listPrice)
       {
         // STIC Custom 20251107 JBL - Fix number format if discount is greater than price
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/???
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/863
         // document.getElementById(key + 'product_discount' + ln).value = listPrice;
         document.getElementById(key + 'product_discount' + ln).value = document.getElementById(key + 'product_list_price' + ln).value
         // END STIC Custom


### PR DESCRIPTION
- Closes #855 

## Descripción
Tal y como se describe en #855, en los módulos de Facturas, Presupuestos y Contratos, si en una línea de producto o servicio se especificaba un descuento por cantidad cuyo valor fuese superior al precio unitario, el descuento adquiría el valor del producto pero no mantenía el formato numérico, cosa que provocaba errores en los cálculos

## Cambios realizados
Al elemento en la UI con el descuento se le asignaba el valor de una variable js con el descuento que se obtenia convirtiendo el texto leído del campo del precio del producto a decimal. Al asignarse éste valor decimal se perdía el formato original. 
Se  ha optado por copiar el campo con el precio en el descuento (manteniendo formatos)

## Pruebas
1. Crear un Presupuesto
2. Añadir un nuevo grupo
3. Añadir una nueva línea de producto
4. Indicar un producto con un precio de lista con decimales
5. Indicar "cantidad" en el tipo de descuento
6. Indicar un descuento superior al precio de lista
7. Cambiar el foco
8. Verificar que el descuento se ha cambiado al precio de lista del producto y no ha cambiado el símbolo de decimales por un punto

