### PR TITLE
Hotfix - Monitorización - Uso de la variable de configuración en tarea programada

### DIFF
--- a/modules/Schedulers/_AddJobsHere.php
+++ b/modules/Schedulers/_AddJobsHere.php
@@ -382,7 +382,10 @@ function trimTracker()
     $trackerConfig = $tracker_config;
 
     require_once('include/utils/db_utils.php');
-    $prune_interval = !empty($admin->settings['tracker_prune_interval']) ? $admin->settings['tracker_prune_interval'] : 30;
+    // STIC-Custom AAM 20251216 - Use sugar_config instead of admin settings
+    // $prune_interval = !empty($admin->settings['tracker_prune_interval']) ? $admin->settings['tracker_prune_interval'] : 30;
+    $prune_interval = !empty($sugar_config['tracker_prune_interval']) ? $sugar_config['tracker_prune_interval'] : 30;
+    // END STIC-Custom
     foreach ($trackerConfig as $tableName => $tableConfig) {
 
         //Skip if table does not exist


### PR DESCRIPTION
En el desarrollo #211 se define que para definir los días de permanencia de los registros del módulo de Monitorización se utiliza la variable de configuración `tracker_prune_interval` des `sugar_config`. Ahora, se ha visto que la tarea programada estaba recogiendo el parámetro de `tracker_prune_interval` desde los parámetros de configuración de administración, los cuáles no se establecen en ningún lugar. 

Se modifica el código para que recoja este parámetro directamente del array `sugar_config`.

