### PR TITLE
Hotfix - General - Conteo asíncrono con campos relacionados

### DIFF
--- a/SticInclude/AsyncListCount.php
+++ b/SticInclude/AsyncListCount.php
@@ -25,6 +25,8 @@ if (!defined('sugarEntry') || !sugarEntry) {
     die('Not A Valid Entry Point');
 }
 
+require_once 'include/EditView/SugarVCR.php';
+
 function outputJson($success, $data = null, $error = null) {
     @ob_end_clean();
     ob_start();
@@ -62,8 +64,20 @@ if (!$bean->ACLAccess('ListView')) {
     return;
 }
 
-$ret_array = $bean->create_new_list_query('', $where, [], [], 0, '', true, $bean, false);
-$countQuery = $bean->create_list_count_query($ret_array['select'] . $ret_array['from'] . $ret_array['where']);
+// The main query stored by ListViewData.php includes all filter joins (inner_join, custom_from, etc.)
+// that are needed for WHERE clauses referencing joined tables (e.g., jt6.name)
+$storedQuery = SugarVCR::retrieve($module);
+if (!empty($storedQuery)) {
+    $countQuery = $bean->create_list_count_query($storedQuery);
+} else {
+    // Fallback: rebuild query without filter joins (may miss search-specific joins)
+    $ret_array = $bean->create_new_list_query('', $where, [], [], 0, '', true, $bean, false);
+    if (!empty($bean->listview_inner_join)) {
+        $ret_array['inner_join'] = ' ' . implode(' ', $bean->listview_inner_join) . ' ';
+    }
+    $mainQuery = $ret_array['select'] . $ret_array['from'] . ($ret_array['inner_join'] ?? '') . $ret_array['where'];
+    $countQuery = $bean->create_list_count_query($mainQuery);
+}
 
 $db = DBManagerFactory::getInstance();
 $result = $db->query($countQuery);


### PR DESCRIPTION
## Descripcion

Corrección de la query COUNT en `AsyncListCount.php` que fallaba al aplicar filtros que referencian tablas unidas mediante joins.

### Problema

Al aplicar un filtro en la vista de lista con `stic_async_list_count = true`, la query COUNT lanzaba error MySQL:

```
MySQL error 1054: Unknown column 'jt6.name' in 'WHERE'
```

El `$where` contenía condiciones referenciando alias de tablas unidas por el SearchForm (ej. `jt6`), pero `AsyncListCount.php` reconstruía la query desde cero con `create_new_list_query('', $where, ...)` sin incluir los joins necesarios (`inner_join`, `custom_from`, etc.).

### Solución

En lugar de reconstruir la query, se usa `SugarVCR::retrieve($module)` para recuperar la query completa que `ListViewData.php` ya construyó y almacenó en sesión en `$_SESSION[$module . '2_QUERY']`. Esta query incluye todos los joins: Security Groups, ACL roles, `listview_inner_join`, `custom_from/where` de `$params`, y overrides de `create_new_list_query()` en módulos.

Como fallback (si no hay query en sesión), se reconstruye añadiendo `listview_inner_join`.

---

## Motivacion y contexto

El conteo asíncrono fallaba con cualquier filtro que implicara un join (búsquedas por campos relacionales, filtros de Security Groups, etc.), dejando la funcionalidad inservible en esos casos. La exportación y selección masiva sí funcionaban correctamente porque usaban la query original del `ListViewData`.

---

## Como probarlo

1. `stic_async_list_count = true`
2. Ir a una vista de lista con >20 registros, por ejemplo Inscripciones.
3. Aplicar un filtro de búsqueda por el Evento.
4. Verificar que el conteo asíncrono carga sin errores y muestra el total correcto
5. Cambiar de página con el filtro aplicado → el conteo debe mantenerse correcto

---

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `SticInclude/AsyncListCount.php` | Añade `require_once SugarVCR`, usa `SugarVCR::retrieve()` para obtener la query completa en lugar de reconstruirla con `create_new_list_query()` |

---

## Tipos de cambios

- [x] Corrección de error
- [ ] Nueva funcionalidad
- [ ] Cambio incompatible

---

## Nota técnica

`ListViewData.php:364` construye `$main_query` con todos los joins y la almacena en sesión en la línea 422 (`SugarVCR::store`). El endpoint AJAX la recupera íntegra, garantizando que el `SELECT COUNT(*)` use exactamente las mismas condiciones que la query principal de la vista de lista.
