### PR TITLE
Hotfix - Formularios Web Avanzados - Edición correcta de Cabecera y Pie de formularios

### DIFF
--- a/modules/stic_AWF_Forms/ui/WizardView/js/wizard.js
+++ b/modules/stic_AWF_Forms/ui/WizardView/js/wizard.js
@@ -68,38 +68,34 @@ function wizardForm() {
         this.formConfig.prepareProcessingMode(newMode);
       });
 
-      // Quill Component Editor
-      Alpine.data('quillEditor', (initialContent, onUpdate) => ({
+      // Quill Editor Modal Component
+      Alpine.data('quillEditorModal', () => ({
         editor: null,
-        content: initialContent,
-        initialized: false,
-        
+
         init() {
+          this.$watch('$store.htmlEditor.isOpen', (isOpen) => {
+            if (isOpen) {
+              this.$nextTick(() => this.initQuill());
+            } else if (this.editor) {
+              this.editor = null;
+              window._quillModalEditor = null;
+              const toolbar = this.$refs.editor.previousElementSibling;
+              if (toolbar && toolbar.classList.contains('ql-toolbar')) {
+                toolbar.remove();
+              }
+              this.$refs.editor.className = '';
+              this.$refs.editor.innerHTML = '';
+            }
+          });
+        },
+
+        initQuill() {
           if (typeof Quill === 'undefined') {
             console.error("Quill JS not loaded");
             return;
           }
 
-          if (this.$refs.editor.offsetHeight > 0) {
-            this.initQuill();
-            return;
-          }
-
-          const accordionCollapse = this.$refs.editor.closest('.accordion-collapse');
-          if (accordionCollapse) {
-            accordionCollapse.addEventListener('shown.bs.collapse', () => {
-              requestAnimationFrame(() => {
-                this.initQuill();
-              });
-            }, { once: true });
-          } else {
-            this.initQuill();
-          }
-        },
-
-        initQuill() {
-          // Initialize Quill to use inline styles
-          this.initialized = true;
+          this.$refs.editor.innerHTML = '';
 
           const Align = Quill.import('attributors/style/align');
           const Background = Quill.import('attributors/style/background');
@@ -115,13 +111,17 @@ function wizardForm() {
 
           const toolbarOptions = [
             [{'header': [1, 2, 3, false] }], 
-                
             ['bold', 'italic', 'underline', 'strike'],
             [{'list': 'ordered'}, { 'list': 'bullet' }],
             [{'align': [] }],
             [{'color': [] }, { 'background': [] }],
             ['link', 'image', 'clean'],
           ];
+
+          const content = Alpine.store('htmlEditor').content;
+          if (content) {
+            this.$refs.editor.innerHTML = content;
+          }
 
           this.editor = new Quill(this.$refs.editor, {
             theme: 'snow',
@@ -132,29 +132,58 @@ function wizardForm() {
             }
           });
 
-          // Load initial content
-          if (this.content) {
-            try {
-                this.editor.clipboard.dangerouslyPasteHTML(0, this.content);
-            } catch (e) {
-                console.warn("Error loading HTML in Quill:", e);
-                // Fallback: Plain text
-                this.editor.setText(this.content);
-            }
-          }
-
-          // Save to Model
-          this.editor.on('text-change', () => {
-            let html = this.editor.root.innerHTML;
-            if (html === '<p><br></p>') html = '';
-            this.content = html;
-            
-            if (typeof onUpdate === 'function') {
-              onUpdate(html);
-            }
-          });
+          window._quillModalEditor = this.editor;
         }
       }));
+
+      // Store for HTML Editor Modal
+      if (!Alpine.store('htmlEditor')) {
+        Alpine.store('htmlEditor', {
+          isOpen: false,
+          type: '',
+          content: '',
+          originalContent: '',
+
+          get title() {
+            if (this.type === 'header') {
+              return utils.translate('LBL_LAYOUT_HEADER');
+            }
+            return utils.translate('LBL_LAYOUT_FOOTER');
+          },
+
+          get formConfig() {
+            return window.alpineComponent.formConfig;
+          },
+
+          open(type) {
+            this.type = type;
+            this.content = type === 'header' ? this.formConfig.layout.header_html : this.formConfig.layout.footer_html;
+            this.originalContent = this.content;
+            this.isOpen = true;
+          },
+
+          save() {
+            const quill = window._quillModalEditor;
+            if (quill) {
+              let html = quill.root.innerHTML;
+              if (html === '<p><br></p>') html = '';
+              this.content = html;
+            }
+
+            if (this.type === 'header') {
+              this.formConfig.layout.header_html = this.content;
+            } else {
+              this.formConfig.layout.footer_html = this.content;
+            }
+
+            this.isOpen = false;
+          },
+
+          cancel() {
+            this.isOpen = false;
+          }
+        });
+      }
     },
 
     async initWizard() {

--- a/modules/stic_AWF_Forms/ui/WizardView/js/wizard.js
+++ b/modules/stic_AWF_Forms/ui/WizardView/js/wizard.js
@@ -72,6 +72,7 @@ function wizardForm() {
       Alpine.data('quillEditor', (initialContent, onUpdate) => ({
         editor: null,
         content: initialContent,
+        initialized: false,
         
         init() {
           if (typeof Quill === 'undefined') {
@@ -79,7 +80,27 @@ function wizardForm() {
             return;
           }
 
+          if (this.$refs.editor.offsetHeight > 0) {
+            this.initQuill();
+            return;
+          }
+
+          const accordionCollapse = this.$refs.editor.closest('.accordion-collapse');
+          if (accordionCollapse) {
+            accordionCollapse.addEventListener('shown.bs.collapse', () => {
+              requestAnimationFrame(() => {
+                this.initQuill();
+              });
+            }, { once: true });
+          } else {
+            this.initQuill();
+          }
+        },
+
+        initQuill() {
           // Initialize Quill to use inline styles
+          this.initialized = true;
+
           const Align = Quill.import('attributors/style/align');
           const Background = Quill.import('attributors/style/background');
           const Color = Quill.import('attributors/style/color');

--- a/modules/stic_AWF_Forms/ui/WizardView/steps/step4.html
+++ b/modules/stic_AWF_Forms/ui/WizardView/steps/step4.html
@@ -372,12 +372,16 @@
                                 </div>
                                 <div id="LayoutHeader_Content" class="accordion-collapse collapse" aria-labelledby="LayoutHeader_Header">
                                     <div id="LayoutHeader_Body" class="accordion-body"> 
-                                        <div class="bg-white text-dark"> 
-                                            <div x-data="quillEditor(formConfig.layout.header_html, (html) => formConfig.layout.header_html = html)">
-                                                <div class="bg-white border rounded overflow-hidden">
-                                                    <div x-ref="editor" style="height: 175px;"></div>
-                                                </div>
+                                        <div class="border rounded p-2 bg-light">
+                                            <div class="d-flex justify-content-end mb-2">
+                                                <button type="button" class="btn" :title="utils.translate('LBL_BUTTON_EDIT')" @click="$store.htmlEditor.open('header')">
+                                                    <span class="suitepicon suitepicon-action-edit"></span>
+                                                </button>
+                                                <button type="button" class="btn ms-2" :title="utils.translate('LBL_BUTTON_DELETE')" @click="formConfig.layout.header_html = ''">
+                                                    <span class="suitepicon suitepicon-action-delete"></span>
+                                                </button>
                                             </div>
+                                            <div x-html="formConfig.layout.header_html"></div>
                                         </div>
                                     </div>
                                 </div>
@@ -535,15 +539,19 @@
                                 </div>
                                 <div id="LayoutFooter_Content" class="accordion-collapse collapse" aria-labelledby="LayoutFooter_Header">
                                     <div id="LayoutFooter_Body" class="accordion-body"> 
-                                        <div class="bg-white text-dark"> 
-                                            <div x-data="quillEditor(formConfig.layout.footer_html, (html) => formConfig.layout.footer_html = html)">
-                                                <div class="bg-white border rounded overflow-hidden">
-                                                    <div x-ref="editor" style="height: 175px;"></div>
-                                                </div>
+                                        <div class="border rounded p-2 bg-light">
+                                            <div class="d-flex justify-content-end mb-2">
+                                                <button type="button" class="btn" :title="utils.translate('LBL_BUTTON_EDIT')" @click="$store.htmlEditor.open('footer')">
+                                                    <span class="suitepicon suitepicon-action-edit"></span>
+                                                </button>
+                                                <button type="button" class="btn ms-2" :title="utils.translate('LBL_BUTTON_DELETE')" @click="formConfig.layout.footer_html = ''">
+                                                    <span class="suitepicon suitepicon-action-delete"></span>
+                                                </button>
                                             </div>
+                                            <div x-html="formConfig.layout.footer_html"></div>
                                         </div>
                                     </div>
-                                </div>
+                                </div>                                
                             </div>
                         </div>
                     </div>
@@ -578,6 +586,28 @@
 
                     </div>
                 </template>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal: Edit Header/Footer HTML -->
+    <div x-show="$store.htmlEditor.isOpen" x-cloak class="custom-modal-wrapper">
+        <div class="custom-modal-backdrop" @click="$store.htmlEditor.cancel()"></div>
+        <div class="custom-modal-dialog" role="dialog" aria-modal="true" style="max-width: 900px;">
+            <div class="custom-modal-content">
+                <div class="custom-modal-header">
+                    <h3 class="modal-title" x-text="$store.htmlEditor.title"></h3>
+                    <button type="button" class="btn-close" @click="$store.htmlEditor.cancel()"></button>
+                </div>
+                <div class="custom-modal-body">
+                    <div x-data="quillEditorModal()">
+                        <div x-ref="editor" style="min-height: 300px;"></div>
+                    </div>
+                </div>
+                <div class="custom-modal-footer">
+                    <button type="button" class="col-2 btn btn-secondary" @click="$store.htmlEditor.cancel()" x-text="utils.translate('LBL_CANCEL_BUTTON_LABEL')"></button>
+                    <button type="button" class="col-2 btn btn-primary" @click="$store.htmlEditor.save()" x-text="utils.translate('LBL_SAVE_BUTTON_LABEL')"></button>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
- Closes #1084

## Descripción
Tal y como se describe en el issue #1084, si se indicaba la Cabecera/Pie de un formulario, no era posible editarlo. El problema residía en cómo el editor de HTML usado (Quill) se inicializaba cuando el acordeón al que pertenecía estaba colapsado, y por tanto el editor no tenía dimensiones.

La solución implementada evita la inicialización de Quill sin dimensiones:
1. En el acordeón de la Cabecera y Pie se muestra el html final
2. Se añaden botones de edición y eliminación de Cabecera y Pie
3. Al editar la Cabecera o Pie, se muestra un modal con el editor

## Pruebas
1. Crear un Formulario Web Avanzado
2. Abrir las herramientas para desarrolladores del navegador, para ver la consola javascript
3. En el paso de Maquetación, añadir una cabecera y un pie del Formulario
4. Previsualizar el formulario y verificar que se ven correctamente la cabecera y el pie
5. Modificar la cabecera y el pie
6. Verificar que se han modificado la cabecera y el pie del formulario
7. Verificar que no aparece ningún error javascript en la consola