### PR TITLE
Hotfix - Formularios Web Avanzados - Duplicar Formularios

### DIFF
--- a/modules/stic_AWF_Forms/stic_AWF_Forms.php
+++ b/modules/stic_AWF_Forms/stic_AWF_Forms.php
@@ -71,5 +71,23 @@ class stic_AWF_Forms extends Basic
 
         return false;
     }
-	
+
+    public function save($check_notify = false)
+    {
+        if ($this->new_with_id && empty($this->fetched_row['id'])) {
+            $this->reset_analytics_and_public_url();
+        }
+
+        return parent::save($check_notify);
+    }
+
+    public function reset_analytics_and_public_url()
+    {
+        $this->analytics_views = 0;
+        $this->analytics_blocked = 0;
+        $this->analytics_submissions = 0;
+        $this->analytics_spam = 0;
+        $this->analytics_referrers = '';
+        $this->public_url = '';
+    }
 }

--- a/modules/stic_AWF_Forms/views/view.edit.php
+++ b/modules/stic_AWF_Forms/views/view.edit.php
@@ -73,17 +73,30 @@ class stic_AWF_FormsViewEdit extends ViewEdit
 
         SticViews::display($this);
 
-        // Assign current user to assifned user if new record
-        if (empty($this->bean->id) && empty($this->bean->assigned_user_id)) {
+        /** @var stic_AWF_Forms $bean */
+        $formBean = $this->bean;
+
+        // Handle duplicate: clear ID so the wizard creates a new record
+        $isDuplicate = !empty($_REQUEST['isDuplicate']) && $_REQUEST['isDuplicate'] === 'true';
+        if ($isDuplicate) {
+            $formBean->id = '';
+            $formBean->date_entered = '';
+            $formBean->date_modified = '';
+            $formBean->status = 'draft';
+            $formBean->reset_analytics_and_public_url();
+        }
+
+        // Assign current user to assigned user if new record
+        if (empty($formBean->id) && empty($formBean->assigned_user_id)) {
             global $current_user;
-            $this->bean->assigned_user_id = $current_user->id;
-            $this->bean->assigned_user_name = $current_user->name ?? $current_user->user_name; // Nom complet o login
+            $formBean->assigned_user_id = $current_user->id;
+            $formBean->assigned_user_name = $current_user->name ?? $current_user->user_name; // Name or username
         }
 
         $responseCount = 0;
-        if (!empty($this->bean->id)) {
+        if (!empty($formBean->id)) {
             $db = DBManagerFactory::getInstance();
-            $formId = $db->quote($this->bean->id);
+            $formId = $db->quote($formBean->id);
 
             $query = "SELECT count(*) FROM stic_awf_forms_stic_awf_responses_c 
                       WHERE stic_awf_forms_stic_awf_responsesforms_ida = '$formId' 
@@ -93,7 +106,7 @@ class stic_AWF_FormsViewEdit extends ViewEdit
         }
         $warnings = [];
         $msgWarnings = "";
-        if ($this->bean->status === 'public') {
+        if ($formBean->status === 'public') {
             $warnings[] = "\t· " . translate('LBL_WIZARD_FORM_EDIT_WARNING_PUBLIC', 'stic_AWF_Forms');
         }
         if ($responseCount > 0) {
@@ -114,12 +127,12 @@ class stic_AWF_FormsViewEdit extends ViewEdit
         $this->ss->assign('msgWarnings', $msgWarnings);
         $this->ss->assign('isAdminUser', $GLOBALS['current_user']->is_admin ? true : false);
 
-        $beanArray = $this->bean->toArray();
-        $beanArray['assigned_user_id'] = $this->bean->assigned_user_id;
-        $beanArray['assigned_user_name'] = $this->bean->assigned_user_name;
+        $beanArray = $formBean->toArray();
+        $beanArray['assigned_user_id'] = $formBean->assigned_user_id;
+        $beanArray['assigned_user_name'] = $formBean->assigned_user_name;
         // Decode HTML in PHP to pass pure JSON to JS and avoid breaking escapes (\").
-        if (!empty($this->bean->configuration)) {
-            $beanArray['configuration'] = html_entity_decode($this->bean->configuration, ENT_QUOTES, 'UTF-8');
+        if (!empty($formBean->configuration)) {
+            $beanArray['configuration'] = html_entity_decode($formBean->configuration, ENT_QUOTES, 'UTF-8');
         }
         $this->ss->assign('beanJson', json_encode($beanArray));
 


### PR DESCRIPTION
- Closes #1074

## Descripción
Tal y como se describe en #1074, el duplicado de Formularios Web Avanzados no funcionaba correctamente: 
1. La acción "Duplica" de la vista de detalle no duplicaba el formulario
2. La "duplicación y actualización masiva" desde la vista de lista no reseteaba las estadísticas del nuevo formulario

Mediante este PR se solucionan ambos problemas:
1. La acción "Duplica" edita un nuevo formulario partiendo del formulario de la vista de detalle, pero: Reseteando las estadísticas y poníendolo en estado "borrador"
2. La "duplicación y actualización masiva" duplica el formulario reseteando las estadísticas del nuevo formulario

## Pruebas
1. Crear y publicar un Formulario Web Avanzado
2. Visitarlo y responderlo, para registrar respuestas al formulario
3. En la vista de Detalle del formulario, Duplicarlo
4. Cambiar el nombre del formulario
5. Verificar que se ha creado una copia sin estadísticas de uso y se ha modificado el formulario copiado
6. Desde el listado, duplicar el formulario con "Duplicado y Actualización Masiva"
7. Verificar que el formulario duplicado tiene reseteadas las estadísticas de uso