### PR TITLE
Hotfix - Formularios Web Avanzados - Visualización correcta del nombre en la edición si tiene apóstrofes

### DIFF
--- a/modules/stic_AWF_Forms/views/view.edit.php
+++ b/modules/stic_AWF_Forms/views/view.edit.php
@@ -117,9 +117,11 @@ class stic_AWF_FormsViewEdit extends ViewEdit
         $beanArray = $this->bean->toArray();
         $beanArray['assigned_user_id'] = $this->bean->assigned_user_id;
         $beanArray['assigned_user_name'] = $this->bean->assigned_user_name;
-        // Decode HTML in PHP to pass pure JSON to JS and avoid breaking escapes (\").
-        if (!empty($this->bean->configuration)) {
-            $beanArray['configuration'] = html_entity_decode($this->bean->configuration, ENT_QUOTES, 'UTF-8');
+        // Decode HTML entities in all string values to pass pure JSON to JS
+        foreach ($beanArray as $key => $value) {
+            if (is_string($value)) {
+                $beanArray[$key] = html_entity_decode($value, ENT_QUOTES, 'UTF-8');
+            }
         }
         $this->ss->assign('beanJson', json_encode($beanArray));
 


### PR DESCRIPTION
- Closes #1072

## Descripción
Tal y como se describe en #1072, si a un Formulario Web Avanzado se le asignaba un nombre con apóstrofes, éste al volverse a editar aparecíac con `&#039;` en vez del apóstrofe.

Esto era causado porqué no se aplicaba `html_entity_decode()` a los campos de tipo texto: únicamente se aplicaba al campo `configuration`, y no a `name` ni a `description`.

En las vistas de lista y detalle, las entidades HTML se renderizan por el navegador como parte del HTML, por lo que `&#039;` se muestra correctamente como `'`. Pero en el asistente de edición, los valores pasan por JSON/JavaScript, que no interpreta entidades HTML.

## Pruebas
1. Crear un Formulario Web Avanzado con el nombre `Formulari d'inscripció assemblea` y guardarlo
2. Editar de nuevo el formulario
3. Verificar que el nombre que aparece en el campo Nombre es: `Formulari d'inscripció assemblea` 