### PR TITLE
Improvement - SinergiaDA - Deshabilitar acceso de solo lectura

### DIFF
--- a/custom/Extension/application/Ext/Language/ca_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/ca_ES.SticLang.php
@@ -3663,7 +3663,7 @@ $app_list_strings['trackers_actions_list']['impersonate_stop'] = 'Fi de suplanta
 // SinergiaDA: Nivells d'accés dels usuaris
 $app_list_strings['sda_users_access_list']['0'] = 'Sense accés';
 $app_list_strings['sda_users_access_list']['1'] = 'Accés complet';
-$app_list_strings['sda_users_access_list']['2'] = 'Accés de només lectura';
+// $app_list_strings['sda_users_access_list']['2'] = 'Accés de només lectura'; 
 
 // Productes financers: Tipus de productes
 $app_list_strings['stic_financial_products_types_list']['current_account'] = 'Compte corrent';

--- a/custom/Extension/application/Ext/Language/en_us.SticLang.php
+++ b/custom/Extension/application/Ext/Language/en_us.SticLang.php
@@ -3662,7 +3662,7 @@ $app_list_strings['trackers_actions_list']['impersonate_stop'] = 'Impersonation 
 // SinergiaDA: Users access levels
 $app_list_strings['sda_users_access_list']['0'] = 'No access';
 $app_list_strings['sda_users_access_list']['1'] = 'Full access';
-$app_list_strings['sda_users_access_list']['2'] = 'Read-only access';
+// $app_list_strings['sda_users_access_list']['2'] = 'Read-only access';
 
 // Financial Products: Product types
 $app_list_strings['stic_financial_products_types_list']['current_account'] = 'Current account';

--- a/custom/Extension/application/Ext/Language/es_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/es_ES.SticLang.php
@@ -3663,7 +3663,7 @@ $app_list_strings['trackers_actions_list']['impersonate_stop'] = 'Fin de suplant
 // SinergiaDA: Niveles de acceso de los usuarios
 $app_list_strings['sda_users_access_list']['0'] = 'Sin acceso';
 $app_list_strings['sda_users_access_list']['1'] = 'Acceso completo';
-$app_list_strings['sda_users_access_list']['2'] = 'Acceso de solo lectura';
+// $app_list_strings['sda_users_access_list']['2'] = 'Acceso de solo lectura'; // Disabled for the moment
 
 // Productos financieros: Tipos de productos
 $app_list_strings['stic_financial_products_types_list']['current_account'] = 'Cuenta corriente';

--- a/custom/Extension/application/Ext/Language/eu_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/eu_ES.SticLang.php
@@ -3663,7 +3663,7 @@ $app_list_strings['trackers_actions_list']['impersonate_stop'] = 'Fin de suplant
 // SinergiaDA: Niveles de acceso de los usuarios
 $app_list_strings['sda_users_access_list']['0'] = 'Sin acceso';
 $app_list_strings['sda_users_access_list']['1'] = 'Acceso completo';
-$app_list_strings['sda_users_access_list']['2'] = 'Acceso de solo lectura';
+// $app_list_strings['sda_users_access_list']['2'] = 'Acceso de solo lectura';
 
 // Productos financieros: Tipos de productos
 $app_list_strings['stic_financial_products_types_list']['current_account'] = 'Cuenta corriente';

--- a/custom/Extension/application/Ext/Language/gl_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/gl_ES.SticLang.php
@@ -3664,7 +3664,7 @@ $app_list_strings['trackers_actions_list']['impersonate_stop'] = 'Fin de suplant
 // SinergiaDA: Niveis de acceso dos usuarios
 $app_list_strings['sda_users_access_list']['0'] = 'Sen acceso';
 $app_list_strings['sda_users_access_list']['1'] = 'Acceso completo';
-$app_list_strings['sda_users_access_list']['2'] = 'Acceso de só lectura';
+// $app_list_strings['sda_users_access_list']['2'] = 'Acceso de só lectura';
 
 // Productos financieros: Tipos de productos
 $app_list_strings['stic_financial_products_types_list']['current_account'] = 'Cuenta corriente';


### PR DESCRIPTION
Se deshabilita la posibilidad de asignar el acceso de solo lectura a los ususarios de SDA hasta que no se aplique el PR correspondiente en SinergiaDA