### PR TITLE
Hotfix - KReports - Correcciones rol NADA

### DIFF
--- a/modules/KReports/KReportQuery.php
+++ b/modules/KReports/KReportQuery.php
@@ -1086,24 +1086,14 @@ class KReportQuery {
                               }
                               // STIC-Custom 20260303 EPS - if user is admin, role must not be checked, but must be applied for every node in the path
                               // https://github.com/SinergiaTIC/SinergiaCRM/pull/1002
-                              $actionPermission = $_SESSION['ACL'][$current_user->id][$this->joinSegments[$thisPath]['object']->module_dir]['module'][$access_check]['aclaccess'] ?? null; 
-                              if (!is_admin($current_user) && $actionPermission == ACL_ALLOW_NONE) {
-                                 if (empty($this->whereString)) {
                               if (!is_admin($current_user)) {
                                  $actionPermission = $_SESSION['ACL'][$current_user->id][$this->joinSegments[$thisPath]['object']->module_dir]['module'][$access_check]['aclaccess'] ?? null; 
-                                 if ($actionPermission == null) {
-                                    // If null then the ACL cache is not yet loaded, so we load it and check again
-                                    ACLAction::getUserActions($current_user->id, true); //, $root_bean->module_dir, 'module', $access_check);
-                                    $actionPermission = $_SESSION['ACL'][$current_user->id][$root_bean->module_dir]['module'][$access_check]['aclaccess'] ?? null; 
-                                 }
                                  if ($actionPermission == ACL_ALLOW_NONE) {
                                     if (empty($this->whereString)) {
                                        $this->whereString = " ( 0 = 1 ) ";
                                     } else {
                                        $this->whereString .= " AND ( 0 = 1 ) ";
                                     }
-                                 } else {
-                                    $this->whereString .= " AND ( 0 = 1 ) ";
                                  }
                               }
                               // END STIC Custom 20260303 EPS


### PR DESCRIPTION
- Closes #1001

## Description
Se añade coprobación de que el usuario no sea admin antes de aplicar la condición creada cuando el permiso es NADA según el rol.

Se revisa la parte de los joinSegments para verificar las condiciones cuando hay distintos módulos implicados, donde se añade la misma condición añadida para 

## Motivation and Context
Corregir la incidencia surgida en la actualización a raíz de #889 .
Añadir la corrección para cuando el informe está compuesto por más de un módulo y hay distintos niveles de seguridad.

## How To Test This
### Los administradores ignoran el rol
1.- Crear un rol que no permita la exportación del módulo Personas
2.- Crear un informe basado en Personas que se pueda exportar
3.- Crear un usuario admnistrador y asignarle el rol creado
4.- Ejecutar la exportación desde el informe y usuarios creados
5.- Comprobar que, aunque el rol indica que no se puede exportar, el usuario puede
### Informes multi-módulo
1.- Crear un rol per SÍ permita la exportación de personas y NO la de relaciones con Personas
2.- Crear informe que incluya datos de ambos
3.- Asignar el rol a un usuario no administrador
4.- Con ese usuario, realizar exportación del informe y comprobar que no muestra nada
5.- Modificar el informe (necesario usuario admin) para que sólo aplique GS al nodo superior
6.- Repetir exportación y comprobar que hay datos
7.- Volver a aplicar la seguridad a todos los nodos
8.- Cambiar el rol para que permita exportación de relación con Personas
9.- Tras realizar nuevo login con el usuario (para actualizar datos del rol), repetir exportación y comprobar que ahora sí hay datos

