### PR TITLE
Hotfix - Formularios Web Avanzados - No enviar notificaciones automáticas al usuario asignado a los registros creados

### DIFF
--- a/modules/stic_AWF_Forms/actions/Hook/SaveRecordAction.php
+++ b/modules/stic_AWF_Forms/actions/Hook/SaveRecordAction.php
@@ -195,7 +195,6 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
             $modifications = $this->populateBean($bean, $block);
             
             // Save without running logic hooks to avoid unwanted side effects in the creation of the record.
-            $bean->check_notify = false;
             $bean->save(false); 
             
             $modificationType = BeanModificationType::CREATED;
@@ -213,7 +212,6 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
                     $modificationType = BeanModificationType::UPDATED;
                     
                     // Save without running logic hooks to avoid unwanted side effects in the creation of the record.
-                    $bean->check_notify = false;
                     $bean->save(false); 
                     break;
 
@@ -223,7 +221,6 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
                     $modificationType = BeanModificationType::ENRICHED;
 
                     // Save without running logic hooks to avoid unwanted side effects in the creation of the record.
-                    $bean->check_notify = false;
                     $bean->save(false); 
                     break;
                 

--- a/modules/stic_AWF_Forms/actions/Hook/SaveRecordAction.php
+++ b/modules/stic_AWF_Forms/actions/Hook/SaveRecordAction.php
@@ -192,8 +192,12 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
                 $bean->assigned_user_id = $context->defaultAssignedUserId;
             }
             // Fill all bean fields
-            $modifications = $this->populateBean($bean, $block); 
-            $bean->save();
+            $modifications = $this->populateBean($bean, $block);
+            
+            // Save without running logic hooks to avoid unwanted side effects in the creation of the record.
+            $bean->check_notify = false;
+            $bean->save(false); 
+            
             $modificationType = BeanModificationType::CREATED;
 
         } else {
@@ -207,14 +211,20 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
                     // Overwrite all fields of the existing bean
                     $modifications = $this->populateBean($bean, $block);
                     $modificationType = BeanModificationType::UPDATED;
-                    $bean->save();
+                    
+                    // Save without running logic hooks to avoid unwanted side effects in the creation of the record.
+                    $bean->check_notify = false;
+                    $bean->save(false); 
                     break;
 
                 case OnDuplicateAction::ENRICH:
                     // Fill only empty fields of the existing bean
                     $modifications = $this->enrichBean($bean, $block); 
                     $modificationType = BeanModificationType::ENRICHED;
-                    $bean->save();
+
+                    // Save without running logic hooks to avoid unwanted side effects in the creation of the record.
+                    $bean->check_notify = false;
+                    $bean->save(false); 
                     break;
                 
                 case OnDuplicateAction::SKIP:


### PR DESCRIPTION
- Closes #1118 

## Descripción
Tal y como se describe en #1118, el usuario asignado de los registros que se crean a partir de la respuesta de un formulario web avanzado recibía por correo electrónico una notificación indicando que se le había asignado un registro.

Este comportamiento difería del comportamiento de los formularios clásicos.

El problema residía en que la acción `SaveRecordAction` guarda los registros con el usuario Administrador y los asigna al usuario correspondiente (el usuario que tenga la sesión abierta activa o el asignado al formulario). El guardado se realizaba mediante el método `$bean->save()` sin parámtros, con el comportamiento estándard de SuiteCRM, el cual incluye el envío de notificaciones al asignado si detecta que no es el mismo que el creador.

Se ha modificado la instrucción `$bean->save()` por el siguiente bloque, para evitar la ejecución del envío de notificaciones:
```php
// Save without running logic hooks to avoid unwanted side effects in the creation of the record.
$bean->check_notify = false;
$bean->save(false); 
```

## Pruebas
1. Crear un Formulario Web Avanzado y asignarlo a un usuario distinto al Administrador, con email configurado
2. Al Formulario añadirle algún bloque de datos enlazado a un módulo, para que cree registros.
3. Publicar el formulario
4. Sin una sesión del CRM abierta (en modo incógnito por ejemplo), enviar una respuesta al formulario para que cree un registro
5. Verificar que el usuario asignado al formulario NO recibe un correo indicando que se le ha asignado un registro