### PR TITLE
Hotfix - Eventos e Inscripciones - Contadores incorrectos en duplicación

### DIFF
--- a/modules/stic_Events/stic_Events.php
+++ b/modules/stic_Events/stic_Events.php
@@ -79,4 +79,21 @@ class stic_Events extends Basic {
         return false;
     }
 
+    public function save($check_notify = false)
+    {
+        if (!isset($this->fetched_row)) {
+            $this->status_not_invited = null;
+            $this->status_confirmed = null;
+            $this->status_invited = null;
+            $this->status_rejected = null;
+            $this->status_maybe = null;
+            $this->status_didnt_take_part = null;
+            $this->status_took_part = null;
+            $this->status_drop_out = null;
+            
+        }
+
+        return parent::save($check_notify);
+    }
+
 }

--- a/modules/stic_Events/stic_Events.php
+++ b/modules/stic_Events/stic_Events.php
@@ -81,6 +81,7 @@ class stic_Events extends Basic {
 
     public function save($check_notify = false)
     {
+        // If is a new record (cloned), reset calculated fields
         if (!isset($this->fetched_row)) {
             $this->status_not_invited = null;
             $this->status_confirmed = null;


### PR DESCRIPTION
- Closes #1023

## Description
Se añade al bean the stic_Events el reseteo de lso contadores cuando no hay fetched_row (registro nuevo), tal cómo se hace en inscripciones (en ese caso todavía en el LH).

## Motivation and Context
Evitar el error en los contadores al duplicar unevento.

## How To Test This
1.- Crear un evento
2.- Crear distintas inscripciones, sesiones y asistencias al evento
3.- Duplicar y actualizar masivamente el evento desde la vista de lista
4.- Comprobar que en el evento creado, los contadores se han reiniciado

