### PR TITLE
Hotfix - Mensjaes - Incluir tipo SMS en plantillas de email

### DIFF
--- a/custom/Extension/application/Ext/Language/ca_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/ca_ES.SticLang.php
@@ -4154,6 +4154,7 @@ $app_list_strings['emailTemplates_type_list_no_workflow']['notification'] = 'Not
 $app_list_strings['emailTemplates_type_list_no_workflow']['email'] = 'Correu electrònic';
 $app_list_strings['emailTemplates_type_list_no_workflow']['event'] = 'Esdeveniment';
 $app_list_strings['emailTemplates_type_list_no_workflow']['system'] = 'Sistema';
+$app_list_strings['emailTemplates_type_list_no_workflow']['sms'] = 'SMS';
 
 // Plantilles de Correu electrònic: Tipus de plantilla
 $app_list_strings['emailTemplates_type_list'][''] = '';

--- a/custom/Extension/application/Ext/Language/es_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/es_ES.SticLang.php
@@ -4158,6 +4158,7 @@ $app_list_strings['emailTemplates_type_list_no_workflow']['notification'] = 'Not
 $app_list_strings['emailTemplates_type_list_no_workflow']['email'] = 'Correo electrónico';
 $app_list_strings['emailTemplates_type_list_no_workflow']['event'] = 'Evento';
 $app_list_strings['emailTemplates_type_list_no_workflow']['system'] = 'Sistema';
+$app_list_strings['emailTemplates_type_list_no_workflow']['sms'] = 'SMS';
 
 // Plantillas de Correo electrónico: Tipos de plantilla
 $app_list_strings['emailTemplates_type_list'][''] = '';

--- a/custom/Extension/application/Ext/Language/eu_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/eu_ES.SticLang.php
@@ -4154,6 +4154,7 @@ $app_list_strings['emailTemplates_type_list_no_workflow']['notification'] = 'Not
 $app_list_strings['emailTemplates_type_list_no_workflow']['email'] = 'Correo electrónico';
 $app_list_strings['emailTemplates_type_list_no_workflow']['event'] = 'Evento';
 $app_list_strings['emailTemplates_type_list_no_workflow']['system'] = 'Sistema';
+$app_list_strings['emailTemplates_type_list_no_workflow']['sms'] = 'SMS';
 
 // Plantillas de Correo electrónico: Tipos de plantilla
 $app_list_strings['emailTemplates_type_list'][''] = '';

--- a/custom/Extension/application/Ext/Language/gl_ES.SticLang.php
+++ b/custom/Extension/application/Ext/Language/gl_ES.SticLang.php
@@ -4154,6 +4154,7 @@ $app_list_strings['emailTemplates_type_list_no_workflow']['notification'] = 'Not
 $app_list_strings['emailTemplates_type_list_no_workflow']['email'] = 'Correo electrónico';
 $app_list_strings['emailTemplates_type_list_no_workflow']['event'] = 'Evento';
 $app_list_strings['emailTemplates_type_list_no_workflow']['system'] = 'Sistema';
+$app_list_strings['emailTemplates_type_list_no_workflow']['sms'] = 'SMS';
 
 // Plantillas de Correo electrónico: Tipos de plantilla
 $app_list_strings['emailTemplates_type_list'][''] = '';


### PR DESCRIPTION
### Descripción 
Se restaura la entrada sms faltante en el dropdown emailTemplates_type_list_no_workflow para catalán (ca), español (es), gallego (gl) y vasco (eu)
Se ha añadido $`app_list_strings['emailTemplates_type_list_no_workflow']['sms'] = 'SMS';` en los archivos de idioma ca_ES, es_ES, eu_ES y gl_ES
### Pruebas
- Verificar que el tipo SMS aparece en el dropdown de tipo de plantilla para todos los idiomas afectados