### PR TITLE
Hotfix - Formularios Web Avanzados - Substitución de variables de plantillas de email con registros "ignorados" por duplicado

### DIFF
--- a/modules/stic_AWF_Forms/core/stic_AWFUtils.php
+++ b/modules/stic_AWF_Forms/core/stic_AWFUtils.php
@@ -656,8 +656,8 @@ class stic_AWFUtils {
         $loadedModules = array_map(function($b) { return $b->module_dir; }, $beansForTemplate);
         foreach ($context->actionResults as $result) {
             foreach ($result->modifiedBeans as $modBean) {
-                // Ignore skipped beans to avoid send data that is not in the CRM
-                if ($modBean->modificationType === BeanModificationType::SKIPPED) continue;
+                // Ignore Metadata entries wich represent action logs not CRM records
+                if ($modBean->modificationType === BeanModificationType::METADATA) continue;
 
                 // Ignore beans from modules that are already loaded to avoid unpredictable overwrites in the template parser
                 if (in_array($modBean->moduleName, $loadedModules)) continue;


### PR DESCRIPTION
- Closes #1090

## Descripción
Tal y como se describe en #1090, existía una exclusión en la substitución de variables de las plantillas de email que evitaba que se incluyeran los Beans que se habían detectado como "duplicado" y a su vez tenían la acción de "Ignorar" asociada en caso de duplicado.

Este PR soluciona la exclusión errónea

## Pruebas
1. Crear un formulario web avanzado con un bloque de datos del módulo Personas
2. Configurar detección de duplicados en el bloque con acción "Ignorar"
3. Añadir una acción "Envía un correo a una dirección" con plantilla que use variables de Persona
4. Enviar el formulario con datos que coincidan con una Persona existente en el CRM (duplicado)
5. El correo recibido tiene las variables de la Persona bien substituídas