### PR TITLE
Improvement - General - Parámetros en SticUpdates

### DIFF
--- a/SticUpdate.php
+++ b/SticUpdate.php
@@ -161,7 +161,7 @@ if (isset($_REQUEST['sinergiacrm_version'])) {
     $configurator = new Configurator();
     $configurator->config['sinergiacrm_version'] = $_REQUEST['sinergiacrm_version'];
     if (isset($_REQUEST['show_update_alert'])) {
-        $configurator->config['stic_show_update_alert'] = $_REQUEST['show_update_alert'];
+        $configurator->config['stic_show_update_alert'] = filter_var($_REQUEST['show_update_alert'], FILTER_VALIDATE_BOOLEAN);
     }
     $configurator->saveConfig();
 }


### PR DESCRIPTION
Se han añadido los siguientes parámetros en SticUpdates.php:

- sinergiacrm_version: Si este parámetro está seteado, se establece el valor en sugar_config['sinergiacrm_version].
- show_update_alert: Si sinergiacrm_version está seteado, establece el valor de show_update_alert en el sugar_config de stic_show_update_alert. Ya sea true o false.