### PR TITLE
Hotfix - General - La respuesta a las llamadas AJAX no debe llevar script de impersonate

### DIFF
--- a/custom/modules/Users/SticImpersonate/LogicHooksCode.php
+++ b/custom/modules/Users/SticImpersonate/LogicHooksCode.php
@@ -37,6 +37,13 @@ class ImpersonateLogicHooks
     {
         global $current_user;
         
+        // STIC 2026-05-19 - Skip injection during AJAX requests (to_pdf=true)
+        // to_pdf=true is used by KReports and other modules for AJAX calls,
+        // and injecting HTML script tags would corrupt the JSON response
+        if (isset($_REQUEST['to_pdf']) && $_REQUEST['to_pdf'] == 'true') {
+            return;
+        }
+        
         // Only inject UI elements if user is logged in
         if (empty($current_user) || empty($current_user->id)) {
             return;


### PR DESCRIPTION
- Closes #1154

## Description
Le modifica el logic hook que añade el script que visualiza al usuario que está impersonando a otro usuario para que no inyecte el script en lso casos de llamada AJAX ($_REQUEST['to_pdf'] =='true'.

## Motivation and Context
Se detecta que se estaba inyectando el script de impersonalización en las llamadas AJAX, lo cual provocaba que en algunos casos no se procesara correctamente la respuesta (ejemplo KReports).

## How To Test This
### Comprobar que la modificación corrige el problema detectado
1.- Impersonar a un usuario
2.- Acceder a KReports con el usaurio impersonado
3.- Crear o modificar un informe y comprobar que el árbol de módulos y campos aparece correctamente
### Otras comprobaciones
Explorar otras llamadas AJAX que no sean desde KReport para comprobar que o bien siguen funcionando igual o también se han corregido.

