### PR TITLE
Hotfix - Correos - Añadir propiedad related_fields en subject para su render en el Dashlet

### DIFF
--- a/include/Dashlets/DashletGeneric.php
+++ b/include/Dashlets/DashletGeneric.php
@@ -419,6 +419,29 @@ class DashletGeneric extends Dashlet
             }
 
             $this->columns = $dashletData[$this->seedBean->module_dir.'Dashlet']['columns'];
+
+            // STIC-Custom 20260424 ART - Ensure Emails dashlet subject column has required related_fields if the custom metadata is missing
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1045
+            if ($this->seedBean->module_dir === 'Emails' && isset($this->columns['subject'])) {
+                $requiredRelatedFields = [
+                    'id',
+                    'name',
+                    'status',
+                    'folder',
+                    'folder_type',
+                    'inbound_email_record',
+                    'uid',
+                    'msgno',
+                ];
+
+                $existingRelatedFields = $this->columns['subject']['related_fields'] ?? [];
+                if (!is_array($existingRelatedFields)) {
+                    $existingRelatedFields = [];
+                }
+                $mergedFields = array_merge($existingRelatedFields, $requiredRelatedFields);
+                $this->columns['subject']['related_fields'] = array_values(array_unique($mergedFields));
+            }
+            // END STIC-Custom
         }
     }
 

