### PR TITLE
Hotfix - Medicación - Evitar el uso del campo Hora en los filtros de la vista de lista

### DIFF
--- a/modules/stic_Medication_Log/vardefs.php
+++ b/modules/stic_Medication_Log/vardefs.php
@@ -160,6 +160,9 @@ $dictionary['stic_Medication_Log'] = array(
     'merge_filter' => 'disabled',
     'len' => '255',
     'size' => '20',
+    'studio' => array(
+      'searchview' => false,
+    ),
   ),
   'stock_depletion' => 
   array (


### PR DESCRIPTION
Relacionado con #968 

## Description
Mientras se trabaja en la mejora del comportamiento de los campos Time, se añade la propiedad     
'studio' => array(
      'searchview' => false,
),
al vardef del campo hora para evitar su uso en los filtros.


## Motivation and Context
Evitar "romper" la vista de lista al añadir el campo Hora.

## How To Test This
1.- Ir a estudio
2.- Seleccionar alguna de los filtros
3.- Comprobar que no se puede añadir el campo Hora (no aparece entre los disponibles)

