### PR TITLE
Enhancement - Activos - Habilitar pestañas en las vistas de detalles y edición

### DIFF
--- a/modules/stic_Assets/metadata/detailviewdefs.php
+++ b/modules/stic_Assets/metadata/detailviewdefs.php
@@ -53,19 +53,19 @@ array(
                 ),
 
                 'LBL_ADDRESS_PANEL' => array(
-                    'newTab' => false,
+                    'newTab' => true,
                     'panelDefault' => 'expanded',
                 ),
                 'LBL_OWNERSHIP_PANEL' => array(
-                    'newTab' => false,
+                    'newTab' => true,
                     'panelDefault' => 'expanded',
                 ),
                 'LBL_INSURANCES_PANEL' => array(
-                    'newTab' => false,
+                    'newTab' => true,
                     'panelDefault' => 'expanded',
                 ),
                 'LBL_UTILITIES_PANEL' => array(
-                    'newTab' => false,
+                    'newTab' => true,
                     'panelDefault' => 'expanded',
                 ),
                 'LBL_PANEL_RECORD_DETAILS' => array(

--- a/modules/stic_Assets/metadata/editviewdefs.php
+++ b/modules/stic_Assets/metadata/editviewdefs.php
@@ -38,26 +38,26 @@ array(
                     'field' => '30',
                 ),
             ),
-            'useTabs' => false,
+            'useTabs' => true,
             'tabDefs' => array(
                 'LBL_DEFAULT_PANEL' => array(
-                    'newTab' => false,
+                    'newTab' => true,
                     'panelDefault' => 'expanded',
                 ),
                 'LBL_ADDRESS_PANEL' => array(
-                    'newTab' => false,
+                    'newTab' => true,
                     'panelDefault' => 'expanded',
                 ),
                 'LBL_OWNERSHIP_PANEL' => array(
-                    'newTab' => false,
+                    'newTab' => true,
                     'panelDefault' => 'expanded',
                 ),
                 'LBL_INSURANCES_PANEL' => array(
-                    'newTab' => false,
+                    'newTab' => true,
                     'panelDefault' => 'expanded',
                 ),
                 'LBL_UTILITIES_PANEL' => array(
-                    'newTab' => false,
+                    'newTab' => true,
                     'panelDefault' => 'expanded',
                 ),
             ),


### PR DESCRIPTION

## Descripción
Este PR ajusta la configuración de las vistas de stic_Assets para que los paneles se muestren en pestañas, alineándose con el comportamiento habitual del resto de módulos.

## Cambios realizados
- Se activa el uso de pestañas en EditView.
- Se configura cada panel existente como pestaña tanto en DetailView como en EditView.

## Pruebas
Vaerificar que se visualizan las pestañas en ambas vistas