### PR TITLE
Hotfix - Formularios Web Avanzados - Validar si el módulo existe antes de guardar los registros por respuestas a formularios

### DIFF
--- a/modules/stic_AWF_Forms/actions/Hook/SaveRecordAction.php
+++ b/modules/stic_AWF_Forms/actions/Hook/SaveRecordAction.php
@@ -52,8 +52,13 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
      */
     public function executeWithBlock(ExecutionContext $context, FormAction $actionConfig, DataBlockResolved $block): ActionResult
     {
-        global $db;
+        global $db, $beanList;
+
         $module = $block->dataBlock->module;
+        if (!isset($beanList[$module])) {
+            return new ActionResult(ResultStatus::ERROR, $actionConfig, "The configured module '{$module}' is not available on the system.");
+        }
+
         $bean = null;
         $onDuplicateAction = null;
         $modifications = [];
@@ -68,6 +73,9 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
 
             $foundBean = null;
             $tempBean = BeanFactory::newBean($module);
+            if (!$tempBean) {
+                return new ActionResult(ResultStatus::ERROR, $actionConfig, "Failed to create a new instance of the module '{$module}'.");
+            }
 
             // Build the search fields for this rule
             foreach ($rule->fields as $fieldName) {
@@ -137,7 +145,7 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
                     if ($beanToCheck) {
                         $match = true;
                         foreach ($scalarFields as $sField => $sValue) {
-                            if ($beanToCheck->$sField != $sValue) {
+                            if (($beanToCheck->$sField ?? null) != $sValue) {
                                 $match = false;
                                 break;
                             }
@@ -187,6 +195,10 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
         if ($bean === null) {
             // No duplicate, create a new one
             $bean = BeanFactory::newBean($module);
+            if (!$bean) {
+                return new ActionResult(ResultStatus::ERROR, $actionConfig, "Failed to create a new instance of the module '{$module}'.");
+            }
+            
             // Assign user if a default one is set
             if (!empty($context->defaultAssignedUserId)) {
                 $bean->assigned_user_id = $context->defaultAssignedUserId;


### PR DESCRIPTION
- Closes #1122 

## Descripción
Tal y como se documenta en #1122, si un Formulario Web Avanzado tiene un bloque de datos que hace referencia a un módulo que ya no existe en el CRM, se producía un error al guardar el registro (correcto), pero este error era descontrolado, era un error de PHP: `Call to a member function retrieve_by_string_fields() on false`

Mediante este PR, se controla el caso produciéndose un error descriptivo.

## Pruebas
- Se puede verificar el PR mediante inspección de código simplemente
- También se puede probar con todo el circuito:
1. Crear un módulo nuevo y publicarlo
2. Crear un formulario sobre ese módulo
3. Eliminar el módulo (descartar los cambios en GIT) y reparar
4. Llenar una respuesta al formulario
5. Verificar que se produce error y éste no es un mensaje de error de PHP
