### PR TITLE
Hotfix - General - Actualización masiva descontrolada cuando comillas dobles en el filtro

### DIFF
--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -712,7 +712,13 @@ class ListViewDisplay
         global $app_strings;
         unset($_REQUEST[session_name()]);
         unset($_REQUEST['PHPSESSID']);
-        $current_query_by_page = htmlentities(json_encode($_REQUEST));
+        // STIC-Custom 20260223 EPS - Fixing quotes in query_by_page
+        // $current_query_by_page = htmlentities(json_encode($_REQUEST));
+        $decoded_request = array_map('html_entity_decode', $_REQUEST);
+        
+        $query = json_encode($decoded_request, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG); 
+        $current_query_by_page = htmlentities($query);
+        // END STIC-Custom
 
         $js = <<<EOF
             if(sugarListView.get_checks_count() < 1) {

--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -713,6 +713,7 @@ class ListViewDisplay
         unset($_REQUEST[session_name()]);
         unset($_REQUEST['PHPSESSID']);
         // STIC-Custom 20260223 EPS - Fixing quotes in query_by_page
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
         // $current_query_by_page = htmlentities(json_encode($_REQUEST));
         $decoded_request = array_map('html_entity_decode', $_REQUEST);
         

--- a/include/ListView/ListViewDisplay.php
+++ b/include/ListView/ListViewDisplay.php
@@ -715,8 +715,12 @@ class ListViewDisplay
         // STIC-Custom 20260223 EPS - Fixing quotes in query_by_page
         // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
         // $current_query_by_page = htmlentities(json_encode($_REQUEST));
-        $decoded_request = array_map('html_entity_decode', $_REQUEST);
-        
+        $decoded_request = $_REQUEST;
+        array_walk_recursive($decoded_request, function(&$value) {
+            if (is_string($value)) {
+                $value = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            }
+        });
         $query = json_encode($decoded_request, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG); 
         $current_query_by_page = htmlentities($query);
         // END STIC-Custom

--- a/include/MVC/Controller/SugarController.php
+++ b/include/MVC/Controller/SugarController.php
@@ -795,7 +795,11 @@ class SugarController
                 }
             }
             $_REQUEST = array();
-            $_REQUEST = json_decode(html_entity_decode($temp_req['current_query_by_page']), true);
+            // STIC-Custom 20260223 EPS - json_decode can cause issues with certain characters, so we need to clean up the query before decoding it.
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
+            // $_REQUEST = json_decode(html_entity_decode($temp_req['current_query_by_page']), true);
+            $_REQUEST = json_decode(html_entity_decode($temp_req['current_query_by_page']), true, 512, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG);
+            // END STIC-Custom
             unset($_REQUEST[$seed->module_dir . '2_' . strtoupper($seed->object_name) . '_offset']);//after massupdate, the page should redirect to no offset page
             $storeQuery->saveFromRequest($_REQUEST['module']);
             $_REQUEST = array(

--- a/include/MVC/Controller/SugarController.php
+++ b/include/MVC/Controller/SugarController.php
@@ -795,11 +795,7 @@ class SugarController
                 }
             }
             $_REQUEST = array();
