### PR TITLE
Hotfix - Formularios Web Avanzados - No se muestran los emails como campos para detección de duplicados

### DIFF
--- a/modules/stic_AWF_Forms/Utils.php
+++ b/modules/stic_AWF_Forms/Utils.php
@@ -123,6 +123,11 @@ class stic_AWF_FormsUtils {
                         continue;
                     }
 
+                    $isEmail = self::isEmailField($arr, $fieldName);
+                    $merge_filter = $arr['merge_filter'] ?? ''; 
+                    if ($isEmail) {
+                        $merge_filter = 'enabled';
+                    }
                     // In source Module: Set fields information
                     if ($moduleOrigName == $moduleName) {
                         // Add field information
@@ -135,7 +140,7 @@ class stic_AWF_FormsUtils {
                             'default' => $arr['default'] ?? null,
                             'options' => $arr['options'] ?? '',
                             'module' => $arr['module'] ?? '',
-                            'merge_filter' => $arr['merge_filter'] ?? '', // 'enabled', 'disabled', 'selected', ''
+                            'merge_filter' => $merge_filter, // 'enabled', 'disabled', 'selected', ''
                             'inViews' => false,
                         ];
 
@@ -248,6 +253,22 @@ class stic_AWF_FormsUtils {
         });
 
         return $result;
+    }
+
+    /**
+     * Determines if a given field definition corresponds to a CRM Email field.
+     */
+    public static function isEmailField($fieldDef, $fieldName) 
+    {
+        if (isset($fieldDef['type']) && $fieldDef['type'] === 'email') {
+            return true;
+        }
+        if (isset($fieldDef['type']) && $fieldDef['type'] === 'varchar' && 
+            isset($fieldDef['source']) && $fieldDef['source'] === 'non-db' &&
+            strpos($fieldName, 'email') !== false) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/modules/stic_AWF_Forms/actions/Hook/SaveRecordAction.php
+++ b/modules/stic_AWF_Forms/actions/Hook/SaveRecordAction.php
@@ -26,6 +26,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
 }
 
 include_once "modules/stic_AWF_Forms/actions/coreActions.php";
