### PR TITLE
Hotfix - General - Merge con conflictos que rompe la búsqueda global

### DIFF
--- a/modules/stic_AWF_Incoming_Events/metadata/SearchFields.php
+++ b/modules/stic_AWF_Incoming_Events/metadata/SearchFields.php
@@ -42,11 +42,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
-<<<<<<<< HEAD:modules/stic_AWF_Incoming_Events/metadata/SearchFields.php
 $module_name = 'stic_AWF_Incoming_Events';
-========
-$module_name = 'stic_AWF_Response_Details';
->>>>>>>> feature/advancedWebForms:modules/stic_AWF_Response_Details/metadata/SearchFields.php
 $searchFields[$module_name] = array(
     'name' => array('query_type' => 'default'),
     'current_user_only' => array(

--- a/modules/stic_AWF_Incoming_Events/metadata/metafiles.php
+++ b/modules/stic_AWF_Incoming_Events/metadata/metafiles.php
@@ -38,11 +38,7 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-<<<<<<<< HEAD:modules/stic_AWF_Incoming_Events/metadata/metafiles.php
 $module_name = 'stic_AWF_Incoming_Events';
-========
-$module_name = 'stic_AWF_Response_Details';
->>>>>>>> feature/advancedWebForms:modules/stic_AWF_Response_Details/metadata/metafiles.php
 $metafiles[$module_name] = array(
     'detailviewdefs' => 'modules/' . $module_name . '/metadata/detailviewdefs.php',
     'listviewdefs' => 'modules/' . $module_name . '/metadata/listviewdefs.php',

--- a/modules/stic_AWF_Incoming_Events/metadata/searchdefs.php
+++ b/modules/stic_AWF_Incoming_Events/metadata/searchdefs.php
@@ -38,11 +38,7 @@
  * display the words "Powered by SugarCRM" and "Supercharged by SuiteCRM".
  */
 
-<<<<<<<< HEAD:modules/stic_AWF_Incoming_Events/metadata/searchdefs.php
 $module_name = 'stic_AWF_Incoming_Events';
-========
-$module_name = 'stic_AWF_Response_Details';
->>>>>>>> feature/advancedWebForms:modules/stic_AWF_Response_Details/metadata/searchdefs.php
 $searchdefs[$module_name] = array(
     'templateMeta' => array(
         'maxColumns' => '3',


### PR DESCRIPTION
## Description
Se detecta que la búsqueda global no funciona.
Tras revisar el error se ve quehay 3 ficheros de AWF con conflictos de merge no resueltos. Se corrigen.

## Motivation and Context
Resolver el error en la búsuqeda global

## How To Test This
1.- Acceder a la búsueda global y comprobar que devuelve resultados

