### PR TITLE
Enhancement - Recursos y Reservas - Literales comunes se recogen de Recursos

### DIFF
--- a/modules/stic_Bookings/Utils.js
+++ b/modules/stic_Bookings/Utils.js
@@ -534,8 +534,8 @@ function insertResourceLine() {
         field +
         "'>" +
         SUGAR.language.get(
-          "stic_Bookings",
-          "LBL_RESOURCES_" + field.toUpperCase()
+          "stic_Resources",
+          "LBL_" + field.toUpperCase()
         ) +
         "</th>";
     });
@@ -679,8 +679,8 @@ function updateResourceFields() {
       field +
       "'>" +
       SUGAR.language.get(
-        "stic_Bookings",
-        "LBL_RESOURCES_" + field.toUpperCase()
+        "stic_Resources",
+        "LBL_" + field.toUpperCase()
       ) +
       "</th>";
   });

--- a/modules/stic_Bookings/Utils.php
+++ b/modules/stic_Bookings/Utils.php
@@ -799,5 +799,30 @@ class stic_BookingsUtils
         return " AND (" . implode(" OR ", $filters) . ")";
     }
 
+    public static function getConfigResourceFields()
+    {
+        $mod_strings = return_module_language($GLOBALS['current_language'], 'stic_Resources');
+        return [
+            'name' => $mod_strings['LBL_NAME'],
+            'code' => $mod_strings['LBL_CODE'],
+            'color' => $mod_strings['LBL_COLOR'],
+            'type' => $mod_strings['LBL_TYPE'],
+            'hourly_rate' => $mod_strings['LBL_HOURLY_RATE'],
+            'daily_rate' => $mod_strings['LBL_DAILY_RATE'],
+        ];
+    }
 
+    public static function getConfigPlaceFields()
+    {
+        $mod_strings = return_module_language($GLOBALS['current_language'], 'stic_Resources');
+        return [
+            'name' => $mod_strings['LBL_NAME'],
+            'code' => $mod_strings['LBL_CODE'],
+            'user_type' => $mod_strings['LBL_USER_TYPE'],
+            'place_type' => $mod_strings['LBL_PLACE_TYPE'],
+            'gender' => $mod_strings['LBL_GENDER'],
+            'amount_day_occupied' => $mod_strings['LBL_AMOUNT_DAY_OCCUPIED'],
+            'amount_copayment' => $mod_strings['LBL_AMOUNT_COPAYMENT'],
+        ];
+    }
 }

--- a/modules/stic_Bookings/configPlaceFields.php
+++ b/modules/stic_Bookings/configPlaceFields.php
@@ -2,16 +2,16 @@
 
 global $current_language;
 
-$mod_strings = return_module_language($current_language, 'stic_Bookings');
+$mod_strings = return_module_language($current_language, 'stic_Resources');
 
 return [
-    'name' => $mod_strings['LBL_RESOURCES_NAME'],
-    'code' => $mod_strings['LBL_RESOURCES_CODE'],
-    'user_type' => $mod_strings['LBL_RESOURCES_USER_TYPE'],
-    'place_type' => $mod_strings['LBL_RESOURCES_PLACE_TYPE'],
-    'gender' => $mod_strings['LBL_RESOURCES_GENDER'],
-    'amount_day_occupied' => $mod_strings['LBL_RESOURCES_AMOUNT_DAY_OCCUPIED'],
-    'amount_copayment' => $mod_strings['LBL_RESOURCES_AMOUNT_COPAYMENT'],
+    'name' => $mod_strings['LBL_NAME'],
+    'code' => $mod_strings['LBL_CODE'],
+    'user_type' => $mod_strings['LBL_USER_TYPE'],
+    'place_type' => $mod_strings['LBL_PLACE_TYPE'],
+    'gender' => $mod_strings['LBL_GENDER'],
+    'amount_day_occupied' => $mod_strings['LBL_AMOUNT_DAY_OCCUPIED'],
+    'amount_copayment' => $mod_strings['LBL_AMOUNT_COPAYMENT'],
 ];
 
 

