### PR TITLE
Hotfix - Roles - Color del texto fijado

### DIFF
--- a/themes/SuiteP/css/Stic/SticCustom.scss
+++ b/themes/SuiteP/css/Stic/SticCustom.scss
@@ -1492,7 +1492,8 @@ span.totals{
 }
 
 .acl-saving-message {
-  color: bw($stic-base);
+  color: black;
+  background-color: white;
   padding: 10px;
   text-align: center;
   font-size: 16px;


### PR DESCRIPTION
## Description
Se cambia el texto del popup de guardado al cambiar los permisos de los roles para que no utilice el color de la entidad ya que el fondo es siempre blanco