### PR TITLE
Hotfix - Flujos de trabajo - Excluir flujos de trabajo del trim global en SugarBean::cleanBean()

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2539,11 +2539,11 @@ class SugarBean
                 // STIC-Custom 20241218 EPS - Avoid using property "key" if it is not setted
                 // https://github.com/SinergiaTIC/SinergiaCRM/pull/470
                 // if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && !is_null($this->$key)) {
-                // STIC-Custom 20260121 PCS - 
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // STIC-Custom 20260122 PCS - 
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/957
                 // if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && property_exists($this, $key) && !empty($this->$key)) {
                 if (isset($def['type']) && in_array($def['type'], ['name', 'varchar']) && property_exists($this, $key) && !empty($this->$key) && empty($this->in_workflow)) {
-                // END STIC-Custom (PCS 20260121)
+                // END STIC-Custom (PCS 20260122)
                 // END STIC-Custom (EPS 20241218)
                     $this->$key = trim($this->$key);
                 }


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/954

## Description
Este PR ajusta la lógica del trim global introducida en #10339 y en https://github.com/SinergiaTIC/SinergiaCRM/pull/470, excluyendo las operaciones de guardado relacionadas con Workflows.
https://github.com/SinergiaTIC/SinergiaCRM/blob/91fcbb46d36edd0dceac68d817d1ceade99d5e34/data/SugarBean.php#L2539-L2543
El cambio original mejoraba la limpieza de datos al aplicar trim() a todos los campos name y varchar al guardar. Sin embargo, rompía las definiciones de Workflow donde los espacios son importantes (por ejemplo, en condiciones que pueden evaluar espacios en blanco).

Para evitar esta regresión, ahora el trim se omite cuando el bean se guarda en un contexto de Workflow, identificado mediante el flag` $this->in_workflow`.

## How To Test This

1. Crear un FdT con condición: Descripción contiene " ".
2. Crear un registro del módulo del FdT con Descripción: "Error trim".
3. Comprobar que el FdT se ejecuta.
4. Comprobar que se siguen cumpliendo las pruebas de: https://github.com/SinergiaTIC/SinergiaCRM/pull/470