--- a/modules/stic_Bookings/configResourceFields.php
+++ b/modules/stic_Bookings/configResourceFields.php
@@ -2,15 +2,15 @@
 
 global $current_language;
 
-$mod_strings = return_module_language($current_language, 'stic_Bookings');
+$mod_strings = return_module_language($current_language, 'stic_Resources');
 
 return [
-    'name' => $mod_strings['LBL_RESOURCES_NAME'],
-    'code' => $mod_strings['LBL_RESOURCES_CODE'],
-    'color' => $mod_strings['LBL_RESOURCES_COLOR'],
-    'type' => $mod_strings['LBL_RESOURCES_TYPE'],
-    'hourly_rate' => $mod_strings['LBL_RESOURCES_HOURLY_RATE'],
-    'daily_rate' => $mod_strings['LBL_RESOURCES_DAILY_RATE'],
+    'name' => $mod_strings['LBL_NAME'],
+    'code' => $mod_strings['LBL_CODE'],
+    'color' => $mod_strings['LBL_COLOR'],
+    'type' => $mod_strings['LBL_TYPE'],
+    'hourly_rate' => $mod_strings['LBL_HOURLY_RATE'],
+    'daily_rate' => $mod_strings['LBL_DAILY_RATE'],
 ];
 
 

--- a/modules/stic_Bookings/controller.php
+++ b/modules/stic_Bookings/controller.php
@@ -69,7 +69,7 @@ class stic_BookingsController extends SugarController
             return;
         }
         
-        $config_place_fields = require 'modules/stic_Bookings/configPlaceFields.php';
+        $config_place_fields = stic_BookingsUtils::getConfigPlaceFields();
 
         $db = DBManagerFactory::getInstance();
         $centerIdsArray = explode(',', $centerIds);
@@ -174,11 +174,11 @@ class stic_BookingsController extends SugarController
             return;
         }
         
-        $config_place_fields = require 'modules/stic_Bookings/configPlaceFields.php';
-        
+        $config_place_fields = stic_BookingsUtils::getConfigPlaceFields();
+
         $db = DBManagerFactory::getInstance();
         $resources = [];
