### PR TITLE
Hotfix - Plantillas PDF - No mostrar todas las opciones de un campo multiselección al no seleccionar alguna

### DIFF
--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -35,8 +35,8 @@ class templateParser
         foreach ($bean_arr as $bean_name => $bean_id) {
             $focus = BeanFactory::getBean($bean_name, $bean_id);
 
-            // STIC Custom 20260420 - Avoid "Attempt to read property 'field_defs' on null" when bean is not found
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // STIC-Custom 20260420 ART - Avoid "Attempt to read property 'field_defs' on null" when bean is not found
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1059
             if (!is_object($focus) || empty($focus->field_defs)) {
                 continue;
             }
@@ -45,8 +45,8 @@ class templateParser
             $string = templateParser::parse_template_bean($string, $focus->table_name, $focus);
 
             foreach ($focus->field_defs as $focus_name => $focus_arr) {
-                // STIC Custom 20260420 - Avoid "Attempt to read property 'id_name' on null" when field definition is not correct
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // STIC-Custom 20260420 ART - Avoid "Attempt to read property 'id_name' on null" when field definition is not correct
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/1059
                 // if ($focus_arr['type'] == 'relate') {
                 //     if (isset($focus_arr['module']) && $focus_arr['module'] != '' && $focus_arr['module'] != 'EmailAddress') {
                 //         $idName = $focus_arr['id_name'];
@@ -126,8 +126,8 @@ class templateParser
                         $translatedVals = array();
 
                         foreach ($mVals as $mVal) {
-                            // STIC Custom 20260420 - Avoid translating full multienum list when value is empty
-                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                            // STIC-Custom 20260420 ART - Avoid translating full multienum list when value is empty
+                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1059
                             // If $mVal is empty, translate() can return the full options array
                             if ($mVal === '' || $mVal === null) {
                                 continue;

--- a/modules/AOS_PDF_Templates/templateParser.php
+++ b/modules/AOS_PDF_Templates/templateParser.php
@@ -34,16 +34,41 @@ class templateParser
     {
         foreach ($bean_arr as $bean_name => $bean_id) {
             $focus = BeanFactory::getBean($bean_name, $bean_id);
+
+            // STIC Custom 20260420 - Avoid "Attempt to read property 'field_defs' on null" when bean is not found
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            if (!is_object($focus) || empty($focus->field_defs)) {
+                continue;
+            }
+            // END STIC Custom
+
             $string = templateParser::parse_template_bean($string, $focus->table_name, $focus);
 
             foreach ($focus->field_defs as $focus_name => $focus_arr) {
-                if ($focus_arr['type'] == 'relate') {
-                    if (isset($focus_arr['module']) && $focus_arr['module'] != '' && $focus_arr['module'] != 'EmailAddress') {
-                        $idName = $focus_arr['id_name'];
-                        $relate_focus = BeanFactory::getBean($focus_arr['module'], $focus->$idName);
+                // STIC Custom 20260420 - Avoid "Attempt to read property 'id_name' on null" when field definition is not correct
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // if ($focus_arr['type'] == 'relate') {
+                //     if (isset($focus_arr['module']) && $focus_arr['module'] != '' && $focus_arr['module'] != 'EmailAddress') {
+                //         $idName = $focus_arr['id_name'];
+                //         $relate_focus = BeanFactory::getBean($focus_arr['module'], $focus->$idName);
 
-                        $string = templateParser::parse_template_bean($string, $focus_arr['name'], $relate_focus);
+                //         $string = templateParser::parse_template_bean($string, $focus_arr['name'], $relate_focus);
+                //     }
+                if (isset($focus_arr['type']) && $focus_arr['type'] == 'relate') {
+                    if (isset($focus_arr['module']) && $focus_arr['module'] != '' && $focus_arr['module'] != 'EmailAddress') {
+                        $idName = $focus_arr['id_name'] ?? '';
+
+                        if ($idName === '' || !isset($focus->{$idName})) {
+                            continue;
+                        }
+
+                        $relate_focus = BeanFactory::getBean($focus_arr['module'], $focus->{$idName});
+
+                        if (!empty($focus_arr['name'])) {
+                            $string = templateParser::parse_template_bean($string, $focus_arr['name'], $relate_focus);
+                        }
                     }
+                    // END STIC Custom
                 }
             }
         }
@@ -101,6 +126,14 @@ class templateParser
                         $translatedVals = array();
 
                         foreach ($mVals as $mVal) {
+                            // STIC Custom 20260420 - Avoid translating full multienum list when value is empty
+                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                            // If $mVal is empty, translate() can return the full options array
+                            if ($mVal === '' || $mVal === null) {
+                                continue;
+                            }
+                            // END STIC Custom
+
                             // STIC Custom 20250312 JBL - Avoid Warning: Array to string conversion
                             // https://github.com/SinergiaTIC/SinergiaCRM/pull/477
                             // $translatedVals[] = translate($field_def['options'], $focus->module_dir, $mVal);

--- a/modules/AOS_PDF_Templates/views/view.edit.php
+++ b/modules/AOS_PDF_Templates/views/view.edit.php
@@ -118,12 +118,23 @@ class AOS_PDF_TemplatesViewEdit extends ViewEdit
 
                         $options = json_encode($options_array);
 
-                        if ($module_arr['vname'] != 'LBL_DELETED') {
+                        // STIC Custom 20260420 - Avoid "Undefined array key 'vname'" when field definition is not correct
+                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                        // if ($module_arr['vname'] != 'LBL_DELETED') {
+                        if (isset($module_arr['vname']) && $module_arr['vname'] != 'LBL_DELETED') {
+                        // END STIC Custom
                             $options_array['$'.$module->table_name.'_'.$name] = translate($module_arr['vname'], $module->module_dir);
                             $fmod_options_array[$module_arr['vname']] = translate($relate_module->module_dir).' : '.translate($module_arr['vname'], $module->module_dir);
                         }
-                        $test = $module_arr['vname'];
-                        $insert_fields_js2 .="'$test':$options,\n";
+                        // STIC Custom 20260420 - Avoid "Undefined array key 'vname'" when field definition is not correct
+                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                        // $test = $module_arr['vname'];
+                        // $insert_fields_js2 .="'$test':$options,\n";
+                        if (isset($module_arr['vname'])) {
+                            $test = $module_arr['vname'];
+                            $insert_fields_js2 .="'$test':$options,\n";
+                        }
+                        // END STIC Custom
                     }
                 }
             }

--- a/modules/AOS_PDF_Templates/views/view.edit.php
+++ b/modules/AOS_PDF_Templates/views/view.edit.php
@@ -118,16 +118,16 @@ class AOS_PDF_TemplatesViewEdit extends ViewEdit
 
                         $options = json_encode($options_array);
 
-                        // STIC Custom 20260420 - Avoid "Undefined array key 'vname'" when field definition is not correct
-                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                        // STIC-Custom 20260420 ART - Avoid "Undefined array key 'vname'" when field definition is not correct
+                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1059
                         // if ($module_arr['vname'] != 'LBL_DELETED') {
                         if (isset($module_arr['vname']) && $module_arr['vname'] != 'LBL_DELETED') {
                         // END STIC Custom
                             $options_array['$'.$module->table_name.'_'.$name] = translate($module_arr['vname'], $module->module_dir);
                             $fmod_options_array[$module_arr['vname']] = translate($relate_module->module_dir).' : '.translate($module_arr['vname'], $module->module_dir);
                         }
-                        // STIC Custom 20260420 - Avoid "Undefined array key 'vname'" when field definition is not correct
-                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                        // STIC-Custom 20260420 ART - Avoid "Undefined array key 'vname'" when field definition is not correct
+                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1059
                         // $test = $module_arr['vname'];
                         // $insert_fields_js2 .="'$test':$options,\n";
                         if (isset($module_arr['vname'])) {


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/1056

## Description
Como se describe en el issue, se ha detectado que si tienes un campo de selección múltiple y lo incluyes en una plantilla PDF, si no se selecciona ninguna opción del campo, te las vuelca todas.

## Motivation and Context
Debe de no mostrar las ninguna opción si el registro no tiene seleccionada alguna opción. Además, al ir corrigiendo el issue, se han ido encontrando varios warnings que se han ido corrigiendo.
```
Warning: Undefined array key "vname" in /application/validaciones/modules/AOS_PDF_Templates/views/view.edit.php on line 121
Warning: Undefined array key "vname" in /application/validaciones/modules/AOS_PDF_Templates/views/view.edit.php on line 122
Warning: Undefined array key "vname" in /application/validaciones/modules/AOS_PDF_Templates/views/view.edit.php on line 123
Warning: Undefined array key "vname" in /application/validaciones/modules/AOS_PDF_Templates/views/view.edit.php on line 125
```

## How To Test This
1. Crear una plantilla PDF y añadir un campo multiseleccion.
2. Ir al módulo donde exista dicho campo multiseleccion.
3. Crear un registro sin seleccionar ninguna opcion de dicho campo y crear otro con varias opciones seleccionadas.
4. Generar el PDF del segundo registro y comprobar que las opciones seleccionadas aparecen.
5. Generar el PDF del primer registro y comprobar que no aparece ninguna opción al no haber seleccionado ninguna.