### PR TITLE
Hotfix - General - Revisar la aplicación de GS en tratamiento de query completa de vista de lista

### DIFF
--- a/modules/stic_Incorpora/controller.php
+++ b/modules/stic_Incorpora/controller.php
@@ -93,22 +93,26 @@ class stic_IncorporaController extends SugarController
             if (!empty($retArray['where'])) {
                 $where = " AND " . $retArray['where'];
             }
+
+            $focus = BeanFactory::getBean($this->returnModule);
+            if ($focus->bean_implements('ACL')) {
+                if (!ACLController::checkAccess($focus->module_dir, 'list', true)) {
+                    ACLController::displayNoAccess();
+                    sugar_die('');
+                }
+
+                $accessWhere = $focus->buildAccessWhere('list');
+                if (!empty($accessWhere)) {
+                    $where .= empty($where) ? $accessWhere : ' AND ' . $accessWhere;
+                }
+            }
         } else {
             $ids = explode(',', $_REQUEST['uid']);
             $idList = implode("','", $ids);
             $where = " AND id in ('{$idList}')";
         }
 
-        $focus = BeanFactory::getBean($this->returnModule);
-        if ($focus->bean_implements('ACL')) {
-            if (!ACLController::checkAccess($focus->module_dir, 'list', true)) {
-                ACLController::displayNoAccess();
-                sugar_die('');
-            }
 
-            $accessWhere = $focus->buildAccessWhere('list');
-            $where .= ' AND ' . $accessWhere;
-        }
 
         $sql .= $where;
         $resultado = $db->query($sql);

--- a/modules/stic_Incorpora/controller.php
+++ b/modules/stic_Incorpora/controller.php
@@ -103,7 +103,7 @@ class stic_IncorporaController extends SugarController
 
                 $accessWhere = $focus->buildAccessWhere('list');
                 if (!empty($accessWhere)) {
-                    $where .= empty($where) ? $accessWhere : ' AND ' . $accessWhere;
+                    $where .= ' AND ' . $accessWhere;
                 }
             }
         } else {

--- a/modules/stic_Job_Applications/controller.php
+++ b/modules/stic_Job_Applications/controller.php
@@ -50,7 +50,9 @@ class stic_Job_ApplicationsController extends SugarController
                 }
 
                 $accessWhere = $focus->buildAccessWhere('list');
-                $where .= ' AND ' . $accessWhere;
+                if (!empty($accessWhere)) {
+                    $where .= empty($where) ? $accessWhere : ' AND ' . $accessWhere;
+                }
             }
             $sql .= $where;
             $resultsQuery = $db->query($sql);

--- a/modules/stic_Job_Applications/controller.php
+++ b/modules/stic_Job_Applications/controller.php
@@ -51,7 +51,7 @@ class stic_Job_ApplicationsController extends SugarController
 
                 $accessWhere = $focus->buildAccessWhere('list');
                 if (!empty($accessWhere)) {
-                    $where .= empty($where) ? $accessWhere : ' AND ' . $accessWhere;
+                    $where .= ' AND ' . $accessWhere;
                 }
             }
             $sql .= $where;

--- a/modules/stic_Remittances/AddPaymentsToRemittance.php
+++ b/modules/stic_Remittances/AddPaymentsToRemittance.php
@@ -46,26 +46,26 @@ function addPaymentsToRemittance() {
         if (!empty($retArray['where'])) {
             $where = " AND " . $retArray['where'];
         }
+        
+        $focus = BeanFactory::newBean('stic_Payments');
+        // Check ACL access
+        if ($focus->bean_implements('ACL')) {
+            if (!ACLController::checkAccess($focus->module_dir, 'list', true)) {
+                ACLController::displayNoAccess();
+                sugar_die('');
+            }
+
+            $accessWhere = $focus->buildAccessWhere('list');
+            if (!empty($accessWhere)) {
+                $where .= empty($where) ? $accessWhere : ' AND ' . $accessWhere;
+            }
+        }
     } else {
         // If not all payments in the listview were selected then we'll get their ids from the form request var
         $ids = explode(',', $_REQUEST['uid']);
         $idList = implode("','", $ids);
         $where = " AND id in ('{$idList}')";
     }
-
-    $focus = BeanFactory::newBean('stic_Payments');
-    // Check ACL access
-    if ($focus->bean_implements('ACL')) {
-        if (!ACLController::checkAccess($focus->module_dir, 'list', true)) {
-            ACLController::displayNoAccess();
-            sugar_die('');
-        }
-
-        $accessWhere = $focus->buildAccessWhere('list');
-        $where .= ' AND ' . $accessWhere;
-    }
-
-
 
     $sql .= $where;
     // Retrieve selected payments from db

--- a/modules/stic_Remittances/AddPaymentsToRemittance.php
+++ b/modules/stic_Remittances/AddPaymentsToRemittance.php
@@ -46,7 +46,7 @@ function addPaymentsToRemittance() {
         if (!empty($retArray['where'])) {
             $where = " AND " . $retArray['where'];
         }
-        
+
         $focus = BeanFactory::newBean('stic_Payments');
         // Check ACL access
         if ($focus->bean_implements('ACL')) {
@@ -57,7 +57,7 @@ function addPaymentsToRemittance() {
 
             $accessWhere = $focus->buildAccessWhere('list');
             if (!empty($accessWhere)) {
-                $where .= empty($where) ? $accessWhere : ' AND ' . $accessWhere;
+                $where .= ' AND ' . $accessWhere;
             }
         }
     } else {


### PR DESCRIPTION
- Closes #1021 

## Description
Se detecta un error en la aplicación del $accessWhere generado en #941 cuando no hay $accessWhere a aplicar, generando sentencias SQL erróneas.
Se protege y sólo se aplica $accessWhere cuando realmente no está vacío. También se comprueba si el $where al que añadirlo está rellenado o no.

## Motivation and Context
Corregir el error provocado por #941 

## How To Test This
Para todos los elementos modificados en #941: relacionar objetivos, sincronizar con incorpora, generar candidaturas, añadir pagos a remesa, calendario laboral

### Probar cuando no debe aplicarse $accessWhere
1.- Probar con un usuario administrador o un usuario que no tenga restricción sobre los módulos aplicados
2.- Probar seleccionando toda la lista con un filtro aplicado
3.- Probar seleccionando toda la lista sin un filtro aplicado
4.- Probar toda la lista sin filtro aplicado, seleccionando elementos individuales

### Probar cuando debe aplicarse $accessWhere
1.- Probar con un usuario no administrador que tenga restricción sobre los módulos aplicados
2.- Probar seleccionando toda la lista con un filtro aplicado
3.- Probar seleccionando toda la lista sin un filtro aplicado
4.- Probar toda la lista sin filtro aplicado, seleccionando elementos individuales

