### PR TITLE
Enhancement - SinergiaDA - Habilitar acceso de solo lectura para usuarios en SinergiaDA

### DIFF
--- a/custom/Extension/application/Ext/Language/ca_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/ca_ES.SticLang.php
@@ -3815,10 +3815,11 @@ $app_list_strings['stic_signature_log_actions']['SIGNATURE_EXPIRED'] = 'La firma
 $app_list_strings['stic_signature_log_actions']['SIGNATURE_NOT_NEEDED'] = 'Una altra persona autoritzada ha firmat el document';
 $app_list_strings['stic_signature_log_actions']['CRM_PDF_DOWNLOADED'] = 'El document ha estat descarregat internament';
 $app_list_strings['stic_signature_log_actions']['SIGNATURE_COMPLETED'] = 'Tots els firmants han firmat';
+
 // SinergiaDA: Nivells d'accés dels usuaris
 $app_list_strings['sda_users_access_list']['0'] = 'Sense accés';
 $app_list_strings['sda_users_access_list']['1'] = 'Accés complet';
-// $app_list_strings['sda_users_access_list']['2'] = 'Accés de només lectura'; 
+$app_list_strings['sda_users_access_list']['2'] = 'Accés de només lectura'; 
 
 // Productes financers: Tipus de productes
 $app_list_strings['stic_financial_products_types_list']['current_account'] = 'Compte corrent';

--- a/custom/Extension/application/Ext/Language/en_us.SticLang.php
+++ b/custom/Extension/application/Ext/Language/en_us.SticLang.php
@@ -3814,10 +3814,11 @@ $app_list_strings['stic_signature_log_actions']['SIGNATURE_EXPIRED'] = 'Signatur
 $app_list_strings['stic_signature_log_actions']['SIGNATURE_NOT_NEEDED'] = 'Document signed by another authorized person';
 $app_list_strings['stic_signature_log_actions']['CRM_PDF_DOWNLOADED'] = 'The document has been downloaded internally';
 $app_list_strings['stic_signature_log_actions']['SIGNATURE_COMPLETED'] = 'All signers have signed';
+
 // SinergiaDA: Users access levels
 $app_list_strings['sda_users_access_list']['0'] = 'No access';
 $app_list_strings['sda_users_access_list']['1'] = 'Full access';
-// $app_list_strings['sda_users_access_list']['2'] = 'Read-only access';
+$app_list_strings['sda_users_access_list']['2'] = 'Read-only access';
 
 // Financial Products: Product types
 $app_list_strings['stic_financial_products_types_list']['current_account'] = 'Current account';

--- a/custom/Extension/application/Ext/Language/es_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/es_ES.SticLang.php
@@ -3815,10 +3815,11 @@ $app_list_strings['stic_signature_log_actions']['SIGNATURE_EXPIRED'] = 'La firma
 $app_list_strings['stic_signature_log_actions']['SIGNATURE_NOT_NEEDED'] = 'Otra persona autorizada ha firmado el documento';
 $app_list_strings['stic_signature_log_actions']['CRM_PDF_DOWNLOADED'] = 'El documento ha sido descargado internamente';
 $app_list_strings['stic_signature_log_actions']['SIGNATURE_COMPLETED'] = 'Todos los firmantes han firmado';
+
 // SinergiaDA: Niveles de acceso de los usuarios
 $app_list_strings['sda_users_access_list']['0'] = 'Sin acceso';
 $app_list_strings['sda_users_access_list']['1'] = 'Acceso completo';
-// $app_list_strings['sda_users_access_list']['2'] = 'Acceso de solo lectura'; // Disabled for the moment
+$app_list_strings['sda_users_access_list']['2'] = 'Acceso de solo lectura'; // Disabled for the moment
 
 // Productos financieros: Tipos de productos
 $app_list_strings['stic_financial_products_types_list']['current_account'] = 'Cuenta corriente';

--- a/custom/Extension/application/Ext/Language/eu_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/eu_ES.SticLang.php
@@ -3815,11 +3815,11 @@ $app_list_strings['stic_signature_log_actions']['SIGNATURE_EXPIRED'] = 'La firma
 $app_list_strings['stic_signature_log_actions']['SIGNATURE_NOT_NEEDED'] = 'Otra persona autorizada ha firmado el documento';
 $app_list_strings['stic_signature_log_actions']['CRM_PDF_DOWNLOADED'] = 'El documento ha sido descargado internamente';
 $app_list_strings['stic_signature_log_actions']['SIGNATURE_COMPLETED'] = 'Todos los firmantes han firmado';
+
 // SinergiaDA: Niveles de acceso de los usuarios
 $app_list_strings['sda_users_access_list']['0'] = 'Sin acceso';
 $app_list_strings['sda_users_access_list']['1'] = 'Acceso completo';
-// $app_list_strings['sda_users_access_list']['2'] = 'Acceso de solo lectura'; // Disabled for the moment
-
+$app_list_strings['sda_users_access_list']['2'] = 'Acceso de solo lectura'; 
 // Productos financieros: Tipos de productos
 $app_list_strings['stic_financial_products_types_list']['current_account'] = 'Cuenta corriente';
 $app_list_strings['stic_financial_products_types_list']['savings_account'] = 'Cuenta de ahorro';

--- a/custom/Extension/application/Ext/Language/gl_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/gl_ES.SticLang.php
@@ -3815,10 +3815,11 @@ $app_list_strings['stic_signature_log_actions']['SIGNATURE_EXPIRED'] = 'Sinatura
 $app_list_strings['stic_signature_log_actions']['SIGNATURE_NOT_NEEDED'] = 'Documento firmado por outra persoa autorizada';
 $app_list_strings['stic_signature_log_actions']['CRM_PDF_DOWNLOADED'] = 'O documento foi descargado internamente';
 $app_list_strings['stic_signature_log_actions']['SIGNATURE_COMPLETED'] = 'Todos os asinantes completaron a sinatura do documento';
+
 // SinergiaDA: Niveles de acceso de los usuarios
 $app_list_strings['sda_users_access_list']['0'] = 'Sen acceso';
 $app_list_strings['sda_users_access_list']['1'] = 'Acceso completo';
-// $app_list_strings['sda_users_access_list']['2'] = 'Acceso de solo lectura'; // Disabled for the moment
+$app_list_strings['sda_users_access_list']['2'] = 'Acceso de solo lectura'; 
 
 // Productos financieros: Tipos de productos
 $app_list_strings['stic_financial_products_types_list']['current_account'] = 'Cuenta corriente';


### PR DESCRIPTION
## Descripción
Se habilitan en la lista desplegable de tipos de acceso a SinergiaDA los usuarios de solo lectura, que quedaron desahbilitados en el PR https://github.com/SinergiaTIC/SinergiaCRM/pull/937 a la espera de que se aplicar la actualización necesaria en SinergiaDA para que el cambio funcionase correctamente .

### Cómo probarlo
Tras reparar verificar que el desplegable Acceso a SinergiaDA en Usuarios presenta la opción _Usuario de solo lectura_ además de _Sin acceso_ y _Acceso completo_