### PR TITLE
Hotfix - KReports - Caracteres especiales en columna fórmula PHP

### DIFF
--- a/modules/KReports/KReport.php
+++ b/modules/KReports/KReport.php
@@ -1436,7 +1436,9 @@ class KReport extends SugarBean {
             $formulaRaw = rawurldecode(base64_decode($thisListEntry ['formulavalue'], true));
             // STIC-Custom 20260318 EPS - Special characters in formulas are not properly handled - convert to UTF-8
             // https://github.com/SinergiaTIC/SinergiaCRM/pull/1030
-            $formulaRaw = mb_convert_encoding($formulaRaw, 'UTF-8', 'ISO-8859-1');
+            if (!mb_check_encoding($formulaRaw, 'UTF-8')) {
+               $formulaRaw = mb_convert_encoding($formulaRaw, 'UTF-8', 'ISO-8859-1');
+            }
             // END STIC
 
             // if the value is not base 64

--- a/modules/KReports/KReport.php
+++ b/modules/KReports/KReport.php
@@ -1435,6 +1435,7 @@ class KReport extends SugarBean {
             //$formulaRaw = urldecode(base64_decode($thisListEntry ['formulavalue'], true));
             $formulaRaw = rawurldecode(base64_decode($thisListEntry ['formulavalue'], true));
             // STIC-Custom 20260318 EPS - Special characters in formulas are not properly handled - convert to UTF-8
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1030
             $formulaRaw = mb_convert_encoding($formulaRaw, 'UTF-8', 'ISO-8859-1');
             // END STIC
 

--- a/modules/KReports/KReport.php
+++ b/modules/KReports/KReport.php
@@ -1434,6 +1434,9 @@ class KReport extends SugarBean {
             //2013-01-22 changed to rawurldecode
             //$formulaRaw = urldecode(base64_decode($thisListEntry ['formulavalue'], true));
             $formulaRaw = rawurldecode(base64_decode($thisListEntry ['formulavalue'], true));
+            // STIC-Custom 20260318 EPS - Special characters in formulas are not properly handled - convert to UTF-8
+            $formulaRaw = mb_convert_encoding($formulaRaw, 'UTF-8', 'ISO-8859-1');
+            // END STIC
 
             // if the value is not base 64
             if (!$formulaRaw)


### PR DESCRIPTION
- Closes #1024

## Description
Se añade una conversión del resultado de la fórmula a UTF-8

## Motivation and Context
Permitir usar caracteres especiales en las fórmulas de PHP de los informes.

## How To Test This
1.- Crear un informe KReports
2.- En el informe agregar una coilumna cuyo resultado sea "Sí"
3.- Comprobar que se visualiza correctamente.
4.- Probar con fórmulas avanzadas y comprobar que no se rompe nada

