### PR TITLE
 Hotfix - Actividades - Corregir referencia a función en ActivitiesRelationship

### DIFF
--- a/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
+++ b/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
@@ -250,16 +250,6 @@ class ActivitiesRelationship extends OneToManyRelationship
                         'module' => 'Calls' ,
                         'subpanel_name' => 'ForActivities' ,
                         'get_subpanel_data' => $relationshipName. '_calls' ),
-                    // STIC Custom 20240909 EPS - SMS Messages
-                    'messages' => array(
-                        'module' => 'stic_Messages',
-                        'subpanel_name' => 'ForActivities',
-                        'get_subpanel_data' => 'function:stic_MessagesUtils::get_stic_messages',
-                        'generate_select' => true,
-                        'function_parameters' => array('import_function_file' => 'modules/stic_Messages/Utils.php', 'return_as_array' => 'true', 'status' => "'draft'"),
-                    )
-                    // END STIC Custom
-
                  ) ) ;
     }
 

--- a/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
+++ b/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
@@ -254,7 +254,7 @@ class ActivitiesRelationship extends OneToManyRelationship
                     'messages' => array(
                         'module' => 'stic_Messages',
                         'subpanel_name' => 'ForActivities',
-                        'get_subpanel_data' => 'function:get_stic_messages',
+                        'get_subpanel_data' => 'function:stic_MessagesUtils::get_stic_messages',
                         'generate_select' => true,
                         'function_parameters' => array('import_function_file' => 'modules/stic_Messages/Utils.php', 'return_as_array' => 'true', 'status' => "'draft'"),
                     )
@@ -310,7 +310,7 @@ class ActivitiesRelationship extends OneToManyRelationship
                     'messages' => array(
                         'module' => 'stic_Messages',
                         'subpanel_name' => 'ForHistory',
-                        'get_subpanel_data' => 'function:get_stic_messages',
+                        'get_subpanel_data' => 'function:stic_MessagesUtils::get_stic_messages',
                         'generate_select' => true,
                         'function_parameters' => array('import_function_file' => 'modules/stic_Messages/Utils.php', 'return_as_array' => 'true', 'status' => "'sent', 'error'"),
                     )


### PR DESCRIPTION
- closes #1161 

## Descripción:
 Se corrige el valor de `get_subpanel_data` para el módulo `stic_Messages` en el archivo `ActivitiesRelationship.php`.
Cambios realizados:
Archivo modificado: `modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php`
```
- 'get_subpanel_data' => 'function:get_stic_messages',
+ 'get_subpanel_data' => 'function:stic_MessagesUtils::get_stic_messages',

``` 
El parámetro get_subpanel_data requiere una referencia completa a la función (clase::método). Sin esto, el sistema buscaba una función global inexistente, provocando errores en los subpaneles de Actividades e Historial.

## Pruebas a realizar:
Crear relación desde Estudio con Actividades y verificar que no se produce el siguiente error:
`2026-05-18 18:11:19 [389681][2][FATAL] Failed to load original or custom subpanel data for messages in modules/stic_Messages/metadata/subpanels/ForActivities.php 
2026-05-18 18:11:19 [389681][2][FATAL] [SinergiaCRM Critical E_ERROR (Fatal run-time error:1)] Uncaught Error: Call to undefined function get_stic_messages(`