-            // STIC-Custom 20260223 EPS - json_decode can cause issues with certain characters, so we need to clean up the query before decoding it.
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
-            // $_REQUEST = json_decode(html_entity_decode($temp_req['current_query_by_page']), true);
-            $_REQUEST = json_decode(html_entity_decode($temp_req['current_query_by_page']), true, 512, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG);
-            // END STIC-Custom
+            $_REQUEST = json_decode(html_entity_decode($temp_req['current_query_by_page']), true);
             unset($_REQUEST[$seed->module_dir . '2_' . strtoupper($seed->object_name) . '_offset']);//after massupdate, the page should redirect to no offset page
             $storeQuery->saveFromRequest($_REQUEST['module']);
             $_REQUEST = array(

--- a/include/MVC/View/views/view.list.php
+++ b/include/MVC/View/views/view.list.php
@@ -144,7 +144,12 @@ class ViewList extends SugarView
                 if (isset($_REQUEST['lvso'])) {
                     $blockVariables[] = 'lvso';
                 }
-                $current_query_by_page = json_decode(html_entity_decode($_REQUEST['current_query_by_page']), true);
+                
+                // STIC-Custom 20260223 EPS - json_decode can cause issues with certain characters, so we need to clean up the query before decoding it.
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
+                // $current_query_by_page = json_decode(html_entity_decode($_REQUEST['current_query_by_page']), true);
+                $current_query_by_page = json_decode(html_entity_decode($_REQUEST['current_query_by_page']), true, 512, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG);
+                // END STIC-Custom                
                 foreach ($current_query_by_page as $search_key => $search_value) {
                     if ($search_key != $module . '2_' . strtoupper($this->bean->object_name) . '_offset' && !in_array($search_key, $blockVariables)) {
                         if (!is_array($search_value)) {

--- a/include/MVC/View/views/view.list.php
+++ b/include/MVC/View/views/view.list.php
@@ -145,11 +145,7 @@ class ViewList extends SugarView
                     $blockVariables[] = 'lvso';
                 }
                 
-                // STIC-Custom 20260223 EPS - json_decode can cause issues with certain characters, so we need to clean up the query before decoding it.
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
-                // $current_query_by_page = json_decode(html_entity_decode($_REQUEST['current_query_by_page']), true);
-                $current_query_by_page = json_decode(html_entity_decode($_REQUEST['current_query_by_page']), true, 512, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG);
-                // END STIC-Custom                
+                $current_query_by_page = json_decode(html_entity_decode($_REQUEST['current_query_by_page']), true);
                 foreach ($current_query_by_page as $search_key => $search_value) {
                     if ($search_key != $module . '2_' . strtoupper($this->bean->object_name) . '_offset' && !in_array($search_key, $blockVariables)) {
                         if (!is_array($search_value)) {

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -1647,16 +1647,8 @@ EOQ;
         // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
         // $query = json_decode(html_entity_decode($query), true);
 
-        // 1. Decode any HTML entities in the query. This is to ensure that any special characters that were encoded as HTML entities are properly decoded before we attempt to parse the query. For example, if the query contains &quot; it will be converted back to a double quote character, which is important for the next step where we look for unescaped quotes.
-        $query_clean = html_entity_decode($query);
+        $query = $this->repair_suitecrm_json($query);
 
-        // 2. Search for any unescaped double quotes that are not part of the JSON structure and escape them. This is to prevent json_decode from breaking due to unescaped quotes in the query values.
-        // The regex looks for double quotes that are not preceded by a colon, an opening brace, an opening bracket, or a comma (which would indicate they are part of the JSON structure) and not followed by a colon, a closing brace, a closing bracket, or a comma (which would also indicate they are part of the JSON structure). These quotes are likely to be part of the query values and need to be escaped.
-        $query_fixed = preg_replace_callback('/(?<![:{[,])"(?![呈现:,}\]])/', function($m) {
-            return '\"';
-        }, $query_clean);
-
-        $query = json_decode($query_fixed, true);
         // END STIC
         $searchForm->populateFromArray($query, null, true);
         $this->searchFields = $searchForm->searchFields;
@@ -1668,6 +1660,69 @@ EOQ;
             $this->where_clauses = '';
         }
     }
+
+
+// STIC-Custom 20260219 EPS - Added function to clean up the query before decoding it, to prevent issues with certain characters in the query.
+
+function repair_suitecrm_json($json_raw) {
+    // 1. Decodifiquem només les entitats HTML (&quot; -> ")
+    // Important: mantenim la codificació original de la resta
+    $input = html_entity_decode($json_raw, ENT_QUOTES, 'UTF-8');
+    
+    $len = strlen($input);
+    $output = "";
+    $in_value = false;
+
+    for ($i = 0; $i < $len; $i++) {
+        $char = $input[$i];
+        
+        // Mirem si el caràcter següent existeix per detectar patrons
+        $next = ($i + 1 < $len) ? $input[$i+1] : "";
+        $prev = ($i > 0) ? $input[$i-1] : "";
+
+        // DETECTAR INICI DE VALOR: :"
+        if (!$in_value && $char == ':' && $next == '"') {
+            $output .= ':"';
+            $in_value = true;
+            $i++; // Saltem la cometa d'obertura
+            continue;
+        }
+
+        // DETECTAR FINAL DE VALOR O COMETA INTERNA
+        if ($in_value && $char == '"') {
+            // Una cometa NOMÉS tanca el valor si va seguida de coma o tancament de JSON
+            // i si NO està ja escapada per la pròpia SuiteCRM (poc probable però possible)
+            $is_closing = ($next == ',' || $next == '}' || $next == ']');
+            
+            if ($is_closing) {
+                $in_value = false;
+                $output .= '"';
+            } else {
+                // És una cometa de text (com a "X"): l'escapem manualment
+                $output .= '\"';
+            }
+            continue;
+        }
+
+        $output .= $char;
+    }
+
+    // Intentem decodificar. Si falla, podria ser per caràcters de control
+    $decoded = json_decode($output, true);
+    
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        // Si falla, provem una neteja de caràcters de control no imprimibles
+        $output = preg_replace('/[\x00-\x1F\x7F]/u', '', $output);
+        $decoded = json_decode($output, true);
+    }
+
+    return $decoded;
+}
+
+// END STIC
+
+
+
 
     protected function getSearchDefs($module, $metafiles = array())
     {

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -1643,7 +1643,20 @@ EOQ;
         }
         /* bug 31271: using false to not add all bean fields since some beans - like SavedReports
            can have fields named 'module' etc. which may break the query */
-        $query = json_decode(html_entity_decode($query), true);
+        // STIC-Custom 20260219 EPS - json_decode can cause issues with certain characters, so we need to clean up the query before decoding it.
+        // $query = json_decode(html_entity_decode($query), true);
+
+        // 1. Decode any HTML entities in the query. This is to ensure that any special characters that were encoded as HTML entities are properly decoded before we attempt to parse the query. For example, if the query contains &quot; it will be converted back to a double quote character, which is important for the next step where we look for unescaped quotes.
+        $query_clean = html_entity_decode($query);
+
+        // 2. Search for any unescaped double quotes that are not part of the JSON structure and escape them. This is to prevent json_decode from breaking due to unescaped quotes in the query values.
+        // The regex looks for double quotes that are not preceded by a colon, an opening brace, an opening bracket, or a comma (which would indicate they are part of the JSON structure) and not followed by a colon, a closing brace, a closing bracket, or a comma (which would also indicate they are part of the JSON structure). These quotes are likely to be part of the query values and need to be escaped.
+        $query_fixed = preg_replace_callback('/(?<![:{[,])"(?![呈现:,}\]])/', function($m) {
+            return '\"';
+        }, $query_clean);
+
+        $query = json_decode($query_fixed, true);
+        // END STIC
         $searchForm->populateFromArray($query, null, true);
         $this->searchFields = $searchForm->searchFields;
         $where_clauses = $searchForm->generateSearchWhere(true, $module);

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -1644,6 +1644,7 @@ EOQ;
         /* bug 31271: using false to not add all bean fields since some beans - like SavedReports
            can have fields named 'module' etc. which may break the query */
         // STIC-Custom 20260219 EPS - json_decode can cause issues with certain characters, so we need to clean up the query before decoding it.
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
         // $query = json_decode(html_entity_decode($query), true);
 
         // 1. Decode any HTML entities in the query. This is to ensure that any special characters that were encoded as HTML entities are properly decoded before we attempt to parse the query. For example, if the query contains &quot; it will be converted back to a double quote character, which is important for the next step where we look for unescaped quotes.

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -112,7 +112,13 @@ class MassUpdate
         unset($_REQUEST['current_query_by_page']);
         unset($_REQUEST[session_name()]);
         unset($_REQUEST['PHPSESSID']);
-        $query = json_encode($_REQUEST);
+
+        // STIC-Custom 20260223 EPS - Fixing quotes in query_by_page
+        // $query = json_encode($_REQUEST);
+        $decoded_request = array_map('html_entity_decode', $_REQUEST);
+        
+        $query = json_encode($decoded_request, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG); 
+        // END STIC
 
         if (!isset($_REQUEST['module'])) {
             LoggerManager::getLogger()->warn('Undefined index: module');
@@ -1643,12 +1649,11 @@ EOQ;
         }
         /* bug 31271: using false to not add all bean fields since some beans - like SavedReports
            can have fields named 'module' etc. which may break the query */
-        // STIC-Custom 20260219 EPS - json_decode can cause issues with certain characters, so we need to clean up the query before decoding it.
+        // STIC-Custom 20260223 EPS - json_decode can cause issues with certain characters, so we need to clean up the query before decoding it.
         // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
         // $query = json_decode(html_entity_decode($query), true);
-
-        $query = $this->repair_suitecrm_json($query);
-
+        $query = json_decode(html_entity_decode($query), true, 512, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG);
+        // $query = $this->repair_suitecrm_json($query);
         // END STIC
         $searchForm->populateFromArray($query, null, true);
         $this->searchFields = $searchForm->searchFields;

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -116,8 +116,12 @@ class MassUpdate
         // STIC-Custom 20260223 EPS - Fixing quotes in query_by_page
         // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
         // $query = json_encode($_REQUEST);
-        $decoded_request = array_map('html_entity_decode', $_REQUEST);
-        
+        $decoded_request = $_REQUEST;
+        array_walk_recursive($decoded_request, function(&$value) {
+            if (is_string($value)) {
+                $value = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            }
+        });
         $query = json_encode($decoded_request, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG); 
         // END STIC
 

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -1654,7 +1654,6 @@ EOQ;
         // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
         // $query = json_decode(html_entity_decode($query), true);
         $query = json_decode(html_entity_decode($query), true, 512, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG);
-        // $query = $this->repair_suitecrm_json($query);
         // END STIC
         $searchForm->populateFromArray($query, null, true);
         $this->searchFields = $searchForm->searchFields;
@@ -1666,69 +1665,6 @@ EOQ;
             $this->where_clauses = '';
         }
     }
-
-
-// STIC-Custom 20260219 EPS - Added function to clean up the query before decoding it, to prevent issues with certain characters in the query.
-
-function repair_suitecrm_json($json_raw) {
-    // 1. Decodifiquem només les entitats HTML (&quot; -> ")
-    // Important: mantenim la codificació original de la resta
-    $input = html_entity_decode($json_raw, ENT_QUOTES, 'UTF-8');
-    
-    $len = strlen($input);
-    $output = "";
-    $in_value = false;
-
-    for ($i = 0; $i < $len; $i++) {
-        $char = $input[$i];
-        
-        // Mirem si el caràcter següent existeix per detectar patrons
-        $next = ($i + 1 < $len) ? $input[$i+1] : "";
-        $prev = ($i > 0) ? $input[$i-1] : "";
-
-        // DETECTAR INICI DE VALOR: :"
-        if (!$in_value && $char == ':' && $next == '"') {
-            $output .= ':"';
-            $in_value = true;
-            $i++; // Saltem la cometa d'obertura
-            continue;
-        }
-
-        // DETECTAR FINAL DE VALOR O COMETA INTERNA
-        if ($in_value && $char == '"') {
-            // Una cometa NOMÉS tanca el valor si va seguida de coma o tancament de JSON
-            // i si NO està ja escapada per la pròpia SuiteCRM (poc probable però possible)
-            $is_closing = ($next == ',' || $next == '}' || $next == ']');
-            
-            if ($is_closing) {
-                $in_value = false;
-                $output .= '"';
-            } else {
-                // És una cometa de text (com a "X"): l'escapem manualment
-                $output .= '\"';
-            }
-            continue;
-        }
-
-        $output .= $char;
-    }
-
-    // Intentem decodificar. Si falla, podria ser per caràcters de control
-    $decoded = json_decode($output, true);
-    
-    if (json_last_error() !== JSON_ERROR_NONE) {
-        // Si falla, provem una neteja de caràcters de control no imprimibles
-        $output = preg_replace('/[\x00-\x1F\x7F]/u', '', $output);
-        $decoded = json_decode($output, true);
-    }
-
-    return $decoded;
-}
-
-// END STIC
-
-
-
 
     protected function getSearchDefs($module, $metafiles = array())
     {

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -1650,11 +1650,7 @@ EOQ;
         }
         /* bug 31271: using false to not add all bean fields since some beans - like SavedReports
            can have fields named 'module' etc. which may break the query */
-        // STIC-Custom 20260223 EPS - json_decode can cause issues with certain characters, so we need to clean up the query before decoding it.
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
-        // $query = json_decode(html_entity_decode($query), true);
-        $query = json_decode(html_entity_decode($query), true, 512, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG);
-        // END STIC
+        $query = json_decode(html_entity_decode($query), true);
         $searchForm->populateFromArray($query, null, true);
         $this->searchFields = $searchForm->searchFields;
         $where_clauses = $searchForm->generateSearchWhere(true, $module);

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -114,6 +114,7 @@ class MassUpdate
         unset($_REQUEST['PHPSESSID']);
 
         // STIC-Custom 20260223 EPS - Fixing quotes in query_by_page
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
         // $query = json_encode($_REQUEST);
         $decoded_request = array_map('html_entity_decode', $_REQUEST);
         

--- a/include/Popups/PopupSmarty.php
+++ b/include/Popups/PopupSmarty.php
@@ -268,7 +268,12 @@ class PopupSmarty extends ListViewSmarty
         // STIC-Custom 20260223 EPS - Fixing quotes in query_by_page
         // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
         // $this->th->ss->assign('current_query', htmlentities(json_encode(($_REQUEST))));
-        $decoded_request = array_map('html_entity_decode', $_REQUEST);
+        $decoded_request = $_REQUEST;
+        array_walk_recursive($decoded_request, function(&$value) {
+            if (is_string($value)) {
+                $value = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            }
+        });
         $this->th->ss->assign('current_query', htmlentities(json_encode($decoded_request, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG)));
         // END STIC-Custom
         $this->th->ss->assign('customFields', $this->customFieldDefs);

--- a/include/Popups/PopupSmarty.php
+++ b/include/Popups/PopupSmarty.php
@@ -265,7 +265,12 @@ class PopupSmarty extends ListViewSmarty
             $this->_popupMeta['create']['createButton'] = translate($this->_popupMeta['create']['createButton']);
         }
         $this->th->ss->assign('popupMeta', $this->_popupMeta);
