### PR TITLE
Hotfix - Economía - Informar relación con Contact en la llamada creada al impagar

### DIFF
--- a/modules/stic_Payments/Utils.php
+++ b/modules/stic_Payments/Utils.php
@@ -53,7 +53,7 @@ class stic_PaymentsUtils
 
         // STIC NOTE - $_REQUEST variable is not the same when saving a record from EDIT_VIEW as from INLINE_EDIT.
         // In order to generate the relationship between the contact and the call, it is necessary to enter the following properties in $_REQUEST
-        if ($_REQUEST['action'] == 'saveHTMLField') {
+        if ($_REQUEST['action'] == 'saveHTMLField' || $_REQUEST['action'] == 'Save') {
             $_REQUEST['relate_to'] = 'Contacts';
             $_REQUEST['relate_id'] = $paymentBean->stic_payments_contactscontacts_ida;
         }

--- a/modules/stic_Payments/Utils.php
+++ b/modules/stic_Payments/Utils.php
@@ -51,12 +51,8 @@ class stic_PaymentsUtils
         $callBean->parent_id = $paymentBean->id;
         $callBean->parent_type = 'stic_Payments';
 
-        // STIC NOTE - $_REQUEST variable is not the same when saving a record from EDIT_VIEW as from INLINE_EDIT.
-        // In order to generate the relationship between the contact and the call, it is necessary to enter the following properties in $_REQUEST
-        if ($_REQUEST['action'] == 'saveHTMLField' || $_REQUEST['action'] == 'Save') {
-            $_REQUEST['relate_to'] = 'Contacts';
-            $_REQUEST['relate_id'] = $paymentBean->stic_payments_contactscontacts_ida;
-        }
+        $_REQUEST['relate_to'] = 'Contacts';
+        $_REQUEST['relate_id'] = $paymentBean->stic_payments_contactscontacts_ida;
 
         $callBean->save();
     }


### PR DESCRIPTION
- Closes #1147 

## Description
Se añade la comparación con Save pues sólo se estaba informando la relación cuando la acción era inline.

## Motivation and Context
La creación de la llamada cuando un pago pasa a Impagado debe ser consistente tanto si se realiza inline o con el guardado genérico.

## How To Test This
Debe probarse las distintas formas de actualizar el estado del pago a impagado.
1.- Modificar el estado de un pago de manera inline
2.- Modificar el estado de un pago mediante el Edit convencional
3.- Remesa rechazada (con más de un pago apra verificar que cada llamada se vincula con el contacto correspondiente)

Si se conoce alguna otra estrategia para realizar el paso a impagado, comprobar que no se produce ningún error.

## Información adicional
El código data de 2020 y no se ha podido localizar ningún PR al que haga referencia. 
Sí se ha localizado el commit original, que parece realizado directamente en master: https://github.com/SinergiaTIC/SinergiaCRM-SuiteCRM/commit/6274b934ebf38bd7c3d6e977abe1b309cce91f65#diff-4a5219a19c51d2bb9a71acc87da6171eb55926d332e64baef88860b7d5d33ec5
