### PR TITLE
Hotfix - General - Corrección en vista de Lista al filtrar por "relacionado con" una "tarea de proyecto"

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3897,7 +3897,7 @@ class SugarBean
             if ($data['type'] == 'parent') {
                 //See if we need to join anything by inspecting the where clause
                 // STIC-Custom 20260504 JBL - Fix regex to support table names with underscores (e.g. project_task)
-                // ttps://github.com/SinergiaTIC/SinergiaCRM/pull/???
+                // ttps://github.com/SinergiaTIC/SinergiaCRM/pull/1100
                 // Old regex only allowed one optional underscore, causing ProjectTask_project_task
                 // to be parsed as module=ProjectTask_project, table=task (wrong)
                 // $match = preg_match(

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -3896,11 +3896,21 @@ class SugarBean
             //Parent Field
             if ($data['type'] == 'parent') {
                 //See if we need to join anything by inspecting the where clause
+                // STIC-Custom 20260504 JBL - Fix regex to support table names with underscores (e.g. project_task)
+                // ttps://github.com/SinergiaTIC/SinergiaCRM/pull/???
+                // Old regex only allowed one optional underscore, causing ProjectTask_project_task
+                // to be parsed as module=ProjectTask_project, table=task (wrong)
+                // $match = preg_match(
+                //     '/(^|[\s(])parent_([a-zA-Z]+_?[a-zA-Z]+)_([a-zA-Z]+_?[a-zA-Z]+)\.name/',
+                //     $where,
+                //     $matches
+                // );
                 $match = preg_match(
-                    '/(^|[\s(])parent_([a-zA-Z]+_?[a-zA-Z]+)_([a-zA-Z]+_?[a-zA-Z]+)\.name/',
+                    '/(^|[\s(])parent_([a-zA-Z]+?)_([a-zA-Z]+(?:_[a-zA-Z]+)*)\.name/',
                     $where,
                     $matches
                 );
+                // END STIC-Custom
                 if ($match) {
                     $joinTableAlias = 'jt' . $jtcount;
                     $joinModule = $matches[2];


### PR DESCRIPTION
- Closes #593 

## Descripción
Tal y como se describe en #593, al aplicar un filtro en una vista lista por un campo "relacionado con" y escoger una "tarea de proyecto", se producía un error fatal de PHP y no mostraba el listado. 
La expresión regular en `data/SugarBean.php:3900` no soportaba nombres de tabla con guión bajo. El nombre de tabla de ProjectTask es project_task, que contiene un guión bajo. La regex anterior solo permitía un guión bajo opcional entre segmentos, por lo que parseaba incorrectamente

## Pruebas
1. Ir al listado del módulo Llamadas (o cualquier módulo con campo "Relacionado con" en filtros)
2. Filtrar indicando en "Relacionado con" el módulo "Tarea de proyecto" y seleccionar una tarea
3. Verificar que el listado aparece bien filtrado y no se produce ningún error
