### PR TITLE
Hotfix - Calendario - Excepción en modal de creación de reunión/llamada

### DIFF
--- a/custom/modules/Calendar/Cal.js
+++ b/custom/modules/Calendar/Cal.js
@@ -201,7 +201,16 @@ CAL.repeat_tab_handle = function (module_name) {
 CAL.GR_update_user = function (user_id) {
     var callback = {
         success: function (o) {
-            SUGAR.util.globalEval("res = (" + o.responseText + ")");
+            // STIC-Custom - JBL - 20260306 - Solve js console errors
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1008
+            // SUGAR.util.globalEval("res = (" + o.responseText + ")");
+
+            // Ensure that the record structure exists before evaluating
+            if (typeof GLOBAL_REGISTRY === 'undefined') GLOBAL_REGISTRY = {};
+            if (typeof GLOBAL_REGISTRY['focus'] === 'undefined') GLOBAL_REGISTRY['focus'] = {};
+
+            SUGAR.util.globalEval("res = " + o.responseText);
+            // END STIC-Custom
             GLOBAL_REGISTRY.focus.users_arr_hash = undefined;
         },
     };
@@ -211,7 +220,16 @@ CAL.GR_update_user = function (user_id) {
 };
 CAL.GR_update_focus = function (module, record) {
     if (record == "") {
-        GLOBAL_REGISTRY["focus"] = { module: module, users_arr: [], fields: { id: "-1" } };
+        // STIC-Custom - JBL - 20260306 - Solve js console errors
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1008
+        // GLOBAL_REGISTRY["focus"] = { module: module, users_arr: [], fields: { id: "-1" } };
+
+        // Save the downloaded users if they exist, otherwise we initialize empty
+        var existing_users = (typeof GLOBAL_REGISTRY !== 'undefined' && GLOBAL_REGISTRY["focus"] && GLOBAL_REGISTRY["focus"].users_arr) 
+                             ? GLOBAL_REGISTRY["focus"].users_arr 
+                             : [];
+        GLOBAL_REGISTRY["focus"] = { module: module, users_arr: existing_users, fields: { id: "-1" } };
+        // END STIC-Custom
         SugarWidgetScheduler.update_time();
     } else {
         var callback = {

--- a/custom/modules/Calendar/tpls/main.tpl
+++ b/custom/modules/Calendar/tpls/main.tpl
@@ -335,7 +335,6 @@ YAHOO.util.Event.onDOMReady(function(){
 <script src='{sugar_getjspath file="modules/Calendar/fullcalendar/fullcalendar.min.js"}'></script>
 <script src='{sugar_getjspath file="modules/Calendar/fullcalendar/locale-all.js"}'></script>
 
-
 <div id='calendarContainer'></div>
 {* STIC-Custom 20210927 AAM - Adding Shared Day option
 STIC#422  

--- a/custom/modules/Calendar/tpls/main.tpl
+++ b/custom/modules/Calendar/tpls/main.tpl
@@ -336,7 +336,7 @@ YAHOO.util.Event.onDOMReady(function(){
 <script src='{sugar_getjspath file="modules/Calendar/fullcalendar/locale-all.js"}'></script>
 
 {* STIC-Custom - JBL - 20260305 - Solve js console errors *}
-{* https://github.com/SinergiaTIC/SinergiaCRM/pull/???? *}
+{* https://github.com/SinergiaTIC/SinergiaCRM/pull/1008 *}
 <script src='{sugar_getjspath file="modules/Reminders/Reminders.js"}'></script>
 {* END STIC-Custom *}
 

--- a/custom/modules/Calendar/tpls/main.tpl
+++ b/custom/modules/Calendar/tpls/main.tpl
@@ -335,11 +335,6 @@ YAHOO.util.Event.onDOMReady(function(){
 <script src='{sugar_getjspath file="modules/Calendar/fullcalendar/fullcalendar.min.js"}'></script>
 <script src='{sugar_getjspath file="modules/Calendar/fullcalendar/locale-all.js"}'></script>
 
-{* STIC-Custom - JBL - 20260305 - Solve js console errors *}
-{* https://github.com/SinergiaTIC/SinergiaCRM/pull/1008 *}
-<script src='{sugar_getjspath file="modules/Reminders/Reminders.js"}'></script>
-{* END STIC-Custom *}
-
 
 <div id='calendarContainer'></div>
 {* STIC-Custom 20210927 AAM - Adding Shared Day option

--- a/custom/modules/Calendar/tpls/main.tpl
+++ b/custom/modules/Calendar/tpls/main.tpl
@@ -335,6 +335,12 @@ YAHOO.util.Event.onDOMReady(function(){
 <script src='{sugar_getjspath file="modules/Calendar/fullcalendar/fullcalendar.min.js"}'></script>
 <script src='{sugar_getjspath file="modules/Calendar/fullcalendar/locale-all.js"}'></script>
 
+{* STIC-Custom - JBL - 20260305 - Solve js console errors *}
+{* https://github.com/SinergiaTIC/SinergiaCRM/pull/???? *}
+<script src='{sugar_getjspath file="modules/Reminders/Reminders.js"}'></script>
+{* END STIC-Custom *}
+
+
 <div id='calendarContainer'></div>
 {* STIC-Custom 20210927 AAM - Adding Shared Day option
 STIC#422  

--- a/custom/themes/SuiteP/include/EditView/EditView.tpl
+++ b/custom/themes/SuiteP/include/EditView/EditView.tpl
@@ -230,7 +230,11 @@
 {sugar_getscript file="cache/include/javascript/sugar_grp_yui_widgets.js"}
 <script type="text/javascript">
 var {{$form_name}}_tabs = new YAHOO.widget.TabView("{{$form_name}}_tabs");
-{{$form_name}}_tabs.selectTab(0);
+{* STIC-Custom 20260504 - Fix Console error in calendar *}
+{* https://github.com/SinergiaTIC/SinergiaCRM/pull/1008 *}
+{{* {{$form_name}}_tabs.selectTab(0); *}}
+try {ldelim} {{$form_name}}_tabs.selectTab(0); {rdelim} catch(e) {ldelim}{rdelim}
+{* End STIC-Custom *}
 </script>
 {{/if}}
 <script type="text/javascript">

--- a/modules/Calls/metadata/quickcreatedefs.php
+++ b/modules/Calls/metadata/quickcreatedefs.php
@@ -198,11 +198,8 @@ array (
     array (
       'includes' => 
       array (
-        0 => 
-        array (
-          'file' => 'modules/Reminders/Reminders.js',
-          'file' => 'modules/Calls/sticCV_quickcreate.php',          
-        ),
+        0 => array ( 'file' => 'modules/Reminders/Reminders.js' ),
+        1 => array ( 'file' => 'modules/Calls/sticCV_quickcreate.php' ),
       ),
       'maxColumns' => '2',
       'form' => 

--- a/modules/Meetings/metadata/quickcreatedefs.php
+++ b/modules/Meetings/metadata/quickcreatedefs.php
@@ -218,11 +218,8 @@ array (
     array (
       'includes' => 
       array (
-        0 => 
-        array (
-          'file' => 'modules/Reminders/Reminders.js',
-          'file' => 'modules/Meetings/sticCV_quickcreate.php',
-        ),
+        0 => array ( 'file' => 'modules/Reminders/Reminders.js' ),
+        1 => array( 'file' => 'modules/Meetings/sticCV_quickcreate.php' ),
       ),
       'maxColumns' => '2',
       'form' => 


### PR DESCRIPTION
- Closes #813 

## Description
En el módulo Calendario, al marcar una franja horaria, se muestra una venta modal para crear una reunión o registrar una llamada. 
En el momento de cargar la ventana emergente, se producía un error fatal javascript (`Uncaught ReferenceError: Reminders is not defined`) cosa que impedía que se ejecutase el resto de código javascript planeado para ejecutarse.
Esto era especialmente crítico si había Vistas Personalizadas, que se ejecutan mediante su motor Javascript cuando las ventanas se han cargado: no se ejecutaban

## Solución
La solución aplicada ha estado referenciar el fichero javascript con la definición del objeto necesario.

## Pruebas
1. Acceder al módulo de Calendario
2. Abrir las herramientas para desarrolladores del navegador y observar la consola 
3. Seleccionar una hora
4. Verificar que no se produce ningún error javascript
5. Navegar entre las opciones de "Programar Reunión" y "Registrar Llamada"
6. Verificar que no se produce ningún error javascript
