### PR TITLE
Hotfix - Firmas - Corregir cadena hardcodeada

### DIFF
--- a/modules/stic_Signatures/language/ca_ES.lang.php
+++ b/modules/stic_Signatures/language/ca_ES.lang.php
@@ -127,6 +127,7 @@ $mod_strings = array(
     'LBL_PORTAL_ACCEPTANCE_AREA' => 'Àrea de firma',
     'LBL_PORTAL_ACCEPTANCE_INSTRUCTION' => 'Per acceptar el document, feu clic al botó de sota.',
     'LBL_PORTAL_ACCEPT_AND_SIGN_BTN' => 'Accepta i firma el document',
+    'LBL_PORTAL_DOCUMENT_ACCEPTED_BY' => 'Document acceptat per:',
     'LBL_PORTAL_DOCUMENT_SIGNED' => 'Document firmat',
     'LBL_PORTAL_DOWNLOAD_SIGNED_DOC' => 'Descarrega el document firmat',
     'LBL_PORTAL_SEND_COPY_EMAIL' => "Envia-me'n una còpia per correu",

--- a/modules/stic_Signatures/language/en_us.lang.php
+++ b/modules/stic_Signatures/language/en_us.lang.php
@@ -127,6 +127,7 @@ $mod_strings = array(
     'LBL_PORTAL_ACCEPTANCE_AREA' => 'Signature area',
     'LBL_PORTAL_ACCEPTANCE_INSTRUCTION' => 'To accept the document, click the button below.',
     'LBL_PORTAL_ACCEPT_AND_SIGN_BTN' => 'Accept and sign the document',
+    'LBL_PORTAL_DOCUMENT_ACCEPTED_BY' => 'Document accepted by:',
     'LBL_PORTAL_DOCUMENT_SIGNED' => 'Document signed',
     'LBL_PORTAL_DOWNLOAD_SIGNED_DOC' => 'Download signed document',
     'LBL_PORTAL_SEND_COPY_EMAIL' => 'Send me a copy by email',

--- a/modules/stic_Signatures/language/es_ES.lang.php
+++ b/modules/stic_Signatures/language/es_ES.lang.php
@@ -127,6 +127,7 @@ $mod_strings = array(
     'LBL_PORTAL_ACCEPTANCE_AREA' => 'Área de firma',
     'LBL_PORTAL_ACCEPTANCE_INSTRUCTION' => 'Para aceptar el documento, haga clic en el botón de abajo.',
     'LBL_PORTAL_ACCEPT_AND_SIGN_BTN' => 'Aceptar y firmar documento',
+    'LBL_PORTAL_DOCUMENT_ACCEPTED_BY' => 'Documento aceptado por:',
     'LBL_PORTAL_DOCUMENT_SIGNED' => 'Documento firmado',
     'LBL_PORTAL_DOWNLOAD_SIGNED_DOC' => 'Descargar documento firmado',
     'LBL_PORTAL_SEND_COPY_EMAIL' => 'Enviarme una copia por correo',

--- a/modules/stic_Signatures/language/eu_ES.lang.php
+++ b/modules/stic_Signatures/language/eu_ES.lang.php
@@ -127,6 +127,7 @@ $mod_strings = array(
     'LBL_PORTAL_ACCEPTANCE_AREA' => 'Área de firma',
     'LBL_PORTAL_ACCEPTANCE_INSTRUCTION' => 'Para aceptar el documento, haga clic en el botón de abajo.',
     'LBL_PORTAL_ACCEPT_AND_SIGN_BTN' => 'Aceptar y firmar documento',
+    'LBL_PORTAL_DOCUMENT_ACCEPTED_BY' => 'Documento aceptado por:',
     'LBL_PORTAL_DOCUMENT_SIGNED' => 'Documento firmado',
     'LBL_PORTAL_DOWNLOAD_SIGNED_DOC' => 'Descargar documento firmado',
     'LBL_PORTAL_SEND_COPY_EMAIL' => 'Enviarme una copia por correo',

--- a/modules/stic_Signatures/language/gl_ES.lang.php
+++ b/modules/stic_Signatures/language/gl_ES.lang.php
@@ -127,6 +127,7 @@ $mod_strings = array(
     'LBL_PORTAL_ACCEPTANCE_AREA' => 'Área de sinatura',
     'LBL_PORTAL_ACCEPTANCE_INSTRUCTION' => 'Para aceptar o documento, prema no botón de abaixo.',
     'LBL_PORTAL_ACCEPT_AND_SIGN_BTN' => 'Aceptar e asinar documento',
+    'LBL_PORTAL_DOCUMENT_ACCEPTED_BY' => 'Documento aceptado por:',
     'LBL_PORTAL_DOCUMENT_SIGNED' => 'Documento asinado',
     'LBL_PORTAL_DOWNLOAD_SIGNED_DOC' => 'Descargar documento asinado',
     'LBL_PORTAL_SEND_COPY_EMAIL' => 'Enviarme unha copia por correo',

--- a/modules/stic_Signatures/sticGenerateSignedPdf.php
+++ b/modules/stic_Signatures/sticGenerateSignedPdf.php
@@ -57,8 +57,10 @@ class sticGenerateSignedPdf
      */
     public static function generateSignaturePdf($signedMode = 'handwritten')
     {
-        global $sugar_config, $app_list_strings, $app_strings, $mod_strings;
-
+        global $sugar_config, $app_list_strings, $app_strings;
+        
+        $mod_strings = return_module_language($GLOBALS['current_language'], 'stic_Signatures');
+        
         // Required utility and function files
         require_once 'custom/modules/AOS_PDF_Templates/SticGeneratePdfFunctions.php';
         require_once 'modules/stic_Signatures/Utils.php';
@@ -167,7 +169,7 @@ class sticGenerateSignedPdf
             case 'button':
                 // Generate an acceptance image with signer details and timestamp
                 $textArray = [
-                    'Document accepted by:',
+                    $mod_strings['LBL_PORTAL_DOCUMENT_ACCEPTED_BY'],
                     $signerBean->parent_name,
                     $signerBean->email_address,
                     $userTime,


### PR DESCRIPTION
Se corrige la cadena _Document accepted by_ incluida en la firma de los PDF aceptados mediante botón, para que se muestre en el idioma correspondiente.

## Cómo probarlo
- Por inspección de código.
- Generando una firma mediante botón de aceptación y verificando que en el PDF resultante el texto de la firma está en el idioma correspondiente, y no necesariamente en Inglés