### PR TITLE
Improvement - General - Añadir información de API y CRON en log de Loki

### DIFF
--- a/SticInclude/SticRemoteLogLogicHooksCode.php
+++ b/SticInclude/SticRemoteLogLogicHooksCode.php
@@ -127,8 +127,8 @@ class SticRemoteLogLogicHooks
                         'user_admin' => is_admin($current_user),
                     ],
                     'curl_options' => [
-                        CURLOPT_CONNECTTIMEOUT_MS => 20,
-                        CURLOPT_TIMEOUT_MS => 25,
+                        CURLOPT_CONNECTTIMEOUT_MS => $sugar_config['stic_remote_monitor_curlopt_connecttimeout'] ?? 20,
+                        CURLOPT_TIMEOUT_MS => $sugar_config['stic_remote_monitor_curlopt_timeout'] ?? 25,
                     ]
                 ])
             ])

--- a/config.php
+++ b/config.php
@@ -644,6 +644,8 @@ $sugar_config = array(
     'stic_remote_monitor_url' => '', 
     'stic_remote_monitor_duration_threshold' => null,
     'stic_remote_monitor_memory_threshold' => null,
+    'stic_remote_monitor_curlopt_connecttimeout' => null,
+    'stic_remote_monitor_curlopt_timeout' => null,
     // END STIC
 
     // STIC Custom 20241016 ART - Tracker prune interval for the Scheduler


### PR DESCRIPTION
Se modifica los mensajes de log que se envían a Loki para definir explícitamente cuando una petición es API o Cron.

Además se incrementa el tiempo de espera por defecto de los envíos de peticiones curl y se parametriza para poder modificar su valor utilizando las variables:
```    
$sugar_config['stic_remote_monitor_curlopt_connecttimeout']
$sugar_config['stic_remote_monitor_curlopt_timeout']

```

Se puede validar por inspección de código.