### PR TITLE
Hotfix - Sesiones y Asistencias - Tratamiento de caracteres especiales en el nombre

### DIFF
--- a/modules/stic_Sessions/Utils.php
+++ b/modules/stic_Sessions/Utils.php
@@ -76,9 +76,10 @@ class stic_SessionsUtils
             $sessionOriginalStartDate = $timeDate->to_display_date_time($sessionBean->fetched_row['start_date'], true, true, $current_user);
         }
         $sessionOriginalName = "{$eventName} | {$sessionOriginalStartDate}h";
+        $sessionOriginalName = html_entity_decode($sessionOriginalName, ENT_QUOTES, 'UTF-8');
 
         // If session name is empty or it has not been customized, (re)built it
-        if ($sessionOriginalName == $sessionBean->name || empty($sessionBean->name)) {
+        if ($sessionOriginalName == html_entity_decode($sessionBean->name, ENT_QUOTES, 'UTF-8') || empty($sessionBean->name)) {
             $sessionCurrentStartDate = $timeDate->to_display_date_time($sessionBean->start_date, true, true, $current_user);
             $sessionBean->name = "{$eventName} | {$sessionCurrentStartDate}h";
         }


### PR DESCRIPTION
- Closes #591

## Description
Se utiliza la función html_entity_decode para tratar el nombre de la sesión (tanto valor previo como nuevo). De esta forma se interpretan correctamente los caracteres espciales y las comillas

## Motivation and Context
Corregir la incidencia detectada al cambiar la fecha de las sesiones.

## How To Test This
1.- Crear evento con un nombre contenga caractares especiales y comillas simples y dobles y un par de sesiones. A una de las sesiones mantenerle el nombre por defecto y a la otra cambiarle el nombre
2.- Modificar la fecha de ambas sesiones
3.- Comprobar que el nombre de la sesión que mantenía el nombre por defecto se cambia mientras que la sesión que tenía un nombre especial se mantiene intacto
4.- Probar cualquier otra casuística que se os ocurra que pueda afectar la creación del nombre.