### PR TITLE
Enhancement - General - Añadir filtro por grupos de seguridad

### DIFF
--- a/include/SugarObjects/implements/security_groups/vardefs.php
+++ b/include/SugarObjects/implements/security_groups/vardefs.php
@@ -51,6 +51,23 @@ $vardefs = array(
             'source' => 'non-db',
             'vname' => 'LBL_SECURITYGROUPS',
         ),
+        // STIC-Custom AAM 20260107 - Many to Many Security Suite filter field
+        // Add securitygroups_name to searchFields if defined in searchdefs
+        'securitygroups_name' => array (
+            'name' => 'securitygroups_name',
+            'label' => 'LBL_SECURITYGROUPS_NAME',
+            'width' => '10%',
+            'default' => true,
+            'type' => 'relate',
+            'source' => 'non-db',
+            'studio' => array(
+                'searchview' => true, // To appear in the filter view layout editor
+                'visible' => false // To avoid appear in the record view layout editor
+            ),
+            'id_name' => true,
+            'module' => 'SecurityGroups',
+        ),
+        // END STIC-Custom
     ),
     'relationships' => array(
         'securitygroups_' . strtolower($module) =>


### PR DESCRIPTION
En el PR https://github.com/SinergiaTIC/SinergiaCRM/pull/805 se añadió una mejora que incluía filtros de varias relaciones Muchos a Muchos en algunos de los módulos de SinergiaCRM. Esta mejora se tubo que tirar atrás https://github.com/SinergiaTIC/SinergiaCRM/pull/809 debido a dos razones:
- Incompatibilidad con la reconstrucción de SinergiaDA debido a nuevos campos no controlados en Vardefs.
- Las instancias que ya tenían su propio SearchFields no podían añadir esos nuevos filtros desde Estudio.

Ahora se ha vuelto a rescatar la funcionalidad pero para añadir únicamente los filtros de Grupos de seguridad para todos los módulos.

Pruebas:
- Comprobar que es posible añadir los filtros de grupos de seguridad en cualquier módulo y en cualquier instancia (ya sea producción o desarrollo). 
- Comprobar que los filtros funcionan correctamente.
- Comprobar que la reconstrucción de SDA funciona correctamente.