### PR TITLE
Hotfix - Recursos y reservas - Ocultar Plazas cuando Recursos está denegado en roles

### DIFF
--- a/custom/Extension/application/Ext/Include/SticModules.php
+++ b/custom/Extension/application/Ext/Include/SticModules.php
@@ -127,7 +127,6 @@ $beanList['stic_Signature_Log'] = 'stic_Signature_Log';
 $beanList['stic_Message_Marketing'] = 'stic_Message_Marketing';
 $beanList['stic_MessagesMan'] = 'stic_MessagesMan';
 $beanList['stic_Bookings_Places_Calendar'] = 'stic_Bookings_Places_Calendar';
-$beanList['stic_Places'] = 'stic_Places';
 $beanList['stic_Transactions'] = 'stic_Transactions';
 $beanList['stic_Financial_Products'] = 'stic_Financial_Products';
 $beanList['stic_Assets'] = 'stic_Assets';

--- a/modules/ACL/ACLController.php
+++ b/modules/ACL/ACLController.php
@@ -151,6 +151,20 @@ class ACLController
                 );
         }
 
+        // STIC-Custom 20260408 PCS - stic_Places is a submodule of stic_Resources - check resources permissions
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        if ($category === 'stic_Places') {
+            return ACLAction::userHasAccess(
+                $current_user->id,
+                'stic_Resources',
+                $action,
+                $type,
+                $is_owner,
+                $in_group
+            );
+        }
+        // END STIC-Custom
+        
         return ACLAction::userHasAccess($current_user->id, $category, $action, $type, $is_owner, $in_group);
     }
 
@@ -232,6 +246,20 @@ class ACLController
                 }
             }
         }
+
+        // STIC-Custom 20260408 PCS - stic_Places inherits from stic_Resources - check resources permissions
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        if (isset($compList['stic_Places'])) {
+            if (!isset($compList['stic_Resources']) || $actions['stic_Resources']['module']['access']['aclaccess'] < ACL_ALLOW_ENABLED) {
+                if ($by_value) {
+                    unset($moduleList[$compList['stic_Places']]);
+                } else {
+                    unset($moduleList['stic_Places']);
+                }
+            }
+        }
+        // END STIC-Custom
+
         if (isset($compList['Calendar']) &&
             !(ACLController::checkModuleAllowed('Calls', $actions)
                 || ACLController::checkModuleAllowed(

--- a/modules/ACL/ACLController.php
+++ b/modules/ACL/ACLController.php
@@ -152,7 +152,7 @@ class ACLController
         }
 
         // STIC-Custom 20260408 PCS - stic_Places is a submodule of stic_Resources - check resources permissions
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1043
         if ($category === 'stic_Places') {
             return ACLAction::userHasAccess(
                 $current_user->id,
@@ -164,7 +164,7 @@ class ACLController
             );
         }
         // END STIC-Custom
-        
+
         return ACLAction::userHasAccess($current_user->id, $category, $action, $type, $is_owner, $in_group);
     }
 
@@ -248,7 +248,7 @@ class ACLController
         }
 
         // STIC-Custom 20260408 PCS - stic_Places inherits from stic_Resources - check resources permissions
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1043
         if (isset($compList['stic_Places'])) {
             if (!isset($compList['stic_Resources']) || $actions['stic_Resources']['module']['access']['aclaccess'] < ACL_ALLOW_ENABLED) {
                 if ($by_value) {


### PR DESCRIPTION
- Closes #1042 
## Descripción
Plazas es un "pseudo-módulo" que hereda su funcionalidad de Recursos. Al denegar acceso a Recursos en los roles ACL, Plazas seguía apareciendo en el menú aunque no era accesible. Con los cambios de este PR:
- Si se deniega acceso a Recursos, Plazas debe ocultarse automáticamente del menú
- Los permisos de Plazas deben depender de Recursos (heredar su comportamiento)
## Pruebas
1. Verificar que Plazas aparece en el menú:
   - Iniciar sesión como admin
   - Confirmar que "Plazas" aparece en el menú principal
2. Verificar que al denegar Recursos se oculta Plazas:
   - Ir a Admin > Gestión de Roles
   - Crear un rol de prueba
   - En la lista de módulos, buscar "Recursos" y establecer "No accesible" (denegar acceso)
   - Guardar el rol
   - Asignar el rol a un usuario de prueba
   - Iniciar sesión con ese usuario
   - Confirmar que tanto "Recursos" como "Plazas" desaparecen del menú
3. Verificar que los permisos funcionan correctamente:
   - Con el rol de prueba (Recursos denegado), intentar acceder directamente a Plazas mediante URL (index.php?module=stic_Places)
   - Confirmar que se muestra error de acceso denegado
4. Verificar que al permitir Recursos también se permite Plazas:
   - Volver al rol de prueba
   - Cambiar "Recursos" a "Acceso"
   - Guardar
   - Confirmar que tanto Recursos como Plazas aparecen en el menú