### PR TITLE
Hotfix - Usuarios y Empleados - No mostrar las opciones de Eliminar y Enviar Correo en las acciones de la vista de lista

### DIFF
--- a/custom/modules/Employees/views/view.list.php
+++ b/custom/modules/Employees/views/view.list.php
@@ -37,6 +37,13 @@ class CustomEmployeesViewList extends EmployeesViewList
 
         SticViews::preDisplay($this);
 
+        // Disable the Delete and Send Email options
+        $this->lv->delete = false;
+        $this->lv->email = false;
+        if (!$GLOBALS['current_user']->isAdminForModule('Users')) {
+            $this->lv->multiSelect = false;
+        }
+
         // Write here the SinergiaCRM code that must be executed for this module and view
     }
 

--- a/custom/modules/Users/views/view.list.php
+++ b/custom/modules/Users/views/view.list.php
@@ -37,6 +37,10 @@ class CustomUsersViewList extends UsersViewList
 
         SticViews::preDisplay($this);
 
+        // Disable the Delete and Send Email options
+        $this->lv->delete = false;
+        $this->lv->email = false;
+        
         // Write here the SinergiaCRM code that must be executed for this module and view
     }
 


### PR DESCRIPTION
- Closes #894 

## Descripción

Se detecta que la llamada a `SticViews::preDisplay($this);` inicializa el objeto  `$this->lv` y se pierden las acciones  que se realizaron en la llamada al método:  `parent::preDisplay();` , que eran las de no mostrar las opciones de **Eliminar** y **Enviar Email** 

El PR recupera dichas acciones tras la ejecución de `SticViews::preDisplay($this);`. Se hace de esta manera por que el método `SticViews::preDisplay($this);` es utilizado de manera genérica por muchos módulos del CRM y está solución es la más sencilla.

## Pruebas
1. Acceder a la vista de lista de Empleados y Usuarios y comprobar que ya no se muestran las opciones de Eliminar y Enviar correo