### PR TITLE
Hotfix  - Flujos de trabajo - Corregir error al modificar registros en tabla _cstm

### DIFF
--- a/modules/AOW_Actions/actions/actionCreateRecord.php
+++ b/modules/AOW_Actions/actions/actionCreateRecord.php
@@ -475,7 +475,19 @@ class actionCreateRecord extends actionBase
         // STIC#960
         $record->not_use_rel_in_req = true;
         // END STIC-Custom
+
+        // STIC-Custom 20250707 JBL - Fix for Issue #1106: Preserve date_entered after save
+        // When saving existing records, date_entered gets unset in SugarBean::save()
+        // We need to preserve it to avoid losing the audit timestamp
+        $oldDateEntered = $record->date_entered;
+        // END STIC Custom
         $record->save($check_notify);
+
+        // STIC-Custom 20250707 JBL - Restore date_entered after save if it was cleared
+        if ($record->id && empty($record->date_entered) && !empty($oldDateEntered)) {
+            $record->date_entered = $oldDateEntered;
+        }
+        // END STIC Custom
 
         if ($was_deleted) {
             $record->mark_deleted($record->id);

--- a/modules/AOW_Actions/actions/actionCreateRecord.php
+++ b/modules/AOW_Actions/actions/actionCreateRecord.php
@@ -476,18 +476,20 @@ class actionCreateRecord extends actionBase
         $record->not_use_rel_in_req = true;
         // END STIC-Custom
 
-        // STIC-Custom 20250707 JBL - Fix for Issue #1106: Preserve date_entered after save
+        // STIC-CUSTOM 20250707 - JCH - Fix for Issue #1106: Preserve date_entered after save
         // When saving existing records, date_entered gets unset in SugarBean::save()
         // We need to preserve it to avoid losing the audit timestamp
+        // PR https://github.com/SinergiaTIC/SinergiaCRM/pull/1107
         $oldDateEntered = $record->date_entered;
-        // END STIC Custom
+        // END STIC CUSTOM
         $record->save($check_notify);
 
-        // STIC-Custom 20250707 JBL - Restore date_entered after save if it was cleared
+        // STIC-CUSTOM 20250707 - JCH - Restore date_entered after save if it was cleared
+        // PR https://github.com/SinergiaTIC/SinergiaCRM/pull/1107
         if ($record->id && empty($record->date_entered) && !empty($oldDateEntered)) {
             $record->date_entered = $oldDateEntered;
         }
-        // END STIC Custom
+        // END STIC CUSTOM
 
         if ($was_deleted) {
             $record->mark_deleted($record->id);

--- a/modules/DynamicFields/DynamicField.php
+++ b/modules/DynamicFields/DynamicField.php
@@ -505,12 +505,15 @@ class DynamicField
                     $first = false;
                     $queryInsert .= " ,$name";
                     $values .= " ,$quote" . $this->db->quote($val) . $quote;
+                    // STIC-CUSTOM - JCH - 20260507 - Fix for Issue #1106: Use INSERT ... ON DUPLICATE KEY UPDATE
+                    // PR https://github.com/SinergiaTIC/SinergiaCRM/pull/1107
                     if ($firstDup) {
                         $onDuplicate .= "$name=VALUES($name)";
                     } else {
                         $onDuplicate .= ",$name=VALUES($name)";
                     }
                     $firstDup = false;
+                    // END STIC-CUSTOM
                 }
             }
             if ($isUpdate) {

--- a/modules/DynamicFields/DynamicField.php
+++ b/modules/DynamicFields/DynamicField.php
@@ -442,6 +442,17 @@ class DynamicField
     {
         if ($this->bean->hasCustomFields() && isset($this->bean->id)) {
             $query = '';
+
+            // STIC-CUSTOM - JCH - 20260507 - Fix for Issue #1106: Check if record exists BEFORE building queries
+            // to prevent duplicate key errors and ensure UPDATE path is used when record already exists. PR https://github.com/SinergiaTIC/SinergiaCRM/pull/1107
+            if (!$isUpdate) {
+                $checkExists = "SELECT id_c FROM {$this->bean->table_name}_cstm WHERE id_c = '{$this->bean->id}'";
+                if ($this->bean->db && $this->bean->db->getOne($checkExists)) {
+                    $isUpdate = true;
+                }
+            }
+            // END STIC-CUSTOM
+
             if ($isUpdate) {
                 $query = 'UPDATE ' . $this->bean->table_name . '_cstm SET ';
             }
@@ -506,25 +517,13 @@ class DynamicField
             $queryInsert .= " ) VALUES $values )";
 
             if (!$first) {
-                // STIC-Custom 20250707 JBL - Fix for Issue #1106: Always check if record exists in _cstm before INSERT
-                // Even when $isUpdate is false, verify the record doesn't exist to prevent duplicate key error
-                if (!$isUpdate) {
-                    $checkQueryExists = "SELECT id_c FROM {$this->bean->table_name}_cstm WHERE id_c = '{$this->bean->id}'";
-                    if ($this->bean->db && $this->bean->db->getOne($checkQueryExists)) {
-                        // Record exists in _cstm but $isUpdate was false - do UPDATE instead
-                        $this->bean->db->query($query);
-                    } else {
-                        $this->bean->db->query($queryInsert);
-                    }
+                // STIC-Custom 20260507 - Fix for Issue #1106: Decision already made at top of save()
+                if ($isUpdate) {
+                    $this->db->query($query);
                 } else {
-                    $checkQuery = "SELECT id_c FROM {$this->bean->table_name}_cstm WHERE id_c = '{$this->bean->id}'";
-                    if ($this->db->getOne($checkQuery)) {
-                        $this->db->query($query);
-                    } else {
-                        $this->db->query($queryInsert);
-                    }
+                    $this->db->query($queryInsert);
                 }
-                // END STIC Custom
+                // END STIC-Custom
             }
         }
     }

--- a/modules/DynamicFields/DynamicField.php
+++ b/modules/DynamicFields/DynamicField.php
@@ -442,11 +442,19 @@ class DynamicField
     {
         if ($this->bean->hasCustomFields() && isset($this->bean->id)) {
             $query = '';
-
+            // STIC-CUSTOM - JCH - 20260507 - Fix for Issue #1106: Use INSERT ... ON DUPLICATE KEY UPDATE
+            // PR https://github.com/SinergiaTIC/SinergiaCRM/pull/1107
+            // if ($isUpdate) {
+            //     $query = 'UPDATE ' . $this->bean->table_name . '_cstm SET ';
+            // }
+            // END STIC-CUSTOM
             $queryInsert = 'INSERT INTO ' . $this->bean->table_name . '_cstm (id_c';
             $values = "('" . $this->bean->id . "'";
+            // STIC-CUSTOM - JCH - 20260507 - Fix for Issue #1106: Use INSERT ... ON DUPLICATE KEY UPDATE
+            // PR https://github.com/SinergiaTIC/SinergiaCRM/pull/1107
             $onDuplicate = '';
             $firstDup = true;
+            // END STIC-CUSTOM
             $first = true;
             foreach ($this->bean->field_defs as $name => $field) {
                 if (empty($field['source']) || $field['source'] != 'custom_fields') {
@@ -514,6 +522,17 @@ class DynamicField
             if (!$first) {
                 // STIC-CUSTOM - JCH - 20260507 - Fix for Issue #1106: Use INSERT ... ON DUPLICATE KEY UPDATE
                 // to avoid duplicate key errors when record already exists in _cstm without extra SELECT query
+                // if (!$isUpdate) {
+                //     $this->db->query($queryInsert);
+                // } else {
+                //     $checkQuery = "SELECT id_c FROM {$this->bean->table_name}_cstm WHERE id_c = '{$this->bean->id}'";
+                //     if ($this->db->getOne($checkQuery)) {
+                //         $this->db->query($query);
+                //     } else {
+                //         $this->db->query($queryInsert);
+                //     }
+                // }                
+                
                 if ($isUpdate) {
                     $this->db->query($query);
                 } else {

--- a/modules/DynamicFields/DynamicField.php
+++ b/modules/DynamicFields/DynamicField.php
@@ -444,7 +444,8 @@ class DynamicField
             $query = '';
 
             // STIC-CUSTOM - JCH - 20260507 - Fix for Issue #1106: Check if record exists BEFORE building queries
-            // to prevent duplicate key errors and ensure UPDATE path is used when record already exists. PR https://github.com/SinergiaTIC/SinergiaCRM/pull/1107
+            // to prevent duplicate key errors and ensure UPDATE path is used when record already exists. 
+            // PR https://github.com/SinergiaTIC/SinergiaCRM/pull/1107
             if (!$isUpdate) {
                 $checkExists = "SELECT id_c FROM {$this->bean->table_name}_cstm WHERE id_c = '{$this->bean->id}'";
                 if ($this->bean->db && $this->bean->db->getOne($checkExists)) {
@@ -517,13 +518,13 @@ class DynamicField
             $queryInsert .= " ) VALUES $values )";
 
             if (!$first) {
-                // STIC-Custom 20260507 - Fix for Issue #1106: Decision already made at top of save()
+                // STIC-CUSTOM - JCH - 20260507 - Fix for Issue #1106: Decision already made at top of save()
                 if ($isUpdate) {
                     $this->db->query($query);
                 } else {
                     $this->db->query($queryInsert);
                 }
-                // END STIC-Custom
+                // END STIC-CUSTOM
             }
         }
     }

--- a/modules/DynamicFields/DynamicField.php
+++ b/modules/DynamicFields/DynamicField.php
@@ -443,22 +443,10 @@ class DynamicField
         if ($this->bean->hasCustomFields() && isset($this->bean->id)) {
             $query = '';
 
-            // STIC-CUSTOM - JCH - 20260507 - Fix for Issue #1106: Check if record exists BEFORE building queries
-            // to prevent duplicate key errors and ensure UPDATE path is used when record already exists. 
-            // PR https://github.com/SinergiaTIC/SinergiaCRM/pull/1107
-            if (!$isUpdate) {
-                $checkExists = "SELECT id_c FROM {$this->bean->table_name}_cstm WHERE id_c = '{$this->bean->id}'";
-                if ($this->bean->db && $this->bean->db->getOne($checkExists)) {
-                    $isUpdate = true;
-                }
-            }
-            // END STIC-CUSTOM
-
-            if ($isUpdate) {
-                $query = 'UPDATE ' . $this->bean->table_name . '_cstm SET ';
-            }
             $queryInsert = 'INSERT INTO ' . $this->bean->table_name . '_cstm (id_c';
             $values = "('" . $this->bean->id . "'";
+            $onDuplicate = '';
+            $firstDup = true;
             $first = true;
             foreach ($this->bean->field_defs as $name => $field) {
                 if (empty($field['source']) || $field['source'] != 'custom_fields') {
@@ -509,6 +497,12 @@ class DynamicField
                     $first = false;
                     $queryInsert .= " ,$name";
                     $values .= " ,$quote" . $this->db->quote($val) . $quote;
+                    if ($firstDup) {
+                        $onDuplicate .= "$name=VALUES($name)";
+                    } else {
+                        $onDuplicate .= ",$name=VALUES($name)";
+                    }
+                    $firstDup = false;
                 }
             }
             if ($isUpdate) {
@@ -518,11 +512,12 @@ class DynamicField
             $queryInsert .= " ) VALUES $values )";
 
             if (!$first) {
-                // STIC-CUSTOM - JCH - 20260507 - Fix for Issue #1106: Decision already made at top of save()
+                // STIC-CUSTOM - JCH - 20260507 - Fix for Issue #1106: Use INSERT ... ON DUPLICATE KEY UPDATE
+                // to avoid duplicate key errors when record already exists in _cstm without extra SELECT query
                 if ($isUpdate) {
                     $this->db->query($query);
                 } else {
-                    $this->db->query($queryInsert);
+                    $this->db->query($queryInsert . " ON DUPLICATE KEY UPDATE $onDuplicate");
                 }
                 // END STIC-CUSTOM
             }

--- a/modules/DynamicFields/DynamicField.php
+++ b/modules/DynamicFields/DynamicField.php
@@ -506,8 +506,16 @@ class DynamicField
             $queryInsert .= " ) VALUES $values )";
 
             if (!$first) {
+                // STIC-Custom 20250707 JBL - Fix for Issue #1106: Always check if record exists in _cstm before INSERT
+                // Even when $isUpdate is false, verify the record doesn't exist to prevent duplicate key error
                 if (!$isUpdate) {
-                    $this->db->query($queryInsert);
+                    $checkQueryExists = "SELECT id_c FROM {$this->bean->table_name}_cstm WHERE id_c = '{$this->bean->id}'";
+                    if ($this->bean->db && $this->bean->db->getOne($checkQueryExists)) {
+                        // Record exists in _cstm but $isUpdate was false - do UPDATE instead
+                        $this->bean->db->query($query);
+                    } else {
+                        $this->bean->db->query($queryInsert);
+                    }
                 } else {
                     $checkQuery = "SELECT id_c FROM {$this->bean->table_name}_cstm WHERE id_c = '{$this->bean->id}'";
                     if ($this->db->getOne($checkQuery)) {
@@ -516,6 +524,7 @@ class DynamicField
                         $this->db->query($queryInsert);
                     }
                 }
+                // END STIC Custom
             }
         }
     }


### PR DESCRIPTION
## Descripcion
Se corrige el issue #1106 donde la accion Modificar Registro (Modify Record) de los Flujos de trabajo causa:
- Error de clave duplicada (MySQL 1062) en tablas _cstm
- Campo date_entered vacio
- Entradas fantasma en tracker
## Cambios
1. **DynamicField.php**: Verifica si el registro existe en _cstm antes de hacer INSERT. Si existe, hace UPDATE en su lugar.
2. **actionCreateRecord.php**: Preserva date_entered despues del save para evitar que quede vacio.
## Como probarlo
1. Crear un campo personalizado en el modulo Sesiones (desde Estudio)
2. Crear un Flujo de trabajo en Eventos con accion Modificar registro que modifique el campo en Sesiones relacionadas
3. Ir a un Evento y crear una Sesion desde el subpanel
4. Verificar que NO hay error de clave duplicada en el log
5. Verificar que date_entered tiene el valor correcto
## Tipos de cambios
- [x] Correccion de error
Closes #1106