### PR TITLE
Hotfix - Formularios Web Avanzados - Corrección de fechas Inicio y Fin de formularios

### DIFF
--- a/modules/stic_AWF_Forms/controller.php
+++ b/modules/stic_AWF_Forms/controller.php
@@ -46,10 +46,12 @@ class stic_AWF_FormsController extends SugarController
                 }
                 $value = $data['bean'][$fieldName];
                 if (($fieldName === 'start_date' || $fieldName === 'end_date') && !empty($value)) {
-                    // Convert the frontend format to DB: 2026-02-28T14:30 -> 2026-02-28 14:30:00
-                    $value = str_replace('T', ' ', $value);
-                    if (strlen($value) === 16) { // YYYY-MM-DD HH:MM
-                        $value .= ':00';
+                    global $current_user;
+                    // Date is in user's local timezone and frontend format, convert to UTC for DB storage
+                    $dateObj = DateTime::createFromFormat('Y-m-d\TH:i', $value, new DateTimeZone($current_user->getPreference('timezone')));
+                    if ($dateObj !== false) {
+                        $dateObj->setTimezone(new DateTimeZone('UTC'));
+                        $value = $dateObj->format('Y-m-d H:i:s');
                     }
                 }
                 $bean->$fieldName = $value;


### PR DESCRIPTION
- Closes #1086

## Descripción
Tal y como se describe en el Issue #1086, las fechas de inicio y fin de publicación un formulario web avanzado se guardaban incrementadas en +2h cada vez que se guardaban. Esto era debido a que se guardaban en formato de Base de Datos pero no convertidas en UT: Al cargarlas el sistema suponía que estaban en UT y las convertía a local, y se guardaban de nuevo como si estuvieran en UT pero con el incremento de +2h


## Pruebas

1. Asegurarse de que el usuario del CRM esta en una zona horaria no-UTC (ej: Europa/Madrid, CEST UTC+2)
2. Ir a un Formulario Web Avanzado (stic_AWF_Forms)
3. Abrir el asistente de edición
4. Ir al Paso 5 "Resumen y publicación"
5. Establecer "Fecha de inicio" a, por ejemplo, 14:30 y "Fecha de finalización"
6. Finalizar
7. Comprobar la Vista de Detalle: las fechas son correctas
8. Editar de nuevo: el Paso 5 muestra correctamente las fechas
9. Guardar de nuevo
10. Comprobar la Vista de Detalle: la fecha es correcta
