### PR TITLE
Hotfix - Formularios Web Avanzados - Mostrar módulos correctamente a usuarios no administradores

### DIFF
--- a/modules/stic_AWF_Forms/Utils.php
+++ b/modules/stic_AWF_Forms/Utils.php
@@ -432,7 +432,7 @@ class stic_AWF_FormsUtils {
      * }
      */
     public static function getEnabledModules() {
-        global $app_list_strings;
+        global $app_list_strings, $beanList;
 
         // Get Enabled Modules
         require_once("modules/MySettings/TabController.php");
@@ -441,12 +441,15 @@ class stic_AWF_FormsUtils {
         
         $enabled = [];
         foreach ($tabs[0] as $key=>$value) {
+            if (!isset($beanList[$key])) {
+                continue;
+            }
             $text = translate($key);
             $textSingular = $app_list_strings['moduleListSingular'][$key] ?? $text;
             $enabled[$key] = ["name" => $key, "text" => $text, "textSingular" => $textSingular, "inStudio" => false, "icon" => ""];
         }
 
-        // Fill inStudio information
+        // Fill inStudio information (only for admin/developer users)
         require_once 'modules/ModuleBuilder/Module/StudioBrowser.php';
         $sb = new StudioBrowser();
         $nodes = $sb->getNodes();
@@ -457,16 +460,12 @@ class stic_AWF_FormsUtils {
             }
         }
 
-        $result = array_filter($enabled, function($item) {
-            return isset($item['inStudio']) && $item['inStudio'] == true;
-        });
-
         // Sort modules by text
-        uasort($result, function($a, $b) {
+        uasort($enabled, function($a, $b) {
             return strcmp($a['text'], $b['text']);
         });
 
-        return $result;
+        return $enabled;
     }
 
     /**

--- a/modules/stic_AWF_Forms/Utils.php
+++ b/modules/stic_AWF_Forms/Utils.php
@@ -449,7 +449,7 @@ class stic_AWF_FormsUtils {
             $enabled[$key] = ["name" => $key, "text" => $text, "textSingular" => $textSingular, "inStudio" => false, "icon" => ""];
         }
 
-        // Fill inStudio information (only for admin/developer users)
+        // Complete information from Studio
         require_once 'modules/ModuleBuilder/Module/StudioBrowser.php';
         $sb = new StudioBrowser();
         $nodes = $sb->getNodes();


### PR DESCRIPTION
- Closes #1071

## Descripción
Tal y como se describe en #1071, a los usuarios no administradores con acceso al módulo de Formularios Web Avanzados no les aparecía ningún módulo al crear un Bloque de Datos enlazado.
Esto era debido al filtro demasiado restrictivo que se realizaba de los módulos a incluir: 
- Se obtenían los módulos visibles para el usuario actual
- Se filtraban aquellos en que el usuario actual tenía permisos totales desde el punto de vista del Module Builder (en la práctica, administrador) 

Este último filtro no era necesario ya que no se modifica ese módulo (tal y como sí se hace en estudio)

Se ha eliminado el filtrado de los módulos que el usuario "vería en Estudio"

## Pruebas
1. Definir un usuario no administrador con acceso al módulo de Formularios Web Avanzados
2. Iniciar sesión con ese usuario
3. Crear o editar un Formulario Web Avanzado
4. En el paso 2 del asistente, intentar añadir un Bloque de datos (normal)
5. Observar que en el desplegable de módulos aparecen los módulos visibles para el usuario
