### PR TITLE
Hotfix - Secciones de plantilla - Quitar el campo grp de las vistas del módulo

### DIFF
--- a/modules/TemplateSectionLine/metadata/dashletviewdefs.php
+++ b/modules/TemplateSectionLine/metadata/dashletviewdefs.php
@@ -23,13 +23,13 @@ $dashletData['TemplateSectionLineDashlet']['columns'] = array(
     'default' => true,
     'name' => 'name',
   ),
-  'grp' =>
-  array(
-    'type' => 'varchar',
-    'label' => 'LBL_GRP',
-    'width' => '10%',
-    'default' => true,
-  ),
+  // 'grp' =>
+  // array(
+  //   'type' => 'varchar',
+  //   'label' => 'LBL_GRP',
+  //   'width' => '10%',
+  //   'default' => true,
+  // ),
   'description' =>
   array(
     'type' => 'text',

--- a/modules/TemplateSectionLine/metadata/detailviewdefs.php
+++ b/modules/TemplateSectionLine/metadata/detailviewdefs.php
@@ -160,14 +160,15 @@ array(
           1 => 'assigned_user_name',          
         ),
         1 => array(
+          // 0 => array(
+          //   'name' => 'grp',
+          //   'label' => 'LBL_GRP',
+          // ),
           0 => array(
-            'name' => 'grp',
-            'label' => 'LBL_GRP',
-          ),
-          1 => array(
             'name' => 'ord',
             'label' => 'LBL_ORD',
           ),
+          1 => array(),
         ),
         3 => array(
           0 => 'htmlcode_c',

--- a/modules/TemplateSectionLine/metadata/editviewdefs.php
+++ b/modules/TemplateSectionLine/metadata/editviewdefs.php
@@ -146,14 +146,15 @@ array(
           1 => 'assigned_user_name',          
         ),
         1 => array(
+          // 0 => array(
+          //   'name' => 'grp',
+          //   'label' => 'LBL_GRP',
+          // ),
           0 => array(
-            'name' => 'grp',
-            'label' => 'LBL_GRP',
-          ),
-          1 => array(
             'name' => 'ord',
             'label' => 'LBL_ORD',
-        ),
+          ),
+          1 => array(),
         ),
         3 => array(
           0 => 'description',

--- a/modules/TemplateSectionLine/metadata/listviewdefs.php
+++ b/modules/TemplateSectionLine/metadata/listviewdefs.php
@@ -71,12 +71,12 @@ array(
     'default' => true,
     'link' => true,
   ),
-  'GRP' => array(
-    'width' => '5%',
-    'label' => 'LBL_GRP',
-    'default' => true,
-    'link' => true,
-  ),
+  // 'GRP' => array(
+  //   'width' => '5%',
+  //   'label' => 'LBL_GRP',
+  //   'default' => true,
+  //   'link' => true,
+  // ),
   'ORD' => array(
     'width' => '5%',
     'label' => 'LBL_ORD',

--- a/modules/TemplateSectionLine/metadata/popupdefs.php
+++ b/modules/TemplateSectionLine/metadata/popupdefs.php
@@ -5,7 +5,7 @@ $popupMeta = array(
     'orderBy' => 'templatesectionline.name',
     'whereClauses' => array(
   'name' => 'templatesectionline.name',
-  'grp' => 'templatesectionline.grp',
+  // 'grp' => 'templatesectionline.grp',
   'description' => 'templatesectionline.description',
 ),
     'searchInputs' => array(
@@ -22,13 +22,13 @@ $popupMeta = array(
     'width' => '10%',
     'name' => 'name',
   ),
-  'grp' =>
-  array(
-    'type' => 'varchar',
-    'label' => 'LBL_GRP',
-    'width' => '10%',
-    'name' => 'grp',
-  ),
+  // 'grp' =>
+  // array(
+  //   'type' => 'varchar',
+  //   'label' => 'LBL_GRP',
+  //   'width' => '10%',
+  //   'name' => 'grp',
+  // ),
   'description' =>
   array(
     'type' => 'text',
@@ -47,13 +47,13 @@ $popupMeta = array(
     'width' => '10%',
     'default' => true,
   ),
-  'GRP' =>
-  array(
-    'type' => 'varchar',
-    'label' => 'LBL_GRP',
-    'width' => '10%',
-    'default' => true,
-  ),
+  // 'GRP' =>
+  // array(
+  //   'type' => 'varchar',
+  //   'label' => 'LBL_GRP',
+  //   'width' => '10%',
+  //   'default' => true,
+  // ),
   'DESCRIPTION' =>
   array(
     'type' => 'text',

--- a/modules/TemplateSectionLine/metadata/quickcreatedefs.php
+++ b/modules/TemplateSectionLine/metadata/quickcreatedefs.php
@@ -141,14 +141,15 @@ array(
           1 => 'assigned_user_name',          
         ),
         1 => array(
+          // 0 => array(
+          //   'name' => 'grp',
+          //   'label' => 'LBL_GRP',
+          // ),
           0 => array(
-            'name' => 'grp',
-            'label' => 'LBL_GRP',
-          ),
-          1 => array(
             'name' => 'ord',
             'label' => 'LBL_ORD',
-        ),
+          ),
+          1 => array(),
         ),
         3 => array(
           0 => 'description',

--- a/modules/TemplateSectionLine/metadata/searchdefs.php
+++ b/modules/TemplateSectionLine/metadata/searchdefs.php
@@ -176,14 +176,14 @@ array(
         'default' => true,
         'width' => '10%',
       ),
-      'grp' =>
-      array(
-        'type' => 'varchar',
-        'label' => 'LBL_GRP',
-        'width' => '10%',
-        'default' => true,
-        'name' => 'grp',
-      ),
+      // 'grp' =>
+      // array(
+      //   'type' => 'varchar',
+      //   'label' => 'LBL_GRP',
+      //   'width' => '10%',
+      //   'default' => true,
+      //   'name' => 'grp',
+      // ),
       'description' =>
       array(
         'type' => 'text',
@@ -226,14 +226,14 @@ array(
         'default' => true,
         'width' => '10%',
       ),
-      'grp' =>
-      array(
-        'type' => 'varchar',
-        'label' => 'LBL_GRP',
-        'width' => '10%',
-        'default' => true,
-        'name' => 'grp',
-      ),
+      // 'grp' =>
+      // array(
+      //   'type' => 'varchar',
+      //   'label' => 'LBL_GRP',
+      //   'width' => '10%',
+      //   'default' => true,
+      //   'name' => 'grp',
+      // ),
       'description' =>
       array(
         'type' => 'text',

--- a/modules/TemplateSectionLine/metadata/subpanels/default.php
+++ b/modules/TemplateSectionLine/metadata/subpanels/default.php
@@ -16,13 +16,13 @@ $subpanel_layout = array(
   'where' => '',
   'list_fields' =>
   array(
-    'grp' =>
-    array(
-      'type' => 'varchar',
-      'vname' => 'LBL_GRP',
-      'width' => '10%',
-      'default' => true,
-    ),
+    // 'grp' =>
+    // array(
+    //   'type' => 'varchar',
+    //   'vname' => 'LBL_GRP',
+    //   'width' => '10%',
+    //   'default' => true,
+    // ),
     'name' =>
     array(
       'vname' => 'LBL_NAME',


### PR DESCRIPTION
## Descripción

Se detecta que el campo Grupo del módulo Secciones de plantilla no funciona correctamente. 

Intuitivamente se presupone que sirve para agrupar secciones de plantilla y que se muestren agrupadas en la barra lateral de mozaik pero el comportamiento actual es que desaparecen de la barra lateral sin aparecer el grupo.

Por ahora se opta por sacar el campo de las vistas del módulo y valorar más adelante si merece la pena recuperar. Para ello se crea el siguiente issue: 


## Pruebas

1. Acceder a las vistas del módulo y comprobar que el campo Grupo no se muestra. 