-        $this->th->ss->assign('current_query', htmlentities(json_encode(($_REQUEST))));
+        // STIC-Custom 20260223 EPS - Fixing quotes in query_by_page
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
+        // $this->th->ss->assign('current_query', htmlentities(json_encode(($_REQUEST))));
+        $decoded_request = array_map('html_entity_decode', $_REQUEST);
+        $this->th->ss->assign('current_query', htmlentities(json_encode($decoded_request, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG)));
+        // END STIC-Custom
         $this->th->ss->assign('customFields', $this->customFieldDefs);
         $this->th->ss->assign('numCols', NUM_COLS);
         $this->th->ss->assign('massUpdateData', $this->massUpdateData);

--- a/modules/Accounts/AccountsListViewSmarty.php
+++ b/modules/Accounts/AccountsListViewSmarty.php
@@ -20,7 +20,12 @@ class AccountsListViewSmarty extends ListViewSmarty
         // STIC-Custom 20260223 EPS - Fixing quotes in query_by_page
         // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
         // $current_query_by_page = htmlentities(json_encode($_REQUEST));
-        $decoded_request = array_map('html_entity_decode', $_REQUEST);
+        $decoded_request = $_REQUEST;
+        array_walk_recursive($decoded_request, function(&$value) {
+            if (is_string($value)) {
+                $value = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            }
+        });
         $query = json_encode($decoded_request, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG);
         $current_query_by_page = htmlentities($query);
         // END STIC-Custom

