### PR TITLE
Hotfix - General -  Añade script de reparación para campos jjwg_maps faltantes

### DIFF
--- a/SticUpdates/Releases/bug/ensureJjwg_Maps/post_install.txt
+++ b/SticUpdates/Releases/bug/ensureJjwg_Maps/post_install.txt
@@ -1,0 +1,1 @@
+SticUpdates/Scripts/RepairJjwgMapsFields.php

--- a/SticUpdates/Scripts/RepairJjwgMapsFields.php
+++ b/SticUpdates/Scripts/RepairJjwgMapsFields.php
@@ -18,7 +18,25 @@ $current_user->getSystemUser();
 // Include the GoogleMaps installer
 require_once 'install/suite_install/GoogleMaps.php';
 
-// Execute the installation function
-install_gmaps();
+$allFields = getCustomFields();
 
-echo "JJWG Maps fields repair completed.\n";
+// Filter out fields that already exist in fields_meta_data
+$missingFields = array();
+foreach ($allFields as $id => $field) {
+    $result = $db->query("SELECT id FROM fields_meta_data WHERE custom_module = '{$field['module']}' AND name = '{$field['name']}' AND deleted = 0");
+    if (!$db->fetchByAssoc($result)) {
+        $missingFields[$id] = $field;
+    }
+}
+
+if (!empty($missingFields)) {
+    require_once('ModuleInstall/ModuleInstaller.php');
+    $ModuleInstaller = new ModuleInstaller();
+    $ModuleInstaller->install_custom_fields($missingFields);
+    echo "Installed " . count($missingFields) . " missing JJWG Maps fields.\n";
+} else {
+    echo "All JJWG Maps fields already exist.\n";
+}
+
+installJJWHooks();
+echo "JJWG Maps logic hooks ensured.\n";

--- a/SticUpdates/Scripts/RepairJjwgMapsFields.php
+++ b/SticUpdates/Scripts/RepairJjwgMapsFields.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * STIC#1021 - Repair JJWG Maps Fields
+ *
+ * This script adds the jjwg_maps custom fields (lat, lng, address, geocode_status)
+ * to the 8 modules that support maps functionality in instances that were created
+ * before the GoogleMaps suite_install was implemented.
+ *
+ * Modules: Accounts, Cases, Contacts, Leads, Meetings, Opportunities, Project, Prospects
+ */
+
+global $current_user, $db;
+
+// Load admin user
+$current_user = new User();
+$current_user->getSystemUser();
+
+// Include the GoogleMaps installer
+require_once 'install/suite_install/GoogleMaps.php';
+
+// Execute the installation function
+install_gmaps();
+
+echo "JJWG Maps fields repair completed.\n";


### PR DESCRIPTION
- Closes #1182 

## Description

Añade script `RepairJjwgMapsFields.php` para reparar los campos de geolocalización (jjwg_maps_*) faltantes en instancias migradas desde versiones antiguas de SugarCRM/SuiteCRM. Las instancias preexistentes no tienen los campos jjwg_maps en los 8 módulos afectados porque el instalador `install/suite_install/GoogleMaps.php` nunca se ejecutó durante la migración.
## Cambios
- `SticUpdates/Scripts/RepairJjwgMapsFields.php` - Ejecuta `install_gmaps()` para crear los campos y registrar los logic hooks necesarios
- `SticUpdates/Releases/{version}/post_install.txt` - Añade referencia al script para ejecución automática
## How To Test This
Consulta SQL para verificar que los campos existen:
```sql
SELECT DISTINCT TABLE_NAME 
FROM INFORMATION_SCHEMA.COLUMNS 
WHERE COLUMN_NAME LIKE 'jjwg%' 
ORDER BY TABLE_NAME;
Resultado esperado: 8 tablas (accounts_cstm, cases_cstm, contacts_cstm, leads_cstm, meetings_cstm, opportunities_cstm, project_cstm, prospects_cstm)