+include_once "modules/stic_AWF_Forms/Utils.php";
 
 /**
  * SaveRecordAction
@@ -78,7 +79,7 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
                     $skipRule = false;
                     break; // Move to the next rule
                 }
-                if ($this->isEmailField($tempBean, $fieldName)) {
+                if (stic_AWF_FormsUtils::isEmailField($tempBean->field_defs[$fieldName], $fieldName)) {
                     $emailValues[] = $fieldValue;
                 } else {
                     $scalarFields[$fieldName] = $fieldValue;
@@ -254,24 +255,6 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
         return $actionResult;
     }
 
-    private function isEmailField($bean, $fieldName) 
-    {
-        if (isset($bean->field_defs[$fieldName]) &&
-            isset($bean->field_defs[$fieldName]['type']) &&
-            $bean->field_defs[$fieldName]['type'] === 'email') {
-            return true;
-        }
-        if (isset($bean->field_defs[$fieldName]) &&
-            isset($bean->field_defs[$fieldName]['type']) &&
-            $bean->field_defs[$fieldName]['type'] === 'varchar' && 
-            isset($bean->field_defs[$fieldName]['source']) &&
-            $bean->field_defs[$fieldName]['source'] === 'non-db' &&
-            strpos($fieldName, 'email') !== false) {
-            return true;
-        }
-        return false;
-    }
-
     /**
      * Fills a bean with all form data (overwrites).
      * @param SugarBean $bean The bean to update
@@ -293,7 +276,7 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
             $isRelate = ($fieldDef && isset($fieldDef['type']) && $fieldDef['type'] === 'relate' && !empty($fieldDef['id_name']));
             $targetField = $isRelate ? $fieldDef['id_name'] : $fieldName;
 
-            if ($this->isEmailField($bean, $targetField)) {
+            if (stic_AWF_FormsUtils::isEmailField($bean->field_defs[$targetField], $targetField)) {
                 if ($targetField === 'email') {
                     $targetField = 'email1';
                 }

--- a/modules/stic_AWF_Forms/stic_AWF.md
+++ b/modules/stic_AWF_Forms/stic_AWF.md
@@ -93,7 +93,8 @@ Aquí se decidirá qué información se quiere pedir a los usuarios. La selecci�
 
 * **Bloques de datos (enlazados)**: Son unidades de información que están conectadas directamente a un módulo específico del CRM (por ejemplo, "Personas", "Inscripciones" u "Organizaciones"). El propósito de estos bloques es que los datos recopilados sirvan para **crear o actualizar un registro real** dentro del sistema. Al estar enlazados a un módulo, permiten definir validaciones propias del CRM, configurar reglas para la detección y gestión de duplicados, y establecer campos de servidor u ocultos.
 
-* **Bloques de datos no enlazados**: Son contenedores diseñados para recopilar información en el formulario, pero que **no están vinculados a ningún módulo del CRM**. Como consecuencia, los datos introducidos quedarán guardados de forma independiente y exclusiva dentro del registro global de la "Respuesta". A diferencia de los bloques enlazados (que permiten mezclar campos del CRM con campos virtuales), **un bloque no enlazado solo puede contener campos no enlazados**. Son ideales para realizar encuestas, recopilar información temporal, hacer valoraciones o incluir casillas de aceptación de condiciones.
+* **Bloques de datos no enlazados**: Son contenedores diseñados para recopilar información en el formulario, pero que **no están vinculados a ningún módulo del CRM**. Como consecuencia, los datos introducidos quedarán guardados de forma independiente y exclusiva dentro del registro global de la "Respuesta". **Importante: Esta información no se volcará en la ficha de la Persona ni alterará ningún registro del CRM.** A diferencia de los bloques enlazados (que permiten mezclar campos del CRM con campos virtuales), un bloque no enlazado solo puede contener campos no enlazados. Son ideales para realizar encuestas, recopilar información temporal, hacer valoraciones o incluir casillas de aceptación de condiciones.
+
 
 #### Secciones de los Bloques de datos ####
 En el asistente, los bloques de datos están definidos en distintas secciones. Estas secciones pueden ser distintas según el tipo de bloque (enlazado o no enlazado).
@@ -104,14 +105,13 @@ Esta sección aparece en ambos bloques, enlazados y no enlazados
 Aquí se define qué datos componen el bloque. Al configurar los campos, se organiza la información en dos pestañas principales:
 
 * **Formulario**: Son los campos visibles que el visitante podrá rellenar. Por cada campo se puede configurar su etiqueta (nombre visible), si es obligatorio, el tipo de entrada (texto, desplegable, fecha, etc.) y el texto de fondo (*placeholder*).
+  * **Buena práctica de configuración:** Es altamente recomendable establecer siempre **al menos un campo como obligatorio** en cada bloque de datos enlazado (por ejemplo, el Nombre o el Email). Si todos los campos de un bloque se configuran como opcionales y el visitante los deja en blanco, el sistema procesará el bloque igualmente y creará un registro vacío en el CRM.
 
   * **Textos de ayuda y Enlaces**: Cada campo permite añadir un texto de ayuda o descripción para guiar al usuario. Además, el asistente incluye una herramienta específica para insertar fácilmente enlaces a páginas externas (ideales para acompañar a las casillas de aceptación de Políticas de Privacidad o Condiciones de Uso).
-  
-  * **Campos no enlazados (virtuales)**: Son campos que no alteran la base de datos principal, sino que su valor vive exclusivamente en el registro de la "Respuesta" enviada. Para agilizar la creación de formularios (especialmente cuando se configuran opciones personalizadas o controles de encuestas), **el asistente permite duplicar estos campos** con un solo clic, generando una copia exacta de toda su configuración. Existen en dos contextos:
+
+  * **Campos no enlazados (virtuales)**: Son campos que no alteran la base de datos principal, sino que su valor vive exclusivamente en el registro de la "Respuesta" enviada (es decir, **no se guardarán en el perfil de la persona ni en los módulos del CRM**). Para agilizar la creación de formularios (especialmente cuando se configuran opciones personalizadas o controles de encuestas), el asistente permite duplicar estos campos con un solo clic, generando una copia exacta de toda su configuración. Existen en dos contextos:
     1. **Dentro de un Bloque no enlazado**: Donde, por la naturaleza del bloque, todos los campos creados son obligatoriamente de este tipo.
-
     2. **Dentro de un Bloque enlazado**: Convivirán junto a los campos normales del CRM. Posibles usos: Son ideales para recabar información que solo tiene sentido en el contexto del envío (como una casilla de "Acepto las condiciones", comentarios adicionales o valoraciones temporales) evitando que estos datos "ensucien" la ficha de la Persona o Inscripción en el CRM.
-
   
   * **Validaciones**: Adicionalmente, se pueden vincular acciones de validación a campos específicos para garantizar la calidad de los datos introducidos. **Para agilizar la configuración, el sistema asigna validadores automáticamente** al detectar ciertos tipos de campos (por ejemplo, al añadir un campo de email, su validador se vincula solo). El sistema incluye un **amplio catálogo de validadores predefinidos**:
 


### PR DESCRIPTION
## Descripción
Los campos de tipo email son campos especiales relacionados. El motor para detectar duplicados con esos tipos de campos está realizado y validado: fue un error corregido durante el proceso de validación de Formularios Web Avanzados.

Ahora bien, en el asistente de creación de formularios no era posible seleccionar estos campos en la detección de duplicados ya que se aplicó un filtro para que únicamente se mostrasen en el listado de campos para la detección de duplicados los campos que tuvieran definido `merge_filter` como "enabled" o "selected". y no fuesen "relate"

## Solución
Se ha extraído la función de identificación de campos "email" a modules/stic_AWF_Forms/Utils.php, y si es un campo email, se modifica la información del campo a enviar al wizard, indicándole que tiene `merge_filter` definido como "enabled"

## Como probarlo
1. Crear un formulario web avanzado con un único bloque de datos de Personas
2. Añadir el campo "email" después del "Apellidos"
3. En detección de duplicados, seleccionar únicamente el campo "email"
4. Publicar el formulario
5. Llenar el formulario con apellidos inventados y un email registrado en el crm
Verificar:
1. Se ha podido definir el campo "email" en el wizard como detección de duplicados
2. Se ha procesado la respuesta correctamente. 
3. El vínculo de la respuesta indica que se refiere a una persona existente