### PR TITLE
Improvement - Formularios Web Avanzados - Tratar los campos booleanos con valor 0 como vacíos al actualizar

### DIFF
--- a/modules/stic_AWF_Forms/actions/Hook/SaveRecordAction.php
+++ b/modules/stic_AWF_Forms/actions/Hook/SaveRecordAction.php
@@ -319,6 +319,18 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
             // Check if the field in the bean is empty or null
             $isEmpty = ($oldValue === null || $oldValue === '');
 
+            // Check if the field is boolean (in that case, consider false as empty)
+            $isBoolean = ($fieldDef && isset($fieldDef['type']) && ($fieldDef['type'] === 'bool' || $fieldDef['type'] === 'boolean'));
+            if ($isBoolean) {
+                // Normalize new value to boolean true if it is sent as checked (otherside, consider it false)
+                $newValue = ($newValue === true || $newValue === 1 || $newValue === '1');
+
+                // If the field has value, consider empty old value false or null
+                if ($newValue) {
+                    $isEmpty = ($isEmpty || $oldValue === false || $oldValue === 0 || $oldValue === '0');
+                }
+            }
+
             if ($isEmpty && $newValue !== null && $newValue !== '') {
                 // The current field is empty.
                 $bean->$targetField = $newValue;


### PR DESCRIPTION
- Closes #1129 

## Descripción
Tal y como se describe en #1129:  Los campos booleanos pueden tener el valor `NULL`, `0` o `1`. En la representación del valor como casilla de selección o interruptor, el valor `NULL` se representa como el valor `0`: Deseactivado o No. 

Los Formularios Web Avanzados, en caso de duplicado pueden aplicar la acción "Ampliar" que inserta un valor en los campos donde "esté vacío". Ahora bien, en los booleanos con valor "0", el concepto "vacío" causa confusión: Técnicamente el valor `0` (o false) es distinto al concepto "vacío", pero a nivel de representación, el valor `0` es "vacío", una casilla desmarcada.

Este PR mejora la comprensión de la acción "Ampliar" tratando los campos booleanos con valor `false` (desmarcados) como campos "vacíos".

## Pruebas
1. Crear un Formulario Web Avanzado sobre el módulo Personas. Añadir el campo "No llamar" y publicar el formulario
2. Enviar una respuesta al formulario con un apellido **SIN MARCAR** la casilla "No llamar"
3. Verificar que la persona creada tiene desmarcado el campo "No llamar"
4. Enviar otra respuesta al formulario con el mismo apellido pero **MARCANDO** la casilla "No llamar"
5. Verificar que a la persona se le ha actualizado el campo "No llamar" y ahora está marcado

