### PR TITLE
Hotfix - Recursos y Reservas - Fechas modificadas en edición y más

### DIFF
--- a/modules/stic_Bookings/Utils.js
+++ b/modules/stic_Bookings/Utils.js
@@ -223,8 +223,9 @@ switch (viewType()) {
     manualPlannedEndHours = "10";
     manualPlannedEndMinutes = "30";
 
-    // With all_day loadCenterResourcesButtoned the DateTime fields shouldn't display the time section
-    // and the end_date should display one day less
+    // With all_day checked the DateTime fields shouldn't display the time section
+    // and the end_date should display one day less (except when reloading from session).
+    var isLoadFromSession = window.location.search.indexOf("loadFromSession=true") !== -1;
     if ($("#all_day", "form").is(":checked")) {
       $("#start_date_hours").val("00");
       $("#start_date_minutes").val("00");
@@ -254,7 +255,7 @@ switch (viewType()) {
       // Hide planned date time sections
       $("#planned_start_date_time_section").parent().hide();
       $("#planned_end_date_time_section").parent().hide();
-      if ($("#end_date_date").val()) {
+      if (!isLoadFromSession && $("#end_date_date").val()) {
         var formatString = cal_date_format
             .replace(/%/g, "")
             .toLowerCase()
@@ -845,6 +846,12 @@ function isResourceAvailable(resourceElement = null) {
   bookingId = $('[name="record"]').val()
     ? $('[name="record"]').val()
     : $(".listview-checkbox", $(".inlineEditActive").closest("tr")).val();
+  debugger;
+    var startDateValue = getFieldValue("start_date");
+  if ($("#all_day", "form").is(":checked") && startDateValue) {
+    // In all-day bookings, avoid carrying residual time (e.g. 11:00) to SQL checks
+    startDateValue = startDateValue.split(" ")[0];
+  }
   if (
     $("#all_day", "form").is(":checked") ||
     getFieldValue("end_date").indexOf(" ") == -1
@@ -874,7 +881,7 @@ function isResourceAvailable(resourceElement = null) {
       dataType: "json",
       async: false,
       data: {
-        startDate: dateToYMDHM(getDateObject(getFieldValue("start_date"))),
+        startDate: dateToYMDHM(getDateObject(startDateValue)),
         endDate: dateToYMDHM(getDateObject(endDateValue)),
         resourceId: resourceElement ? $("#" + resourceElement).val() : null,
         bookingId: bookingId,
@@ -1108,8 +1115,16 @@ function loadCenterResources(
   numberOfPlaces = ""
 ) {
   var centerIds = selectedCenters.map((center) => center.centerId).join(",");
-  var startDate = getDateObject(getFieldValue("start_date"));
-  var endDate = getDateObject(getFieldValue("end_date"));
+  var startDateValue = getFieldValue("start_date");
+  var endDateValue = getFieldValue("end_date");
+
+  if ($("#all_day", "form").is(":checked")) {
+    startDateValue = startDateValue ? startDateValue.split(" ")[0] : startDateValue;
+    endDateValue = endDateValue ? endDateValue.split(" ")[0] : endDateValue;
+  }
+
+  var startDate = getDateObject(startDateValue);
+  var endDate = getDateObject(endDateValue);
   
   var existingResourceIds = getCurrentResourceIds();
 

--- a/modules/stic_Bookings/Utils.js
+++ b/modules/stic_Bookings/Utils.js
@@ -846,8 +846,7 @@ function isResourceAvailable(resourceElement = null) {
   bookingId = $('[name="record"]').val()
     ? $('[name="record"]').val()
     : $(".listview-checkbox", $(".inlineEditActive").closest("tr")).val();
-  debugger;
-    var startDateValue = getFieldValue("start_date");
+  var startDateValue = getFieldValue("start_date");
   if ($("#all_day", "form").is(":checked") && startDateValue) {
     // In all-day bookings, avoid carrying residual time (e.g. 11:00) to SQL checks
     startDateValue = startDateValue.split(" ")[0];

--- a/modules/stic_Bookings/Utils.php
+++ b/modules/stic_Bookings/Utils.php
@@ -86,7 +86,11 @@ class stic_BookingsUtils
         }
     
         if ($isAllDay) {
-            return date('Y-m-d ' . ($isStart ? '00:00:00' : '23:59:59'), $timestamp);
+            if($isStart) {
+                return date('Y-m-d 00:00:00', $timestamp);
+            } else {
+                return date('Y-m-d 00:00:00', strtotime('+1 day', $timestamp));
+            }
         } else {
             return date('Y-m-d H:i:s', $timestamp);
         }

--- a/modules/stic_Bookings/controller.php
+++ b/modules/stic_Bookings/controller.php
@@ -88,9 +88,10 @@ class stic_BookingsController extends SugarController
         }
         
         foreach ($centerIdsArray as $centerId) {
-            $query = "SELECT stic_resources_stic_centersstic_resources_idb
+            $query = "SELECT DISTINCT stic_resources_stic_centersstic_resources_idb
                       FROM stic_resources_stic_centers_c
-                      WHERE stic_resources_stic_centersstic_centers_ida = '$centerId'";
+                      WHERE stic_resources_stic_centersstic_centers_ida = '$centerId'
+                      AND deleted = 0";
             $result = $db->query($query, true);
             
             while ($row = $db->fetchByAssoc($result)) {

--- a/modules/stic_Bookings/controller.php
+++ b/modules/stic_Bookings/controller.php
@@ -88,9 +88,10 @@ class stic_BookingsController extends SugarController
         }
         
         foreach ($centerIdsArray as $centerId) {
+            $centerIdSafe = $db->quote($centerId);
             $query = "SELECT DISTINCT stic_resources_stic_centersstic_resources_idb
                       FROM stic_resources_stic_centers_c
-                      WHERE stic_resources_stic_centersstic_centers_ida = '$centerId'
+                      WHERE stic_resources_stic_centersstic_centers_ida = '$centerIdSafe'
                       AND deleted = 0";
             $result = $db->query($query, true);
             

--- a/modules/stic_Bookings/metadata/additionalDetails.php
+++ b/modules/stic_Bookings/metadata/additionalDetails.php
@@ -37,8 +37,8 @@ function additionalDetailsstic_Bookings($fields, ?SugarBean $bean = null, $param
 
     } else {
         global $current_language,$timedate, $current_user;
-        $fields['RESOURCE_NAME'] = $_REQUEST['resource_name'];
-        $fields['RESOURCE_ID'] = $_REQUEST['resource_id'];
+        $fields['RESOURCE_NAME'] = $_REQUEST['resource_name'] ?? null;
+        $fields['RESOURCE_ID'] = $_REQUEST['resource_id'] ?? null;
     
         if ($bean->load_relationship('stic_resources_stic_bookings')) {
             $resourcesBeans = $bean->stic_resources_stic_bookings->getBeans();

--- a/modules/stic_Bookings/tpls/bookingsAssistantSummary.tpl
+++ b/modules/stic_Bookings/tpls/bookingsAssistantSummary.tpl
@@ -396,6 +396,7 @@
             }
         }
 
+        // @param isEndDate: if we are formatting endDate and the hour is 00:00, the day must be the day before
         function formatDate(dateString, isEndDate = false) {
             if (!dateString) return '';
 

--- a/modules/stic_Bookings/tpls/bookingsAssistantSummary.tpl
+++ b/modules/stic_Bookings/tpls/bookingsAssistantSummary.tpl
@@ -144,6 +144,7 @@
 
 <script>
     var consolidatedSummaryData = {$CONSOLIDATED_SUMMARY};
+    const isAllDayBooking = {$IS_ALL_DAY};
     const pageSize = {$RECORDS_PER_PAGE};
     let createdRecords = [];
     let notCreatedRecords = [];
@@ -297,12 +298,12 @@
 
                 const startDateSpan = document.createElement('span');
                 startDateSpan.className = 'row';
-                startDateSpan.textContent = formatDate(record.startDate) || '';
+                startDateSpan.textContent = formatDate(record.startDate, false) || '';
                 recordRow.appendChild(startDateSpan);
                 
                 const endDateSpan = document.createElement('span');
                 endDateSpan.className = 'row';
-                endDateSpan.textContent = formatDate(record.endDate) || '';
+                endDateSpan.textContent = formatDate(record.endDate, true) || '';
                 recordRow.appendChild(endDateSpan);
 
                                 
@@ -340,12 +341,12 @@
 
                 const startDateSpan = document.createElement('span');
                 startDateSpan.className = 'row';
-                startDateSpan.textContent = formatDate(record.startDate) || '';
+                startDateSpan.textContent = formatDate(record.startDate, false) || '';
                 recordRow.appendChild(startDateSpan);
                 
                 const endDateSpan = document.createElement('span');
                 endDateSpan.className = 'row';
-                endDateSpan.textContent = formatDate(record.endDate) || '';
+                endDateSpan.textContent = formatDate(record.endDate, true) || '';
                 recordRow.appendChild(endDateSpan);
                 
                 const requestedResourcesSpan = document.createElement('span');
@@ -395,8 +396,20 @@
             }
         }
 
-        function formatDate(dateString) {
+        function formatDate(dateString, isEndDate = false) {
             if (!dateString) return '';
+
+            if (isAllDayBooking && typeof dateString === 'string') {
+                const parts = dateString.split(' ');
+                let datePart = parts[0] || '';
+                const timePart = parts[1] || '';
+
+                if (isEndDate && timePart.indexOf('00:00') === 0) {
+                    datePart = subtractOneDayPreservingFormat(datePart);
+                }
+
+                return datePart;
+            }
             
             if (typeof dateString === 'string' && dateString.includes('/')) {
                 return dateString;
@@ -412,6 +425,70 @@
             }
             
             return dateString;
+        }
+
+        function subtractOneDayPreservingFormat(datePart) {
+            if (!datePart) return datePart;
+
+            const separator = datePart.includes('/') ? '/' : (datePart.includes('-') ? '-' : '');
+            if (!separator) return datePart;
+
+            const tokens = datePart.split(separator);
+            if (tokens.length !== 3) return datePart;
+
+            let day, month, year;
+            let format;
+
+            if (tokens[0].length === 4) {
+                // yyyy-mm-dd
+                year = parseInt(tokens[0], 10);
+                month = parseInt(tokens[1], 10);
+                day = parseInt(tokens[2], 10);
+                format = 'YMD';
+            } else {
+                const first = parseInt(tokens[0], 10);
+                const second = parseInt(tokens[1], 10);
+                year = parseInt(tokens[2], 10);
+
+                if (first > 12) {
+                    // dd/mm/yyyy
+                    day = first;
+                    month = second;
+                    format = 'DMY';
+                } else if (second > 12) {
+                    // mm/dd/yyyy
+                    month = first;
+                    day = second;
+                    format = 'MDY';
+                } else {
+                    // Ambiguous: use configured calendar format
+                    const lowerDateFormat = (cal_date_format || '').toLowerCase();
+                    if (lowerDateFormat.indexOf('%d') < lowerDateFormat.indexOf('%m')) {
+                        day = first;
+                        month = second;
+                        format = 'DMY';
+                    } else {
+                        month = first;
+                        day = second;
+                        format = 'MDY';
+                    }
+                }
+            }
+
+            if (!day || !month || !year) return datePart;
+
+            const dateObj = new Date(year, month - 1, day);
+            if (isNaN(dateObj.getTime())) return datePart;
+
+            dateObj.setDate(dateObj.getDate() - 1);
+
+            const d = String(dateObj.getDate()).padStart(2, '0');
+            const m = String(dateObj.getMonth() + 1).padStart(2, '0');
+            const y = String(dateObj.getFullYear());
+
+            if (format === 'YMD') return [y, m, d].join(separator);
+            if (format === 'DMY') return [d, m, y].join(separator);
+            return [m, d, y].join(separator);
         }
 
         function formatUnavailableResources(unavailableResources) {

--- a/modules/stic_Bookings/views/view.bookingsassistantsummary.php
+++ b/modules/stic_Bookings/views/view.bookingsassistantsummary.php
@@ -41,9 +41,17 @@ class stic_BookingsViewBookingsAssistantSummary extends SugarView
         if (isset($_SESSION['summary']) && isset($_SESSION['consolidated_summary'])) {
             $this->ss->assign('DATA', $_SESSION['summary']['global']);
             $this->ss->assign('CONSOLIDATED_SUMMARY', json_encode($_SESSION['consolidated_summary']));
+
+            $isAllDay = false;
+            if (!empty($_SESSION['bookings_to_confirm']) && is_array($_SESSION['bookings_to_confirm'])) {
+                $firstBooking = reset($_SESSION['bookings_to_confirm']);
+                $isAllDay = !empty($firstBooking['all_day']) && $firstBooking['all_day'] == '1';
+            }
+            $this->ss->assign('IS_ALL_DAY', $isAllDay ? 'true' : 'false');
         } else {
             $this->ss->assign('DATA', ['totalRecordsProcessed' => 0, 'totalRecordsCreated' => 0, 'totalRecordsNotCreated' => 0]);
             $this->ss->assign('CONSOLIDATED_SUMMARY', json_encode([]));
+            $this->ss->assign('IS_ALL_DAY', 'false');
         }
         
         $this->ss->assign('RECORDS_PER_PAGE', $sugar_config['list_max_entries_per_page']);

--- a/modules/stic_Bookings/views/view.bookingsassistantsummary.php
+++ b/modules/stic_Bookings/views/view.bookingsassistantsummary.php
@@ -41,7 +41,7 @@ class stic_BookingsViewBookingsAssistantSummary extends SugarView
         if (isset($_SESSION['summary']) && isset($_SESSION['consolidated_summary'])) {
             $this->ss->assign('DATA', $_SESSION['summary']['global']);
             $this->ss->assign('CONSOLIDATED_SUMMARY', json_encode($_SESSION['consolidated_summary']));
-
+            // is_all_day is needed in the template to know if we need to apply the logic of removing hours and minutes to the dates or not, as the summary can be shown both for all day events and for events with specific hours. This value is obtained from the first booking in the list of bookings to confirm, but it could be obtained from any of them as they should all have the same value for all_day.
             $isAllDay = false;
             if (!empty($_SESSION['bookings_to_confirm']) && is_array($_SESSION['bookings_to_confirm'])) {
                 $firstBooking = reset($_SESSION['bookings_to_confirm']);

--- a/modules/stic_Bookings/views/view.edit.php
+++ b/modules/stic_Bookings/views/view.edit.php
@@ -103,35 +103,17 @@ class stic_BookingsViewEdit extends ViewEdit
             // and apply timezone to the dates
             if (isset($this->bean->all_day) && $this->bean->all_day == '1') {
                 
-                // Use the appropriate source for dates based on whether we're loading from session
-                $sourceStartDate = '';
-                $sourceEndDate = '';
-                
-                if ($isLoadingFromSession) {
-                    // When loading from session, use the bean properties directly
-                    $sourceStartDate = $this->bean->start_date ?? '';
-                    $sourceEndDate = $this->bean->end_date ?? '';
-                } else {
-                    // When not loading from session, use fetched_row as before
-                    $sourceStartDate = $this->bean->fetched_row['start_date'] ?? '';
-                    $sourceEndDate = $this->bean->fetched_row['end_date'] ?? '';
-                }
+                // Always use bean values to avoid date drift when reopening EditView.
+                $sourceStartDate = $this->bean->start_date ?? '';
+                $sourceEndDate = $this->bean->end_date ?? '';
                 
                 // Process start_date
                 if (!empty($sourceStartDate)) {
                     $startDateParts = explode(' ', $sourceStartDate);
                     // Ensure we have the date part
                     if (isset($startDateParts[0])) {
-                        if ($isLoadingFromSession) {
-                            // When loading from session, preserve the exact date format the user entered
-                            // Don't attempt any conversion as the date is already in the user's preferred format
-                            $this->bean->start_date = $startDateParts[0] . ' 00:00';
-                        } else {
-                            // When not loading from session, use the original logic
-                            $startDate = new DateTime($startDateParts[0]);
-                            $startDateDisplay = $timedate->asUserDate($startDate, false, $current_user);
-                            $this->bean->start_date = $startDateDisplay . ' 00:00';
-                        }
+                        // Preserve current date format (already prepared for current user/view context)
+                        $this->bean->start_date = $startDateParts[0] . ' 00:00';
                     } else {
                         // If explode failed or doesn't have expected format, use current date
                         $this->bean->start_date = date('Y-m-d') . ' 00:00';
@@ -146,58 +128,16 @@ class stic_BookingsViewEdit extends ViewEdit
                     $endDateParts = explode(' ', $sourceEndDate);
                     // Ensure we have the date part
                     if (isset($endDateParts[0])) {
-                        if ($isLoadingFromSession) {
-                            // When loading from session, preserve the exact date format the user entered
-                            // Don't attempt any conversion as the date is already in the user's preferred format
-                            
-                            // TEMPORAL FIX: If this is end_date and all_day, it seems to be off by one day
-                            // so let's add one day to compensate
-                            if (isset($this->bean->all_day) && $this->bean->all_day == '1') {
-                                try {
-                                    // Parse the date using the same format it came in
-                                    $originalFormat = $endDateParts[0];
-                                    
-                                    // Try to determine if it's DD/MM/YYYY or MM/DD/YYYY format
-                                    $parts = explode('/', $originalFormat);
-                                    if (count($parts) == 3) {
-                                        // Create date object and add one day
-                                        $dateObj = DateTime::createFromFormat('d/m/Y', $originalFormat);
-                                        if (!$dateObj) {
-                                            $dateObj = DateTime::createFromFormat('m/d/Y', $originalFormat);
-                                        }
-                                        if ($dateObj) {
-                                            $dateObj->modify('+1 day');
-                                            // Return in the same format as input
-                                            if (DateTime::createFromFormat('d/m/Y', $originalFormat)) {
-                                                $this->bean->end_date = $dateObj->format('d/m/Y') . ' 23:59';
-                                            } else {
-                                                $this->bean->end_date = $dateObj->format('m/d/Y') . ' 23:59';
-                                            }
-                                        } else {
-                                            $this->bean->end_date = $endDateParts[0] . ' 23:59';
-                                        }
-                                    } else {
-                                        $this->bean->end_date = $endDateParts[0] . ' 23:59';
-                                    }
-                                } catch (Exception $e) {
-                                    $this->bean->end_date = $endDateParts[0] . ' 23:59';
-                                }
-                            } else {
-                                $this->bean->end_date = $endDateParts[0] . ' 23:59';
-                            }
-                        } else {
-                            // When not loading from session, use the original logic
-                            $endDate = new DateTime($endDateParts[0]);
-                            $endDateDisplay = $timedate->asUserDate($endDate, false, $current_user);
-                            $this->bean->end_date = $endDateDisplay . ' 23:59';
-                        }
+                        // Preserve current date format and normalize all-day end time to 00:00.
+                        // No day arithmetic here to avoid shifting dates unexpectedly.
+                        $this->bean->end_date = $endDateParts[0] . ' 00:00';
                     } else {
                         // If explode failed or doesn't have expected format, use current date
-                        $this->bean->end_date = date('Y-m-d') . ' 23:59';
+                        $this->bean->end_date = date('Y-m-d') . ' 00:00';
                     }
                 } else {
                     // If end_date is empty, use current date
-                    // $this->bean->end_date = date('Y-m-d') . ' 23:59';
+                    // $this->bean->end_date = date('Y-m-d') . ' 00:00';
                 }
             }
         }

--- a/modules/stic_Bookings_Places_Calendar/controller.php
+++ b/modules/stic_Bookings_Places_Calendar/controller.php
@@ -78,6 +78,8 @@ class stic_Bookings_Places_CalendarController extends stic_Bookings_CalendarCont
             AND sb.status != 'cancelled'
             AND sb.deleted = 0
             AND sr.deleted = 0
+            AND srsc.deleted = 0
+            AND sc.deleted = 0
             AND srsb.deleted = 0
         ";
 
@@ -222,7 +224,8 @@ class stic_Bookings_Places_CalendarController extends stic_Bookings_CalendarCont
                     stic_centers
                 ON    stic_centers.id = stic_resources_stic_centers_c.stic_resources_stic_centersstic_centers_ida and stic_centers.deleted = 0
                 WHERE
-                    stic_resources.deleted = 0 AND stic_resources.type = 'place'";
+                    stic_resources.deleted = 0 AND stic_resources.type = 'place'
+                    AND stic_resources_stic_centers_c.deleted = 0 AND stic_centers.deleted = 0";
         // Filters are added
         if (!empty($filteredResources)) {
             $query .= " AND stic_resources.id IN ('" . implode("','", $filteredResources) . "')";
@@ -347,6 +350,8 @@ class stic_Bookings_Places_CalendarController extends stic_Bookings_CalendarCont
                     r.deleted = 0 
                   AND  
                     r.type = 'place'
+                  AND 
+                    rc.deleted = 0
                 ";
 
         if (!empty($users)) {

--- a/modules/stic_Bookings_Places_Calendar/controller.php
+++ b/modules/stic_Bookings_Places_Calendar/controller.php
@@ -78,8 +78,6 @@ class stic_Bookings_Places_CalendarController extends stic_Bookings_CalendarCont
             AND sb.status != 'cancelled'
             AND sb.deleted = 0
             AND sr.deleted = 0
-            AND srsc.deleted = 0
-            AND sc.deleted = 0
             AND srsb.deleted = 0
         ";
 

--- a/modules/stic_Bookings_Places_Calendar/controller.php
+++ b/modules/stic_Bookings_Places_Calendar/controller.php
@@ -72,8 +72,8 @@ class stic_Bookings_Places_CalendarController extends stic_Bookings_CalendarCont
             JOIN stic_bookings sb ON srsb.stic_resources_stic_bookingsstic_bookings_idb = sb.id
             LEFT JOIN stic_resources_stic_centers_c srsc ON sr.id = srsc.stic_resources_stic_centersstic_resources_idb and srsc.deleted = 0
             LEFT JOIN stic_centers sc ON srsc.stic_resources_stic_centersstic_centers_ida = sc.id and sc.deleted = 0
-            WHERE sb.end_date >= '$start_date'
-            AND sb.start_date <= '$end_date'
+            WHERE sb.end_date >= '{$db->quote($start_date)}'
+            AND sb.start_date <= '{$db->quote($end_date)}'
             AND sr.type ='place'
             AND sb.status != 'cancelled'
             AND sb.deleted = 0

--- a/modules/stic_Bookings_Places_Calendar/controller.php
+++ b/modules/stic_Bookings_Places_Calendar/controller.php
@@ -243,16 +243,18 @@ class stic_Bookings_Places_CalendarController extends stic_Bookings_CalendarCont
             );
         }
 
-        $query = "SELECT stic_resources_stic_bookingsstic_resources_ida as resource_id,
+        $query = "SELECT DISTINCT stic_resources_stic_bookingsstic_resources_ida as resource_id,
                      CONVERT_TZ(start_date, '+00:00', '$user_tz_name') as start_date, CONVERT_TZ(end_date, '+00:00', '$user_tz_name') as end_date
                     --  start_date, end_date
               FROM stic_bookings
               JOIN stic_resources_stic_bookings_c ON stic_resources_stic_bookingsstic_bookings_idb = stic_bookings.id
               WHERE stic_bookings.deleted = 0
                 AND stic_resources_stic_bookings_c.deleted = 0
+            AND stic_bookings.status != 'cancelled'
                 AND start_date <= '$end_date'
                 AND end_date >= '$start_date'
-                AND stic_bookings.place_booking = 1";
+                AND stic_bookings.place_booking = 1
+            ";
         $result = $db->query($query);
 
         $bookedResources = array();
@@ -263,7 +265,11 @@ class stic_Bookings_Places_CalendarController extends stic_Bookings_CalendarCont
             // if endDate end with 00:00:00, we consider that the place is freed that day
             if (substr($endDate, 11, 8) == '00:00:00') {
                 $endDate = date('Y-m-d', strtotime($endDate . ' -1 day'));
-            }            
+            } else {
+                $endDate = date('Y-m-d', strtotime($endDate));
+            }
+
+            $startDate = date('Y-m-d', strtotime($startDate));
 
             $currentDate = $startDate;
             while ($currentDate <= $endDate && $currentDate <= $end_date) {


### PR DESCRIPTION
- Closes #1028

## Description
### Trailing date
Se trabaja siempre a partir de la fecha ya formateada y con el GMT aplicado.
Se deben revisar los js para limpiar la hora de la start_date y refinar cuando sumar/restar un día a la end_date

### Calendario
Se añaden algunos deleted=0 que faltaban en algunas consultas

### Reservas periódicas de todo el día
Se elimina todo el tratamiento que se hace de 23:59.
Se modifica también la pantalla de confirmación para mostrar sólo fecha cuando la reserva es de todo el día

### Disponibilidad de recurso en reservas todo el día
Se elimna la parte de hora de la start_date en el JS antes de enviar el checkeo de colisión.

### AdditionalDetails
Se añade comprobación ?? null para evitar el error.

## How To Test This

### Trailing date
1.- Crear una reserva de todo el día
2.- Editar la reserva, observar cómo se mantienen las fechas

### Calendario
1.- Asignar una plaza a un centro
2.- Asignar la misma plaza a otro centro
3.- Realizar una reserva de esa plaza
4.- Consultar en el calendario las fechas correspondientes a la reserva y comprobar que los contadores que aparecen son correctos

### Reservas periódicas de todo el día
1.- Realizar una reserva periódica de todo el día
2.- Comprobar en BBDD que las end_date corresponden a dia+1 a las 00:00
3.- Comrpobar que al editarlas, las fechas de cada una de las reservas son correctas

### Disponibilidad de recurso en resrvas todo el día
1.- Hacer una reserva entre las 9:00 y las 10:00
2.- Con el mismo recurso y día, hacer una reserva de día completo
3.- Comprobar que NO deja hacer la reserva de todo el día
4.- [Opcional] Se puede añadir una traza para ver la consulta de disponibilidad Utils.php de stic_Bookings, función checkResourceAvailability y comprobar que las horas usadas cuando la reserva es de todo el día son las 00:00 y no las 11:00 como pasaba hasta ahora

### Error en additionalDetails
1.- Asegurarse en el workkit de tener activo el reporte de errores => error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
2.- Acceder desde la vista de lista de reservas a cualquier icono de additionalDetails

### Adicional
Realizar distintas pruebas para comprobar que la funcionalidad sigue funcionando correctamente
1.- Reservas individuales de todo el día
2.- Reservas por horas
3.- Combinar (casos límite) reservas de todo el día y por horas
4.- Reservas periódicas (todo el día / por horas)
5.- Combinar reservas periódicas con casos límite de reservas de todo el día y por horas
6.- Editar reservas
     Comprobar start_date y end_date
     Comprobar las planned dates
7.- Visualizar reservas (detalle, lista y subpanel de recurso)
8.- Reserva no disponible para algún recurso seleccionado (probar primero, intermedio y último)
9.- Probar caso límite "cambios de hora": reserva que termina justo cuando cambia la hora y reserva que comienza justo después
10.- Probar diferentes formatos de fecha y hora
11.- Probar los additionalDetails
12.- Repetir pruebas para reserva de plazas
13.- Visualización en los calendarios