### PR TITLE
Improvement -  SinergiaDA - Añadir configuración para auto-reconstrucción al borrar campos o modulos

### DIFF
--- a/ModuleInstall/ModuleInstaller.php
+++ b/ModuleInstall/ModuleInstaller.php
@@ -296,7 +296,7 @@ class ModuleInstaller
         $rebuildSDAFile = 'SticInclude/SinergiaDARebuild.php';
         $sdaAutoRebuild = $sugar_config['stic_sinergiada']['auto_rebuild_on_studio_events'] ?? true;
 
-        if (file_exists($rebuildSDAFile) && $sdaEnabled && $sdaAutoRebuild) {
+        if (file_exists($rebuildSDAFile) && $sdaEnabled && $sdaAutoRebuild != false) {
             require_once $rebuildSDAFile;
             $GLOBALS['log']->stic('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Uninstalling module. {$this->base_dir}. Rebuilding SinergiaDA");
             SinergiaDARebuild::callApiRebuildSDA(true, 'views');

--- a/modules/Administration/QuickRepairAndRebuild.php
+++ b/modules/Administration/QuickRepairAndRebuild.php
@@ -139,7 +139,7 @@ class RepairAndClear
         $rebuildSDAFile = 'SticInclude/SinergiaDARebuild.php';
         $sdaAutoRebuild = $sugar_config['stic_sinergiada']['auto_rebuild_on_studio_events'] ?? true;
 
-        if (file_exists($rebuildSDAFile) && $sdaEnabled && $sdaAutoRebuild) {
+        if (file_exists($rebuildSDAFile) && $sdaEnabled && $sdaAutoRebuild != false) {
             if (
                 // It is necessary to assess whether $_REQUEST['silent'] == True, since by erase a field, the pass flow
                 // twice here with different values and we want the code to be one time. In the case of deleting relationships


### PR DESCRIPTION
## Descripción
Actualmente cuando se elimina un campo en estudio, o cuando se desinstala un módulo a través del cargador de módulos, se lanza de manera automática el Rebuild de SinergiaDA. Esto provoca que, dependiendo del tiempo que tarde este proceso, se puede alcanzar un timeout que deja sin control al usuario que ha lanzado la acción.

Para evitar este comportamiento en los casos en que sea necesario, se puede utilizar en config_overrride.php la variable `$sugar_config['stic_sinergiada']['auto_rebuild_on_studio_events']`, en caso de que esta sea _false_, se omitirá el proceso de reconstrucción, y en cualquier otro caso se hará la reconstrucción.

## Cómo probarlo
- Crear la variable `$sugar_config['stic_sinergiada']['auto_rebuild_on_studio_events'] = false` en config_override.php
- Crear y eliminar un campo en estudio en cualquier módulo. Verificar que no se lanza la reconstrucción. (se puede comprobar viendo el fichero sinergiacrm.log).
- Eliminar un modulo de pruebas previamente cargado mediante el Cargador de módulos y verificar que no se lanza la reconstrucción.
- Cambiar el valor de la configuración a true (o eliminar la configuración) y verificar que sí se lanza la reconstrucción en los casos anteriores.

