### PR TITLE
Hotfix - Tareas - Error BD en vista de lista

### DIFF
--- a/modules/Tasks/Task.php
+++ b/modules/Tasks/Task.php
@@ -186,7 +186,7 @@ class Task extends SugarBean
         }
 
         // STIC-Custom 20260424 ART - Fix parent name not showing in task list view when parent is deleted
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1077
         if (empty($this->parent_id)) {
             $this->parent_name = '';
             return;
@@ -201,7 +201,7 @@ class Task extends SugarBean
             $query = "SELECT first_name, last_name, assigned_user_id parent_name_owner from $parent->table_name where id = '$this->parent_id'";
         } else {
             // STIC-Custom 20260424 ART - Fix parent name not showing in task list view when parent is deleted
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1077
             // if (is_subclass_of($parent, 'File')) {
             if (is_subclass_of($parent, 'File') && $parent->table_name != 'notes') {
             // END STIC-Custom
@@ -229,7 +229,7 @@ class Task extends SugarBean
             $this->parent_name = $locale->getLocaleFormattedName(stripslashes($row['first_name']), stripslashes($row['last_name']));
         } else {
             // STIC-Custom 20260424 ART - Fix parent name not showing in task list view when parent is deleted
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1077
             // if (is_subclass_of($parent, 'File') && $row != null) {
             if (is_subclass_of($parent, 'File') && $parent->table_name != 'notes' && $row != null) {
             // END STIC-Custom

--- a/modules/Tasks/Task.php
+++ b/modules/Tasks/Task.php
@@ -185,6 +185,14 @@ class Task extends SugarBean
             return;
         }
 
+        // STIC-Custom 20260424 ART - Fix parent name not showing in task list view when parent is deleted
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        if (empty($this->parent_id)) {
+            $this->parent_name = '';
+            return;
+        }
+        // END STIC-Custom
+
         $beanType = $beanList[$this->parent_type];
         require_once($beanFiles[$beanType]);
         $parent = new $beanType();
@@ -192,7 +200,11 @@ class Task extends SugarBean
         if (is_subclass_of($parent, 'Person')) {
             $query = "SELECT first_name, last_name, assigned_user_id parent_name_owner from $parent->table_name where id = '$this->parent_id'";
         } else {
-            if (is_subclass_of($parent, 'File')) {
+            // STIC-Custom 20260424 ART - Fix parent name not showing in task list view when parent is deleted
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // if (is_subclass_of($parent, 'File')) {
+            if (is_subclass_of($parent, 'File') && $parent->table_name != 'notes') {
+            // END STIC-Custom
                 $query = "SELECT document_name, assigned_user_id parent_name_owner from $parent->table_name where id = '$this->parent_id'";
             } else {
                 $query = "SELECT name ";
@@ -216,7 +228,11 @@ class Task extends SugarBean
         if (is_subclass_of($parent, 'Person') && $row != null) {
             $this->parent_name = $locale->getLocaleFormattedName(stripslashes($row['first_name']), stripslashes($row['last_name']));
         } else {
-            if (is_subclass_of($parent, 'File') && $row != null) {
+            // STIC-Custom 20260424 ART - Fix parent name not showing in task list view when parent is deleted
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // if (is_subclass_of($parent, 'File') && $row != null) {
+            if (is_subclass_of($parent, 'File') && $parent->table_name != 'notes' && $row != null) {
+            // END STIC-Custom
                 $this->parent_name = $row['document_name'];
             } elseif ($row != null) {
                 $this->parent_name = stripslashes($row['name']);


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/1076

## Description
Este PR corrige dos errores en el método `fill_in_additional_parent_fields()` dentro de `modules/Tasks/Task.php` que provocaban un error en base de datos al cargar la vista de lista de Tareas:
1.  **`parent_id` vacío:** Cuando una tarea tiene un `parent_type` asignado pero el `parent_id` está vacío, el código ejecutaba una consulta SQL con `where id = ''`, lo que genera errores en ciertos entornos de BD. Se ha añadido una validación para retornar si el ID está vacío antes de lanzar la consulta.
2.  **Módulo Notes usa `document_name` incorrectamente:** El código comprueba si el módulo padre hereda de la clase `File` y, de ser así, intenta usar el campo `document_name`. Aunque `Notes` extiende de `File`, su tabla de base de datos utiliza la columna `name`. Esto generaba el error: `Unknown column 'document_name' in 'SELECT'`. Se ha excluido explícitamente el módulo `Notes` de esta condición para que use el campo `name` estándar.

## Motivation and Context
La vista de lista del módulo de Tareas se rompe completamente para usuarios que tienen visibilidad sobre registros que cumplen estas condiciones (especialmente tareas relacionadas con Notas). Corrige el error reportado en `suitecrm.log`:
`FATAL: Mysqli_query failed. ... MySQL error 1054: Unknown column 'document_name' in 'field list'`

## How To Test This
### Paso 1: Reproducir el error
Ejecutar los siguientes SQL para crear datos de prueba (sustituir `<user_id>` por el ID de un usuario):

```sql
-- Caso 1: Tarea con padre tipo Nota (provoca error de columna 'document_name')
INSERT INTO notes (id, name, date_entered, date_modified, deleted)
VALUES ('test-note-0001', 'Nota de prueba', NOW(), NOW(), 0);

INSERT INTO tasks (id, name, assigned_user_id, parent_type, parent_id, date_entered, date_modified, deleted)
VALUES ('test-task-0001', 'Tarea con padre Notes', '<user_id>', 'Notes', 'test-note-0001', NOW(), NOW(), 0);

-- Caso 2: Tarea con padre Notes pero ID vacío (provoca error de consulta vacía)
INSERT INTO tasks (id, name, assigned_user_id, parent_type, parent_id, date_entered, date_modified, deleted)
VALUES ('test-task-0002', 'Tarea con padre vacío', '<user_id>', 'Notes', '', NOW(), NOW(), 0);
```

1. Inicia sesión con el usuario asignado.
2. Accede al módulo de Tareas.
3. La vista de lista aparecerá con error de bbdd y en suitecrm.log se registrará un error indicando `Unknown column 'document_name' in 'SELECT'`
4. Probar con un usuario donde no se haya asignado en los sql y comprobar que se visualiza la vista de lista.

### Paso 2: Comprobar la solución
1. Cuando se haya aplicado la solución, reparar la instancia.
2. Iniciar sesión con el usuario asignado en los sql.
3. Ir al módulo de Tareas y comprobar que se carga la vista de lista y no aparece ningún error ni por pantalla ni en `suitecrm.log`
4. Comprobar que el campo de relación en la tarea muestra el nombre de la nota de forma correcta.