### PR TITLE
Hotfix - Documentos - Recuperar información del documento aunque el usuario creador de la revisión no exista

### DIFF
--- a/modules/Documents/Document.php
+++ b/modules/Documents/Document.php
@@ -238,7 +238,7 @@ class Document extends File
         $mod_strings = return_module_language($current_language, 'Documents');
 
         if (!empty($this->document_revision_id)) {
-            // STIC-Custom - 
+            // STIC-Custom 20251119 MHP - https://github.com/SinergiaTIC/SinergiaCRM/pull/874
             // Use a right join instead join to return the document information even if there is no associated user.
             // $query = "SELECT users.first_name AS first_name, users.last_name AS last_name, document_revisions.date_entered AS rev_date,
             // 	 document_revisions.filename AS filename, document_revisions.revision AS revision,


### PR DESCRIPTION
- Closes #873 

## Descripción
Este PR soluciona la incidencia descrita en el issue cambiando un JOIN por un RIGTH JOIN en una query realizada en el fichero: modules/Documents/Document.php

## Pruebas
1. Crear un documento, acceder a la versión y copiar el ID.
2. Acceder al registro de la revisión en la tabla de `document_revisions` de la base de datos, modificar el valor de la columna `created_by` e indicar un ID que no pertenezca a ningún usuario del CRM. 
3. Acceder a las vistas de detalle y de edición del documento y comprobar que SÍ aparece el campo **Nombre de Archivo**