### PR TITLE
Enhancement - General - Actualizar URL en dashlet SticNews

### DIFF
--- a/custom/modules/Home/Dashlets/SticNewsDashlet/SticNewsDashlet.php
+++ b/custom/modules/Home/Dashlets/SticNewsDashlet/SticNewsDashlet.php
@@ -36,12 +36,12 @@ class SticNewsDashlet extends Dashlet {
         $language = $GLOBALS['current_language'];
         switch($language) {
             case 'ca_ES':
-                $this->defaultURL = 'https://sinergiacrm.org/develop/ca/actualitat-sinergiacrm-news/';
+                $this->defaultURL = 'https://www.sinergiatic.org/actualitat-sinergiacrm-news/';
                 break;
             case 'es_ES':
             case 'en_us':
             default:
-                $this->defaultURL = 'https://sinergiacrm.org/develop/es/actualidad-sinergiacrm-news/';
+                $this->defaultURL = 'https://www.sinergiatic.org/es/actualidad-sinergiacrm-news/';
                 break;
         }
         $this->isConfigurable = false; // Dashlet won't be configurable


### PR DESCRIPTION
Se actualizan las URL del dashlet de SinergiaTIC, SticNews.

Queda pendiente aún el PR del cambio al nuevo dominio #808 

**Pruebas:**
- Verificar que el Dashlet muestra las noticias correctamente.