--- a/modules/Accounts/AccountsListViewSmarty.php
+++ b/modules/Accounts/AccountsListViewSmarty.php
@@ -17,7 +17,13 @@ class AccountsListViewSmarty extends ListViewSmarty
         global $app_strings;
         unset($_REQUEST[session_name()]);
         unset($_REQUEST['PHPSESSID']);
-        $current_query_by_page = htmlentities(json_encode($_REQUEST));
+        // STIC-Custom 20260223 EPS - Fixing quotes in query_by_page
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
+        // $current_query_by_page = htmlentities(json_encode($_REQUEST));
+        $decoded_request = array_map('html_entity_decode', $_REQUEST);
+        $query = json_encode($decoded_request, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG);
+        $current_query_by_page = htmlentities($query);
+        // END STIC-Custom
 
         $js = <<<EOF
              if(sugarListView.get_checks_count() < 1) {

--- a/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
+++ b/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
@@ -668,7 +668,7 @@ EOJS;
             $value = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
          }
       });
-      $current_query_by_page = base64_encode(json_encode($decoded_request));
+      $current_query_by_page = base64_encode(json_encode($decoded_request, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG));
       // END STIC-Custom
       
       $html .= "<input type='hidden' name='current_query_by_page' id='MGD_current_query_by_page' value='{$current_query_by_page}' />\n";

