### PR TITLE
Enhancement - Correo - Añadir filtros en el Dashlet de Correos

### DIFF
--- a/modules/Emails/Dashlets/MyEmailsDashlet/MyEmailsDashlet.data.php
+++ b/modules/Emails/Dashlets/MyEmailsDashlet/MyEmailsDashlet.data.php
@@ -46,8 +46,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
 
 global $current_user, $app_strings;
 
-// STIC-Custom 20260130 ART - Email dashlet does not display records
-// https://github.com/SinergiaTIC/SinergiaCRM/pull/974
+// STIC-Custom 20260130 ART - Add filters to the Email Dashlet
+// https://github.com/SinergiaTIC/SinergiaCRM/pull/976
 // $dashletData['MyEmailsDashlet']['searchFields'] = array(
 //     'date_sent_received'  => array('default' => ''),
 //     'name'  => array('default' => ''),

--- a/modules/Emails/Dashlets/MyEmailsDashlet/MyEmailsDashlet.php
+++ b/modules/Emails/Dashlets/MyEmailsDashlet/MyEmailsDashlet.php
@@ -82,8 +82,8 @@ class MyEmailsDashlet extends DashletGeneric
         if ($this->myItemsOnly) {
             $this->filters['assigned_user_id'] = $current_user->id;
         }
-        // STIC-Custom 20260130 ART - Email dashlet does not display records
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/974
+        // STIC-Custom 20260130 ART - Add filters to the Email Dashlet
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/976
         // $this->filters['type'] = array("inbound");
         // $this->filters['status'] = array("unread");
         // END STIC-Custom


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please be aware that as of the 31st January 2022 we no longer support 7.10.x.
New PRs to hotfix-7.10.x will be invalid. If your fix is still applicable to 7.12.x, 
please create the pull request to the hotfix branch accordingly. -->
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/973

## Description
Se ha quitado los filtros de tipo/estado en el dashlet de correos, ya que estaban siendo "forzados". Quitando dichos filtros, aparecen los emails asignados al usuario (no solo inbound/unread).

Además, se han añadido los filtros de type y status para que el usuario decida lo que quiera ver en el dashlet.

## Motivation and Context
Mostrar los correos para el usuario asignado, independientemente de si se ha leído o si es de tipo "Entrante".

## How To Test This
1. Comprobar que existen varios correos asignados a varios usuarios.
2. Añadir el dashlet en el Inicio.
3. Seleccionar un usuario asignado que tenga registros.
4. Comprobar que ya aparecen los correos y, además, los filtros de "Type" y "Status" se visualizan en la configuración.