### PR TITLE
Enhancement - Traducciones - Nueva configuración Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -25,6 +25,9 @@ files:
 
   - source: 'modules/Charts/Dashlets/PipelineBySalesStageDashlet/PipelineBySalesStageDashlet.es_ES.lang.php'
     translation: '/modules/Charts/Dashlets/PipelineBySalesStageDashlet/PipelineBySalesStageDashlet.%locale_with_underscore%.lang.php'
+  
+  - source: 'modules/Home/Dashlets/ChartsDashlet/ChartsDashlet.es_ES.lang.php'
+    translation: '/modules/Home/Dashlets/ChartsDashlet/ChartsDashlet.%locale_with_underscore%.lang.php'
 
   - source: 'modules/Home/Dashlets/InvadersDashlet/InvadersDashlet.es_ES.lang.php'
     translation: '/modules/Home/Dashlets/InvadersDashlet/InvadersDashlet.%locale_with_underscore%.lang.php'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->


## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Se ha añadido una nueva configuración para recoger los ficheros que contengan traducciones con la palabra `...Dashlet.es_ES.lang.php` ya que, como estaba actualmente configurado el _crowdin.yml_, creaba nuevos ficheros, en vez de recoger los que ya existen con el idioma.