--- a/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
+++ b/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
@@ -658,7 +658,12 @@ EOJS;
       if ($accion == 'DetailView') 
          $html .= "<input type='hidden' name='uid' id='MGD_uid' value='{$this->sugarbean->id}'>\n";  // si estamos en el DetailView, no se rellena por javascript, ya sabemos su valor
       
-      $current_query_by_page = base64_encode(json_encode($_REQUEST));
+      // STIC-Custom 20260223 EPS - Fixing quotes in query_by_page
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
+      // $current_query_by_page = base64_encode(json_encode($_REQUEST));
+      $decoded_request = array_map('html_entity_decode', $_REQUEST);
+      $current_query_by_page = base64_encode(json_encode($decoded_request));
+      // END STIC-Custom
       
       $html .= "<input type='hidden' name='current_query_by_page' id='MGD_current_query_by_page' value='{$current_query_by_page}' />\n";
       

--- a/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
+++ b/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
@@ -661,7 +661,13 @@ EOJS;
       // STIC-Custom 20260223 EPS - Fixing quotes in query_by_page
       // https://github.com/SinergiaTIC/SinergiaCRM/pull/999
       // $current_query_by_page = base64_encode(json_encode($_REQUEST));
-      $decoded_request = array_map('html_entity_decode', $_REQUEST);
+      // $decoded_request = array_map('html_entity_decode', $_REQUEST);
+      $decoded_request = $_REQUEST;
+      array_walk_recursive($decoded_request, function(&$value) {
+         if (is_string($value)) {
+            $value = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+         }
+      });
       $current_query_by_page = base64_encode(json_encode($decoded_request));
       // END STIC-Custom
       


### PR DESCRIPTION
- Closes #998

## Description
Se introduce una expresión regular para volver a escapar aquellas comillas dobles que no forman parte de la estructura del JSON.

## Motivation and Context
Solucionar elproblema de actualización descontrolada cuando hay comillas dobles en algún campo del filtro.

## How To Test This
1.- Reproducir los pasos descritos en el issue y comprobar que ahora sólo se actualizan los registros que debe
2.- Probar introduciendo alguna comilla doble directamente en algún campo de búsqueda (por ejemplo en el nombre de la inscripción)
3.- Probar a introducir comillas dobles, simples y otros caracteres especiales en distintas partes de las cadenas de filtro (inicido, centro, fin, combinadas %", ...)