-        
+
         $booking = BeanFactory::getBean('stic_Bookings', $bookingId);
         if ($booking && $booking->load_relationship('stic_resources_stic_bookings')) {
             foreach ($booking->stic_resources_stic_bookings->getBeans() as $resourceBean) {

--- a/modules/stic_Bookings/tpls/EditViewFooter.tpl
+++ b/modules/stic_Bookings/tpls/EditViewFooter.tpl
@@ -99,7 +99,7 @@
   </div>
 </div>
 
-<h2 id="resourcesTitle">{$MOD.LBL_RESOURCES}  <button id="openCenterPopup" type="button" class="button">{$MOD.LBL_CENTERS_BUTTON}</button></h2>
+<h2 id="resourcesTitle">{$RESOURCES_MOD.LBL_MODULE_NAME}  <button id="openCenterPopup" type="button" class="button">{$RESOURCES_MOD.LBL_CENTERS_BUTTON}</button></h2>
 <div class="filter-box">
     <div id="resourceSearchFields" class="filter-content">
         <div id="selectedCentersContainer">
@@ -108,40 +108,40 @@
         
         <div class="filter-row">
             <div class="filter-item">
-                <label for="resourcePlaceUserType">{$MOD.LBL_RESOURCES_USER_TYPE}</label>
+                <label for="resourcePlaceUserType">{$RESOURCES_MOD.LBL_USER_TYPE}</label>
                 <select id="resourcePlaceUserType" name="resourcePlaceUserType" multiple></select>
             </div>
             
             <div class="filter-item">
-                <label for="resourcePlaceType">{$MOD.LBL_RESOURCES_PLACE_TYPE}</label>
+                <label for="resourcePlaceType">{$RESOURCES_MOD.LBL_PLACE_TYPE}</label>
                 <select id="resourcePlaceType" name="resourcePlaceType" multiple></select>
             </div>
         </div>
         
         <div class="filter-row">
             <div class="filter-item">
-                <label for="resourceGender">{$MOD.LBL_RESOURCES_GENDER}</label>
+                <label for="resourceGender">{$RESOURCES_MOD.LBL_GENDER}</label>
                 <select id="resourceGender" name="resourceGender" multiple></select>
             </div>
             
             <div class="filter-item">
-                <label for="resourceName">{$MOD.LBL_RESOURCES_NAME}</label>
+                <label for="resourceName">{$RESOURCES_MOD.LBL_NAME}</label>
                 <input type="text" id="resourceName" name="resourceName">
             </div>
         </div>
         
         <div class="filter-row">
             <div class="filter-item">
-                <label for="numberOfPlaces">{$MOD.LBL_NUMBER_OF_PLACES}</label>
+                <label for="numberOfPlaces">{$RESOURCES_MOD.LBL_NUMBER_OF_PLACES}</label>
                 <input type="number" id="numberOfPlaces" name="numberOfPlaces">
             </div>
         </div>
         <div class="filter-actions grouped-buttons">
             <button id="loadCenterResourcesButton" type="button" class="button">
-                {$MOD.LBL_ADD_BUTTON}
+                {$RESOURCES_MOD.LBL_ADD_BUTTON}
             </button>
             <button id="resetResourcesButton" type="button" class="button">
-                {$MOD.LBL_UNDO_BUTTON}
+                {$RESOURCES_MOD.LBL_UNDO_BUTTON}
             </button>
             <button id="deleteResourcesButton" type="button" class="button">
                 {$APP.LBL_DELETE_BUTTON}
@@ -163,7 +163,7 @@
     </tr>
 </table>
 <div style="padding-top: 2px">
-    <input type="button" class="button" value="{$MOD.LBL_RESOURCES_ADD}" id="addResourceLine" />
+    <input type="button" class="button" value="{$RESOURCES_MOD.LBL_RESOURCES_ADD}" id="addResourceLine" />
 </div>
 <br>
 {literal}

--- a/modules/stic_Bookings/tpls/EditViewFooter.tpl
+++ b/modules/stic_Bookings/tpls/EditViewFooter.tpl
@@ -138,10 +138,10 @@
         </div>
         <div class="filter-actions grouped-buttons">
             <button id="loadCenterResourcesButton" type="button" class="button">
-                {$RESOURCES_MOD.LBL_ADD_BUTTON}
+                {$MOD.LBL_ADD_BUTTON}
             </button>
             <button id="resetResourcesButton" type="button" class="button">
-                {$RESOURCES_MOD.LBL_UNDO_BUTTON}
+                {$MOD.LBL_UNDO_BUTTON}
             </button>
             <button id="deleteResourcesButton" type="button" class="button">
                 {$APP.LBL_DELETE_BUTTON}
@@ -163,7 +163,7 @@
     </tr>
 </table>
 <div style="padding-top: 2px">
-    <input type="button" class="button" value="{$RESOURCES_MOD.LBL_RESOURCES_ADD}" id="addResourceLine" />
+    <input type="button" class="button" value="{$MOD.LBL_RESOURCES_ADD}" id="addResourceLine" />
 </div>
 <br>
 {literal}

--- a/modules/stic_Bookings/views/view.edit.php
+++ b/modules/stic_Bookings/views/view.edit.php
@@ -220,12 +220,20 @@ class stic_BookingsViewEdit extends ViewEdit
             jsLanguage::createModuleStringsCache($moduleName, $GLOBALS['current_language']);
         }
         echo getVersionedScript("cache/jsLanguage/{$moduleName}/{$GLOBALS['current_language']}.js", $GLOBALS['sugar_config']['js_lang_version']);
+        $moduleName = 'stic_Bookings';
+        if (!is_file("cache/jsLanguage/{$moduleName}/{$GLOBALS['current_language']}.js")) {
+            require_once 'include/language/jsLanguage.php';
+            jsLanguage::createModuleStringsCache($moduleName, $GLOBALS['current_language']);
+        }
+        echo getVersionedScript("cache/jsLanguage/{$moduleName}/{$GLOBALS['current_language']}.js", $GLOBALS['sugar_config']['js_lang_version']);
 
         global $mod_strings, $app_strings;
         SticViews::display($this);
         
-        $config_resource_fields = require 'modules/stic_Bookings/configResourceFields.php';
-        $config_place_fields = require 'modules/stic_Bookings/configPlaceFields.php';
+
+        require_once 'modules/stic_Bookings/Utils.php';
+        $config_resource_fields = stic_BookingsUtils::getConfigResourceFields();
+        $config_place_fields = stic_BookingsUtils::getConfigPlaceFields();
     
 
         global $sugar_config, $current_language, $app_list_strings, $current_user;
@@ -456,7 +464,7 @@ SCRIPT;
     {
         global $app_list_strings;
 
-        $config_resource_fields = require 'modules/stic_Bookings/configResourceFields.php';
+        $config_resource_fields = stic_BookingsUtils::getConfigResourceFields();
 
         $parsedResources = array();
         foreach ($resourcesBeanArray as $resourceBean) {

--- a/modules/stic_Bookings/views/view.edit.php
+++ b/modules/stic_Bookings/views/view.edit.php
@@ -213,6 +213,14 @@ class stic_BookingsViewEdit extends ViewEdit
     {
         require_once 'SticInclude/Utils.php';
 
+        // Load JS language file for Resources to get field labels in the editview
+        $moduleName = 'stic_Resources';
+        if (!is_file("cache/jsLanguage/{$moduleName}/{$GLOBALS['current_language']}.js")) {
+            require_once 'include/language/jsLanguage.php';
+            jsLanguage::createModuleStringsCache($moduleName, $GLOBALS['current_language']);
+        }
+        echo getVersionedScript("cache/jsLanguage/{$moduleName}/{$GLOBALS['current_language']}.js", $GLOBALS['sugar_config']['js_lang_version']);
+
         global $mod_strings, $app_strings;
         SticViews::display($this);
         

--- a/modules/stic_Bookings/views/view.edit.php
+++ b/modules/stic_Bookings/views/view.edit.php
@@ -280,6 +280,7 @@ class stic_BookingsViewEdit extends ViewEdit
         $config_place_fields_json = json_encode(array_keys($config_place_fields)); 
         $this->ss->assign('MOD', $mod_strings);
         $this->ss->assign('APP', $app_strings);
+        $this->ss->assign('RESOURCES_MOD', return_module_language($current_language, 'stic_Resources'));
 
         echo "<script>
             var config_resource_fields = $config_resource_fields_json;

--- a/modules/stic_Bookings_Calendar/tpls/filter.tpl
+++ b/modules/stic_Bookings_Calendar/tpls/filter.tpl
@@ -20,7 +20,7 @@
  * You can contact SinergiaTIC Association at email address info@sinergiacrm.org.
  *}
 <div class="filter-container">
-    <label for="filter-resources-label">{$MOD.LBL_FILTER_RESOURCES}</label>
+    <label for="filter-resources-label">{$RESOURCES_MOD.LBL_FILTER_RESOURCES}</label>
     <select name="filter-resources" id="filter-resources" class="filter-resources" multiple>
         <option value=""></option>
         {foreach from=$RESOURCESGROUP item=RESOURCES key=GROUP}

--- a/modules/stic_Bookings_Calendar/views/view.list.php
+++ b/modules/stic_Bookings_Calendar/views/view.list.php
@@ -90,6 +90,8 @@ class stic_Bookings_CalendarViewList extends ViewList
         $resources = stic_Bookings_CalendarUtils::getAllResources();
         $this->ss->assign('MOD', $mod_strings);
         $this->ss->assign('APP', $app_strings);
+        global $current_language;
+        $this->ss->assign('RESOURCES_MOD', return_module_language($current_language, 'stic_Resources'));
         $this->ss->assign('RESOURCESGROUP', $resources['resourcesArrayByGroup']);
 
         $resourcesArrayJson = json_encode($resources['resourcesArrayNoPlaces']);

--- a/modules/stic_Bookings_Places_Calendar/tpls/filters.tpl
+++ b/modules/stic_Bookings_Places_Calendar/tpls/filters.tpl
@@ -23,7 +23,7 @@
     <div class="filters-container">
         <div class="filter-row">
             <div class="filter-group">
-                <label for="stic_center_name">{$MOD.LBL_FILTERS_STIC_CENTER}</label>
+                <label for="stic_center_name">{$RESOURCES_MOD.LBL_CENTERS_FILTER}</label>
                 <div class="input-group">
                     <input type='text' class='form-control sqsEnabled' name='stic_center_name'
                         id='stic_center_name' autocomplete='off'
@@ -48,7 +48,7 @@
 
         <div class="filter-row">
             <div class="filter-group">
-                <label for="stic_resources_places_gender_list">{$MOD.LBL_FILTERS_STIC_PLACE_GENDER}</label>
+                <label for="stic_resources_places_gender_list">{$RESOURCES_MOD.LBL_GENDER}</label>
                 <select multiple id="stic_resources_places_gender_list" 
                         name="stic_resources_places_gender_list[]" 
                         tabindex="102">
@@ -59,7 +59,7 @@
 
         <div class="filter-row">
             <div class="filter-group">
-                <label for="stic_resources_places_type_list">{$MOD.LBL_FILTERS_STIC_PLACE_TYPE}</label>
+                <label for="stic_resources_places_type_list">{$RESOURCES_MOD.LBL_PLACE_TYPE}</label>
                 <select multiple id="stic_resources_places_type_list" 
                         name="stic_resources_places_type_list[]" 
                         tabindex="102">
@@ -70,7 +70,7 @@
 
         <div class="filter-row">
             <div class="filter-group">
-                <label for="stic_resources_places_users_list">{$MOD.LBL_FILTERS_STIC_PLACE_USER_TYPE}</label>
+                <label for="stic_resources_places_users_list">{$RESOURCES_MOD.LBL_USER_TYPE}</label>
                 <select multiple id="stic_resources_places_users_list" 
                         name="stic_resources_places_users_list[]" 
                         tabindex="102">

--- a/modules/stic_Bookings_Places_Calendar/views/view.list.php
+++ b/modules/stic_Bookings_Places_Calendar/views/view.list.php
@@ -93,6 +93,7 @@ class stic_Bookings_Places_CalendarViewList extends ViewList
         $sticPlacesType = $savedFilters['stic_resources_places_type_list']?? '';
         $sticPlacesGender = $savedFilters['stic_resources_places_gender_list']?? '';
 
+        $this->ss->assign('RESOURCES_MOD', return_module_language($current_language, 'stic_Resources'));
         $this->ss->assign('stic_center_id', $sticCenterId);
         $this->ss->assign('stic_center_name', $sticCenterName);
         $this->ss->assign('stic_resources_places_users_list', get_select_options_with_id($app_list_strings['stic_resources_places_users_list'], $sticPlacesUser ?? []));

--- a/modules/stic_Resources/language/ca_ES.lang.php
+++ b/modules/stic_Resources/language/ca_ES.lang.php
@@ -89,4 +89,8 @@ $mod_strings = array(
 
     // Camps de filtre en relacions molts a molts
     'LBL_STIC_RESOURCES_STIC_BOOKINGS_NAME' => 'Reserva',
+    'LBL_FILTER_RESOURCES' => 'Filtre de recursos',
+    'LBL_NUMBER_OF_PLACES' => 'Nombre de places',
+    'LBL_CENTERS_BUTTON' => 'Carrega els centres',
+    'LBL_CENTERS_FILTER' => 'Centre',
 );

--- a/modules/stic_Resources/language/en_us.lang.php
+++ b/modules/stic_Resources/language/en_us.lang.php
@@ -89,4 +89,8 @@ $mod_strings = array(
 
     // Many to Many filter fields
     'LBL_STIC_RESOURCES_STIC_BOOKINGS_NAME' => 'Booking',
+    'LBL_FILTER_RESOURCES' => 'Resources filter',
+    'LBL_NUMBER_OF_PLACES' => 'Number of places',
+    'LBL_CENTERS_BUTTON' => 'Load centers',
+    'LBL_CENTERS_FILTER' => 'Center',
 );

--- a/modules/stic_Resources/language/es_ES.lang.php
+++ b/modules/stic_Resources/language/es_ES.lang.php
@@ -89,4 +89,8 @@ $mod_strings = array(
 
     // Campos de filtro en relaciones muchos a muchos
     'LBL_STIC_RESOURCES_STIC_BOOKINGS_NAME' => 'Reserva',
+    'LBL_FILTER_RESOURCES' => 'Filtro de recursos',
+    'LBL_NUMBER_OF_PLACES' => 'Número de plazas',
+    'LBL_CENTERS_BUTTON' => 'Cargar centros',
+    'LBL_CENTERS_FILTER' => 'Centro',
 );

--- a/modules/stic_Resources/language/eu_ES.lang.php
+++ b/modules/stic_Resources/language/eu_ES.lang.php
@@ -89,4 +89,8 @@ $mod_strings = array(
 
     // Campos de filtro en relaciones muchos a muchos
     'LBL_STIC_RESOURCES_STIC_BOOKINGS_NAME' => 'Reserva',
+    'LBL_FILTER_RESOURCES' => 'Filtro de recursos',
+    'LBL_NUMBER_OF_PLACES' => 'Número de plazas',
+    'LBL_CENTERS_BUTTON' => 'Cargar centros',
+    'LBL_CENTERS_FILTER' => 'Centro',
 );

--- a/modules/stic_Resources/language/gl_ES.lang.php
+++ b/modules/stic_Resources/language/gl_ES.lang.php
@@ -89,4 +89,8 @@ $mod_strings = array(
 
     // Campos de filtro en relaciones muchos a muchos
     'LBL_STIC_RESOURCES_STIC_BOOKINGS_NAME' => 'Reserva',
+    'LBL_FILTER_RESOURCES' => 'Filtro de recursos',
+    'LBL_NUMBER_OF_PLACES' => 'Número de plazas',
+    'LBL_CENTERS_BUTTON' => 'Cargar centros',
+    'LBL_CENTERS_FILTER' => 'Centro',
 );


### PR DESCRIPTION
- Closes #1026 

## Description
En los calendarios y en el pie de las reservas se cargan los literales directamente del módulo de Recursos, garantizando así que se mantenga la coherencia de literales.

## Motivation and Context
Mantener la coherencia de literales en los distintos sitios en que aparecen.

## How To Test This
1.- Observar los literales que aparecen en reservas al seleccionar un centro para una reserva de plazas o en el calendario de reservas de plazas.
2.- Modificar alguno de estos literales vía estudio en el módulo de Recursos
3.- Observar que el literal se muestra modificado tanto en Recursos como en REservas como en el calendario de plazas

## A valorar
Se han incluído los distintos literales del pié de reservas en Recursos para no estar cogiendo un literal de aquí y uno de allí, pero quizás los que sólo se usan en Reservas deberían dejarse donde estaban.

