### PR TITLE
Hotfix - Informes - Deshacer PR #821 (permisos en Kreports)

### DIFF
--- a/modules/KReports/KReportQuery.php
+++ b/modules/KReports/KReportQuery.php
@@ -908,17 +908,17 @@ class KReportQuery {
                      $this->whereString .= ' AND ' . $group_where;
                   }
                }
-               // STIC Custom 20251003 EPS - Fixing behaviour when Nothing selected in role
-               // https://github.com/SinergiaTIC/SinergiaCRM/pull/821
-               $actionPermission = $_SESSION['ACL'][$current_user->id][$root_bean->module_dir]['module'][$access_check]['aclaccess'] ?? ACL_ALLOW_NONE; 
-               if ($actionPermission == ACL_ALLOW_NONE) {
-                   if (empty($this->whereString)) {
-                        $this->whereString = " ( 0 = 1 ) ";
-                     } else {
-                        $this->whereString .= " AND ( 0 = 1) ";
-                     }
-               }
-               // END STIC Custom
+               // // STIC Custom 20251003 EPS - Fixing behaviour when Nothing selected in role
+               // // https://github.com/SinergiaTIC/SinergiaCRM/pull/821
+               // $actionPermission = $_SESSION['ACL'][$current_user->id][$root_bean->module_dir]['module'][$access_check]['aclaccess'] ?? ACL_ALLOW_NONE; 
+               // if ($actionPermission == ACL_ALLOW_NONE) {
+               //     if (empty($this->whereString)) {
+               //          $this->whereString = " ( 0 = 1 ) ";
+               //       } else {
+               //          $this->whereString .= " AND ( 0 = 1) ";
+               //       }
+               // }
+               // // END STIC Custom
 
                break;
          }


### PR DESCRIPTION
## Descripción
Se deshacen los cambios introducidos por el el PR #821 al comprobar que provocan que no funcionen (algunos) informes afectados por grupos de seguridad, a falta de verificacion detallada.