### PR TITLE
Hotfix - Formularios Web Avanzados - Traducción de mensaje de formulario corrupto

### DIFF
--- a/modules/stic_AWF_Forms/language/ca_ES.lang.php
+++ b/modules/stic_AWF_Forms/language/ca_ES.lang.php
@@ -92,6 +92,9 @@ $mod_strings = array (
   'LBL_WIZARD_FORM_EDIT_WARNING_RESPONSES' => "Hi ha %s respostes enregistrades: canviar l'estructura del formulari podria causar inconsistències.",
   'LBL_WIZARD_FORM_EDIT_WARNING_PROCEED' => 'En cas de voler realitzar canvis significatius es recomana valorar la possibilitat de duplicar el formulari.',
   
+  // Corrupted form warning
+  'LBL_WIZARD_FORM_CORRUPTED_WARNING_MESSAGE' => "⚠️ Error crític: No s'ha pogut carregar la configuració correctament. El formulari es mostrarà buit i s'ha bloquejat el desat automàtic per evitar pèrdues de dades.",
+
   // Steps
   'LBL_WIZARD_TITLE_STEP1' => 'Informació general',
   'LBL_WIZARD_DESC_STEP1' => 'Definició de les propietats generals del formulari.',

--- a/modules/stic_AWF_Forms/language/en_us.lang.php
+++ b/modules/stic_AWF_Forms/language/en_us.lang.php
@@ -93,7 +93,7 @@ $mod_strings = array (
   'LBL_WIZARD_FORM_EDIT_WARNING_PROCEED' => 'If you want to make significant changes, it is recommended to consider duplicating the form.',
   
   // Corrupted form warning
-  'LBL_WIZARD_FORM_CORRUPTED_WARNING_MESSAGE' => '⚠️ Critical Error: Configuration failed to load properly. The form will appear empty, and auto-save has been disabled to prevent data loss.',
+  'LBL_WIZARD_FORM_CORRUPTED_WARNING_MESSAGE' => '⚠️ Critical error: Configuration failed to load properly. The form will appear empty and auto-save has been disabled to prevent data loss.',
 
   // Steps
   'LBL_WIZARD_TITLE_STEP1' => 'General information',

--- a/modules/stic_AWF_Forms/language/en_us.lang.php
+++ b/modules/stic_AWF_Forms/language/en_us.lang.php
@@ -92,6 +92,9 @@ $mod_strings = array (
   'LBL_WIZARD_FORM_EDIT_WARNING_RESPONSES' => 'There are %s recorded responses: changing the form structure could cause inconsistencies.',
   'LBL_WIZARD_FORM_EDIT_WARNING_PROCEED' => 'If you want to make significant changes, it is recommended to consider duplicating the form.',
   
+  // Corrupted form warning
+  'LBL_WIZARD_FORM_CORRUPTED_WARNING_MESSAGE' => '⚠️ Critical Error: Configuration failed to load properly. The form will appear empty, and auto-save has been disabled to prevent data loss.',
+
   // Steps
   'LBL_WIZARD_TITLE_STEP1' => 'General information',
   'LBL_WIZARD_DESC_STEP1' => 'Definition of the form general properties.',

--- a/modules/stic_AWF_Forms/language/es_ES.lang.php
+++ b/modules/stic_AWF_Forms/language/es_ES.lang.php
@@ -91,6 +91,9 @@ $mod_strings = array (
   'LBL_WIZARD_FORM_EDIT_WARNING_PUBLIC' => 'Este formulario es público: alguien podría estar rellenándolo en este mismo momento.',
   'LBL_WIZARD_FORM_EDIT_WARNING_RESPONSES' => 'Hay %s respuestas registradas: cambiar la estructura del formulario podría causar inconsistencias.',
   'LBL_WIZARD_FORM_EDIT_WARNING_PROCEED' => 'En caso de querer realizar cambios significativos se recomienda valorar la posibilidad de duplicar el formulario.',
+
+  // Corrupted form warning
+  'LBL_WIZARD_FORM_CORRUPTED_WARNING_MESSAGE' => '⚠️ Error crítico: No se ha podido cargar la configuración correctamente. El formulario se mostrará vacío y el guardado automático se ha desactivado para evitar la pérdida de datos.',
   
   // Steps
   'LBL_WIZARD_TITLE_STEP1' => 'Información general',

--- a/modules/stic_AWF_Forms/language/eu_ES.lang.php
+++ b/modules/stic_AWF_Forms/language/eu_ES.lang.php
@@ -91,6 +91,9 @@ $mod_strings = array (
   'LBL_WIZARD_FORM_EDIT_WARNING_PUBLIC' => 'Este formulario es público: alguien podría estar rellenándolo en este mismo momento.',
   'LBL_WIZARD_FORM_EDIT_WARNING_RESPONSES' => 'Hay %s respuestas registradas: cambiar la estructura del formulario podría causar inconsistencias.',
   'LBL_WIZARD_FORM_EDIT_WARNING_PROCEED' => 'En caso de querer realizar cambios significativos se recomienda valorar la posibilidad de duplicar el formulario.',
+
+  // Corrupted form warning
+  'LBL_WIZARD_FORM_CORRUPTED_WARNING_MESSAGE' => '⚠️ Error crítico: No se ha podido cargar la configuración correctamente. El formulario se mostrará vacío y el guardado automático se ha desactivado para evitar la pérdida de datos.',
   
   // Steps
   'LBL_WIZARD_TITLE_STEP1' => 'Información general',

--- a/modules/stic_AWF_Forms/language/gl_ES.lang.php
+++ b/modules/stic_AWF_Forms/language/gl_ES.lang.php
@@ -91,6 +91,9 @@ $mod_strings = array (
   'LBL_WIZARD_FORM_EDIT_WARNING_PUBLIC' => 'Este formulario es público: alguien podría estar rellenándolo en este mismo momento.',
   'LBL_WIZARD_FORM_EDIT_WARNING_RESPONSES' => 'Hay %s respuestas registradas: cambiar la estructura del formulario podría causar inconsistencias.',
   'LBL_WIZARD_FORM_EDIT_WARNING_PROCEED' => 'En caso de querer realizar cambios significativos se recomienda valorar la posibilidad de duplicar el formulario.',
+
+  // Corrupted form warning
+  'LBL_WIZARD_FORM_CORRUPTED_WARNING_MESSAGE' => '⚠️ Error crítico: No se ha podido cargar la configuración correctamente. El formulario se mostrará vacío y el guardado automático se ha desactivado para evitar la pérdida de datos.',
   
   // Steps
   'LBL_WIZARD_TITLE_STEP1' => 'Información general',

--- a/modules/stic_AWF_Forms/ui/WizardView/js/wizard.js
+++ b/modules/stic_AWF_Forms/ui/WizardView/js/wizard.js
@@ -151,7 +151,7 @@ function wizardForm() {
         console.error("Error parsing JSON:", e);
         console.log("Bad JSON String:", jsonString);
         // Fallback to empty config if parsing fails: Lock save
-        alert("⚠️ Error crític: No s'ha pogut carregar la configuració correctament. El formulari es mostrarà buit i s'ha bloquejat el desat automàtic per evitar pèrdues de dades.");
+        alert(utils.translate('LBL_WIZARD_FORM_CORRUPTED_WARNING_MESSAGE'));
         this.formConfig = new stic_AwfConfiguration();
         this.isReadOnly = true;
       }


### PR DESCRIPTION
## Descripción
Este PR traduce el mensaje que se muestra en el caso que un Formulario Web Avanzado tenga la configuración corrupta. El mensaje que se mostraba estaba escrito directamente en catalán y no se usaba el sistema de etiquetas: 
<img width="963" height="255" alt="image" src="https://github.com/user-attachments/assets/3afd15ea-3a29-4ab0-840b-bfe4ab80faa7" />

## Como probarlo
1. Iniciar sesión en el crm con un idioma distinto al català.
2. Crear un Formulario Web Avanzado
3. Ir a la Base de datos, y editar el campo `configuration` de la tabla `stic_awf_forms` y eliminar el primer `{`
4. En el CRM, editar el formulario
5. Verificar que el mensaje que aparece no está en catalán.
