### PR TITLE
Hotfix - Plantillas PDF - {PAGENO} en encabezado

### DIFF
--- a/lib/PDF/TCPDF/SuiteTCPDF.php
+++ b/lib/PDF/TCPDF/SuiteTCPDF.php
@@ -49,6 +49,18 @@ class SuiteTCPDF extends TCPDF
      */
     public function setHtmlHeader($htmlHeader): void
     {
+        // STIC-Custom 20260421 ART - Allow to use {PAGENO} variable in the header
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        $htmlHeader = str_replace('{PAGENO}', $this->getAliasNumPage(), $htmlHeader);
+
+        $htmlHeader = preg_replace_callback(
+            '/{DATE\s+(.*?)}/',
+            static function ($matches) {
+                return date($matches[1]);
+            },
+            $htmlHeader
+        );
+        // END STIC-Custom
         $this->htmlHeader = $htmlHeader;
     }
 

--- a/lib/PDF/TCPDF/SuiteTCPDF.php
+++ b/lib/PDF/TCPDF/SuiteTCPDF.php
@@ -50,7 +50,7 @@ class SuiteTCPDF extends TCPDF
     public function setHtmlHeader($htmlHeader): void
     {
         // STIC-Custom 20260421 ART - Allow to use {PAGENO} variable in the header
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1066
         $htmlHeader = str_replace('{PAGENO}', $this->getAliasNumPage(), $htmlHeader);
 
         $htmlHeader = preg_replace_callback(


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/921

## Description
Como se describe en el issue, a raíz de una consulta del foro se comprueba que la variable {PAGENO} no funciona en el encabezado de las plantillas PDF. Sí que funciona en el pie de página.
No salta ningún error y el documento se genera perfectamente, salvo porque la variable no se sustituye por su valor, independientemente del número de páginas.

## Motivation and Context
Se ha añadido en lib/PDF/TCPDF/SuiteTCPDF.php, la sustitución de la variable en el Encabezado, setHtmlHeader, como se hace en la función setHtmlFooter.

## How To Test This
1. Ir a Plantilla PDF y crear una plantilla añadiendo {PAGENO} en las variables Encabezado y Pie de página.
2. Generar el PDF en el módulo correspondiente.
3. Comprobar que el PDF se ha generado correctamente y que en el encabezado aparece el número de página que corresponde, al igual que el Pie de página.