### PR TITLE
Hotfix - Formularios Web Avanzados - Evitar producir error si alguna relación ya no existe

### DIFF
--- a/modules/stic_AWF_Forms/actions/Hook/RelateRecordsAction.php
+++ b/modules/stic_AWF_Forms/actions/Hook/RelateRecordsAction.php
@@ -136,7 +136,7 @@ class RelateRecordsAction extends HookBeanActionDefinition {
 
         // Load the relationship in source Bean
         if (!$bean->load_relationship($linkName)) {
-            return new ActionResult(ResultStatus::ERROR, $actionConfig, "Could not load relationship '{$linkName}' in module '{$bean->module_name}'. Check vardefs link name.");
+            return new ActionResult(ResultStatus::SKIPPED, $actionConfig, "Could not load relationship '{$linkName}' in module '{$bean->module_name}'. Check vardefs link name.");
         }
         // Verify that it is a Link2
         if (!($bean->$linkName instanceof Link2)) {


### PR DESCRIPTION
- Closes #1121 

## Descripción
Tal y como se describe en #1121, en el caso que un Formulario Web Avanzado haga referencia a una relación que ya no exista en el CRM se producía error al procesar las respuestas. 

Con este PR, las respuestas se procesan sin error y muestran que se ha "Omitido" la creación de la relación porque no existe.

El cambio consiste en rebajar el nivel de "error" al no encontrar la relación a guardar

# Pruebas
- Este PR se puede verificar por código, los cambios son mínimos. 
- De todas formas, se puede verificar:
1. Definir desde Estudio una relación entre dos módulos.
2. Crear un FWA con los dos bloques de datos implicados en la relación y relacionarlos
3. Publicar el FWA
4. Verificar que el formulario funciona
5. Eliminar la relación en Estudio
6. Llenar el formulario
7. Verificar no envía la respuesta correctamente sin error
8. En la vista detalle de la respuesta, verificar que la acción de creación de la relación se ha OMITIDO