### PR TITLE
Hotfix - KReports - Se añaden campos a la búsqueda avanzada que estaban en la básica

### DIFF
--- a/modules/KReports/metadata/searchdefs.php
+++ b/modules/KReports/metadata/searchdefs.php
@@ -112,6 +112,20 @@ $searchdefs['KReports'] = array(
                 'label' => 'LBL_MODULE',
                 'width' => '10%',
             ),
+            'report_status' => array(
+                'type' => 'enum',
+                'name' => 'report_status', 
+                'default' => true,
+                'label' => 'LBL_REPORT_STATUS',
+                'width' => '10%',
+            ),
+            'report_segmentation' => array(
+                'type' => 'enum',
+                'name' => 'report_segmentation', 
+                'default' => true,
+                'label' => 'LBL_REPORT_SEGMENTATION',
+                'width' => '10%',
+            ),
             'date_entered' => array(
                 'type' => 'datetime',
                 'label' => 'LBL_DATE_ENTERED',


### PR DESCRIPTION
## Description
A raíz de una consulta en el foro (ya resuelta por otra vía) se observa que hay un par de campos que están presentes en la búsqueda básica pero no en la avanzada.
Semodifica el campo searchdefs para incluirlos.

## Motivation and Context
Todos los campos de la búsqueda básica deberían estar presentes también en la avanzada

## How To Test This
1.- Ir al listado de informes
2.- Comprobar que los campos status y segmentation aparecen en ambos buscadores

