### PR TITLE
Bug - Economía - Manejo de respuesta no válida de la pasarela de pago al enviar pagos recurrentes

### DIFF
--- a/modules/stic_Payments/language/ca_ES.lang.php
+++ b/modules/stic_Payments/language/ca_ES.lang.php
@@ -112,6 +112,7 @@ $mod_strings = array(
     'LBL_CARD_PAYMENT_SUCCESSFUL' => "El pagament s'ha fet efectiu correctament.",
     'LBL_CARD_PAYMENT_COMMITMENT_EXPIRED_TITLE' => 'Compromís de pagament donat de baixa per targeta caducada.',
     'LBL_CARD_PAYMENT_COMMITMENT_EXPIRED_SUBTITLE' => "El pagament no s'ha pogut fer efectiu.",
+    'LBL_CARD_PAYMENT_GATEWAY_NO_RESPONSE' => "No s'ha rebut resposta de la passarel·la de pagament. Si us plau, intenti-ho de nou més tard o contacti amb l'administrador del sistema.",
     'LBL_AGGREGATED_PAYMENTS_MENU' => 'Calcula els pagaments agregats',
     'LBL_AGGREGATED_TITLE' => 'Pagaments de serveis agregats',
     'LBL_AGGREGATED_SUMMARY_TITLE' => 'Resum dels pagaments',

--- a/modules/stic_Payments/language/en_us.lang.php
+++ b/modules/stic_Payments/language/en_us.lang.php
@@ -113,6 +113,7 @@ $mod_strings = array(
     'LBL_CARD_PAYMENT_SUCCESSFUL' => 'Payment successfully charged.',
     'LBL_CARD_PAYMENT_COMMITMENT_EXPIRED_TITLE' => 'Payment commitment has been cancelled due to an expired card.',
     'LBL_CARD_PAYMENT_COMMITMENT_EXPIRED_SUBTITLE' => 'Payment could not be charged.',
+    'LBL_CARD_PAYMENT_GATEWAY_NO_RESPONSE' => 'No response has been received from the payment gateway. Please try again later or contact the system administrator.',
     'LBL_AGGREGATED_PAYMENTS_MENU' => 'Calculate aggregated payments',
     'LBL_AGGREGATED_TITLE' => 'Aggregated services payments',
     'LBL_AGGREGATED_SUMMARY_TITLE' => 'Payments summary',

--- a/modules/stic_Payments/language/es_ES.lang.php
+++ b/modules/stic_Payments/language/es_ES.lang.php
@@ -112,6 +112,7 @@ $mod_strings = array(
     'LBL_CARD_PAYMENT_SUCCESSFUL' => 'El pago ha sido hecho efectivo correctamente.',
     'LBL_CARD_PAYMENT_COMMITMENT_EXPIRED_TITLE' => 'Compromiso de pago cancelado debido a tarjeta caducada.',
     'LBL_CARD_PAYMENT_COMMITMENT_EXPIRED_SUBTITLE' => 'El pago no se ha podido hacer efectivo.',
+    'LBL_CARD_PAYMENT_GATEWAY_NO_RESPONSE' => 'No se ha recibido respuesta de la pasarela de pago. Por favor, inténtelo de nuevo más tarde o contacte con el administrador del sistema.',
     'LBL_AGGREGATED_PAYMENTS_MENU' => 'Calcular pagos agregados',
     'LBL_AGGREGATED_TITLE' => 'Pagos de servicios agregados',
     'LBL_AGGREGATED_SUMMARY_TITLE' => 'Resumen de los pagos',

--- a/modules/stic_Payments/language/eu_ES.lang.php
+++ b/modules/stic_Payments/language/eu_ES.lang.php
@@ -112,6 +112,7 @@ $mod_strings = array(
     'LBL_CARD_PAYMENT_SUCCESSFUL' => 'El pago ha sido hecho efectivo correctamente.',
     'LBL_CARD_PAYMENT_COMMITMENT_EXPIRED_TITLE' => 'Compromiso de pago cancelado debido a tarjeta caducada.',
     'LBL_CARD_PAYMENT_COMMITMENT_EXPIRED_SUBTITLE' => 'El pago no se ha podido hacer efectivo.',
+    'LBL_CARD_PAYMENT_GATEWAY_NO_RESPONSE' => 'No se ha recibido respuesta de la pasarela de pago. Por favor, inténtelo de nuevo más tarde o contacte con el administrador del sistema.',
     'LBL_AGGREGATED_PAYMENTS_MENU' => 'Calcular pagos agregados',
     'LBL_AGGREGATED_TITLE' => 'Pagos de servicios agregados',
     'LBL_AGGREGATED_SUMMARY_TITLE' => 'Resumen de los pagos',

--- a/modules/stic_Payments/language/gl_ES.lang.php
+++ b/modules/stic_Payments/language/gl_ES.lang.php
@@ -112,6 +112,7 @@ $mod_strings = array (
     'LBL_CARD_PAYMENT_SUCCESSFUL' => 'O pago foi feito efectivo correctamente.',
     'LBL_CARD_PAYMENT_COMMITMENT_EXPIRED_TITLE' => 'Compromiso de pago cancelado debido a tarxeta caducada.',
     'LBL_CARD_PAYMENT_COMMITMENT_EXPIRED_SUBTITLE' => 'O pago non se  puido facer efectivo.',
+    'LBL_CARD_PAYMENT_GATEWAY_NO_RESPONSE' => 'Non se recibiu resposta da pasarela de pago. Por favor, inténtoo de novo máis tarde ou contacte co administrador do sistema.',
     'LBL_AGGREGATED_PAYMENTS_MENU' => 'Calcular pagos agregados',
     'LBL_AGGREGATED_TITLE' => 'Pagos de servizos agregados',
     'LBL_AGGREGATED_SUMMARY_TITLE' => 'Resumo dos pagos',


### PR DESCRIPTION
En este PR se previene el caso descrito en el issue #864, forzando el registro del error recibido cuando la pasarela no ha podido procesarlo y lo ha rechazado directamente. 

## Cómo validarlo
- Para provocar este error y verificar que se registra, es necesario estavblecer TPVTEST a 0, paraq ue la petición se envíe al entorno de producción de Redsys.