### PR TITLE
Hotfix - Plantillas PDF - Aplicar grupos de seguridad al generar PDF de manera masiva

### DIFF
--- a/modules/AOS_PDF_Templates/formLetterPdf.php
+++ b/modules/AOS_PDF_Templates/formLetterPdf.php
@@ -62,6 +62,7 @@ if (isset($_REQUEST['current_post']) && $_REQUEST['current_post'] != '') {
     $ret_array = create_export_query_relate_link_patch($_REQUEST['module'], $mass->searchFields, $mass->where_clauses);
 
     // STIC-Custom 20260112 EPS - Adding SG check as in export_utils.php
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/928
     // $query = $bean->create_export_query($order_by, $ret_array['where'], $ret_array['join']);
     $where = $ret_array['where'];
 


### PR DESCRIPTION

## Description
Se observa en el curso de una adaptació que la generación de documentos PDF de algunos módulos incluye en la generación registros que por grupo de seguridad no pueden visualizarse.
Se comprueba que en la exportación a CSV esto no ocurre y se incorpora al procedimiento de generación de PDF la misma salvaguarda que existe en export_utils.php para la exportación a CSV.

## Motivation and Context
No deberían incluirse en un PDF datos de registros a los que no se tiene acceso.

## How To Test This
1.- Crear distintos registros en Personas (u Organizaciones, Reuniones...).
2.- Asignar parte de estos registros a un grupo de seguridad S1
3.- Crear un usuario y rol, demanera que dicho usuario sólo pueda ver, listar, exportar registros de su grupo S1.
4.- Acceder con el usuario creado y comrpobar que sólo aparecen en la vista de lista las personas que debe por GS.
**5.- Crear un documento PDF seleccionando "todos los registros" y comprobar que las personas que se muestran en el PDF son las mismas que en la vista lista
6.- Realizar la prueba tanto habiéndo realizado un filtro como sin filtro**