--- a/modules/Emails/metadata/dashletviewdefs.php
+++ b/modules/Emails/metadata/dashletviewdefs.php
@@ -118,8 +118,8 @@ $dashletData['EmailsDashlet']['searchFields'] = array (
       'width' => '10%',
       'default' => true,
       'name' => 'subject',
-      // STIC Custom 20260409 ART - Add related fields to the Emails Dashlet to be able to use them in the displaySubjectField function
-      // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+      // STIC-Custom 20260409 ART - Add related fields to the Emails Dashlet to be able to use them in the displaySubjectField function
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/1045
       'related_fields' =>
       array (
         0 => 'id',
@@ -131,7 +131,7 @@ $dashletData['EmailsDashlet']['searchFields'] = array (
         6 => 'uid',
         7 => 'msgno',
       ),
-      // END STIC Custom
+      // END STIC-Custom
     ),
     'date_sent_received' => 
     array (
@@ -167,11 +167,11 @@ $dashletData['EmailsDashlet']['searchFields'] = array (
     'from_addr_name' => 
     array (
       'type' => 'varchar',
-      // STIC Custom 20260409 ART - Get the label correctly
+      // STIC-Custom 20260409 ART - Get the label correctly
       // https://github.com/SinergiaTIC/SinergiaCRM/pull/
       // 'label' => 'from_addr_name',
       'label' => 'LBL_LIST_FROM_ADDR',
-      // END STIC Custom
+      // END STIC-Custom
       'width' => '10%',
       'default' => false,
       'name' => 'from_addr_name',
@@ -179,11 +179,11 @@ $dashletData['EmailsDashlet']['searchFields'] = array (
     'reply_to_addr' => 
     array (
       'type' => 'varchar',
-      // STIC Custom 20260409 ART - Get the label correctly
-      // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+      // STIC-Custom 20260409 ART - Get the label correctly
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/1045
       // 'label' => 'reply_to_addr',
       'label' => 'LBL_REPLY_TO_ADDRESS',
-      // END STIC Custom
+      // END STIC-Custom
       'width' => '10%',
       'default' => false,
       'name' => 'reply_to_addr',
@@ -191,11 +191,11 @@ $dashletData['EmailsDashlet']['searchFields'] = array (
     'to_addrs_names' => 
     array (
       'type' => 'varchar',
-      // STIC Custom 20260409 ART - Get the label correctly
-      // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+      // STIC-Custom 20260409 ART - Get the label correctly
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/1045
       // 'label' => 'to_addrs_names',
       'label' => 'LBL_TO_ADDRS',
-      // END STIC Custom
+      // END STIC-Custom
       'width' => '10%',
       'default' => false,
       'name' => 'to_addrs_names',
@@ -294,11 +294,11 @@ $dashletData['EmailsDashlet']['searchFields'] = array (
     'description' => 
     array (
       'type' => 'text',
-      // STIC Custom 20260409 ART - Get the label correctly
-      // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+      // STIC-Custom 20260409 ART - Get the label correctly
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/1045
       // 'label' => 'description',
       'label' => 'LBL_DESCRIPTION',
-      // END STIC Custom
+      // END STIC-Custom
       'sortable' => false,
       'width' => '10%',
       'default' => false,

--- a/modules/Emails/metadata/dashletviewdefs.php
+++ b/modules/Emails/metadata/dashletviewdefs.php
@@ -118,6 +118,20 @@ $dashletData['EmailsDashlet']['searchFields'] = array (
       'width' => '10%',
       'default' => true,
       'name' => 'subject',
+      // STIC Custom 20260409 ART - Add related fields to the Emails Dashlet to be able to use them in the displaySubjectField function
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+      'related_fields' =>
+      array (
+        0 => 'id',
+        1 => 'name',
+        2 => 'status',
+        3 => 'folder',
+        4 => 'folder_type',
+        5 => 'inbound_email_record',
+        6 => 'uid',
+        7 => 'msgno',
+      ),
+      // END STIC Custom
     ),
     'date_sent_received' => 
     array (
@@ -153,7 +167,11 @@ $dashletData['EmailsDashlet']['searchFields'] = array (
     'from_addr_name' => 
     array (
       'type' => 'varchar',
-      'label' => 'from_addr_name',
+      // STIC Custom 20260409 ART - Get the label correctly
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+      // 'label' => 'from_addr_name',
+      'label' => 'LBL_LIST_FROM_ADDR',
+      // END STIC Custom
       'width' => '10%',
       'default' => false,
       'name' => 'from_addr_name',
@@ -161,7 +179,11 @@ $dashletData['EmailsDashlet']['searchFields'] = array (
     'reply_to_addr' => 
     array (
       'type' => 'varchar',
-      'label' => 'reply_to_addr',
+      // STIC Custom 20260409 ART - Get the label correctly
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+      // 'label' => 'reply_to_addr',
+      'label' => 'LBL_REPLY_TO_ADDRESS',
+      // END STIC Custom
       'width' => '10%',
       'default' => false,
       'name' => 'reply_to_addr',
@@ -169,7 +191,11 @@ $dashletData['EmailsDashlet']['searchFields'] = array (
     'to_addrs_names' => 
     array (
       'type' => 'varchar',
-      'label' => 'to_addrs_names',
+      // STIC Custom 20260409 ART - Get the label correctly
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+      // 'label' => 'to_addrs_names',
+      'label' => 'LBL_TO_ADDRS',
+      // END STIC Custom
       'width' => '10%',
       'default' => false,
       'name' => 'to_addrs_names',
@@ -268,7 +294,11 @@ $dashletData['EmailsDashlet']['searchFields'] = array (
     'description' => 
     array (
       'type' => 'text',
-      'label' => 'description',
+      // STIC Custom 20260409 ART - Get the label correctly
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+      // 'label' => 'description',
+      'label' => 'LBL_DESCRIPTION',
+      // END STIC Custom
       'sortable' => false,
       'width' => '10%',
       'default' => false,


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/1044


## Description
Se ha comprobado que existe un bug donde el dashlet de correos si se hace alguna modificación en Estudio, tanto en la vista de lista del dashlet como en la búsqueda, el subject aparece Sin asunto, cuando realmente existe.
Después de aplicar algún cambio:
<img width="769" height="157" alt="Image" src="https://github.com/user-attachments/assets/360db64d-807a-4e8f-b387-a395bfdf2839" />

Antes de aplicar el cambio:
<img width="769" height="177" alt="Image" src="https://github.com/user-attachments/assets/5a6f1178-1b6c-4945-9ef9-1045cc3aead7" />

Se ha añadido la siguiente propiedad de `related_fields`: `id, name, status` para enlaces normales (DetailView / DetailDraftView). Y, si no hay id, usan `folder, folder_type, inbound_email_record, uid, msgno` para enlace IMAP. Además, de corregir los labels de algunos campos.

## How To Test This
1. Añadir el dashlet de Correos en el Inicio y comprobar que hay registros con Asunto.
2. Ir a Estudio, hacer algún cambio relacionado con el diseño del Dashlet de la vista de lista, guardar y publicar.
4. Comprobar que en el dashlet aparece el subject correctamente en lios registros.
5. Si se pincha en el subject del registro, comprobar que el asunto es el que aparece en su vista de detalle.

**Additional test**
1. Tener editado el dashlet antes de tener ejecutada la corrección (tener el custom/modules/Emails/metadata/dashletviewdefs.php creado).
2. Aplicar la corrección del PR.
3. Comprobar que funciona.
