### PR TITLE
Hotfix - SinergiaDA - Corrección de relaciones auto-referenciales y mejora de etiquetas de campos relacionados

### DIFF
--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -591,8 +591,8 @@ class ExternalReporting
                                         'column' => $fieldV['name'],
                                         'type' => 'text',
                                         'aggregations' => 'count,count_distinct,none',
-                                        'label' => $fieldV['label'],
-                                        'description' => addslashes($fieldV['label']),
+                                        'label' => "{$fieldV['label']} ({$relatedModuleName})",
+                                        'description' => addslashes("{$fieldV['label']} ({$relatedModuleName})"),
                                         'sda_hidden' => 0,
                                         'stic_type' => $fieldV['type'] . '-name',
                                     ]
@@ -608,7 +608,7 @@ class ExternalReporting
                                         'target_table' => "{$this->viewPrefix}_{$fieldV['targetModule']}",
                                         'target_column' => 'id',
                                         'info' => 'relate',
-                                        'label' => "{$fieldV['label']}|{$txModuleName}",
+                                        'label' => "{$fieldV['label']} ({$relatedModuleName})|{$relatedModuleName}",
                                     ]
                                 );
                             }

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -913,7 +913,7 @@ class ExternalReporting
             unset($qualifiedLabel);
             if (!empty($autoRelationships)) {
                 foreach ($autoRelationships as $key => $value) {
-                    if ($txModuleName != $value['rLabel']) {
+                    if ($txModuleName != $value['rLabel'] && strpos($value['rLabel'], 'LBL_') !== 0) {
                         $qualifiedLabel = "{$txModuleName} ({$value['rLabel']})";
                     } else {
                         $qualifiedLabel = "{$txModuleName} ({$value['label']})";

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -352,9 +352,11 @@ class ExternalReporting
 
                 $fieldPrefix = ($fieldV['source'] ?? null) == 'custom_fields' ? 'c' : 'm';
 
-                // If the field is excluded, skip it
+                // If the field is excluded, skip it unless it belongs to a self-referencing relationship (auto-relationship)
                 if (in_array($fieldV['name'], $this->evenExcludedFields)) {
-                    continue;
+                    if (($fieldV['module'] ?? null) != $moduleName) {
+                        continue;
+                    }
                 }
 
                 // Conditionally controls the visibility of fields in the detail view:
@@ -468,6 +470,12 @@ class ExternalReporting
                                     $fieldV['rLabel'] = translate('LBL_' . strtoupper($fieldV['link']) . '_FROM_' . strtoupper($moduleName) . '_R_TITLE', $fieldV['module']);
                                     $fieldV['lLabel'] = translate('LBL_' . strtoupper($fieldV['link']) . '_FROM_' . strtoupper($moduleName) . '_L_TITLE', $fieldV['module']);
                                     $fieldV['autoRelJoinModuleRelLabel'] = 'LBL_' . strtoupper($fieldV['link']) . '_FROM_' . strtoupper($moduleName) . '_R_TITLE';
+                                    // Resolve the actual relationship name from the link field definition
+                                    // (needed when the link field name differs from the relationship name, e.g. member_of vs member_accounts)
+                                    $linkFieldDef = $moduleBean->getFieldDefinitions()[$fieldV['link']] ?? null;
+                                    if ($linkFieldDef && !empty($linkFieldDef['relationship'])) {
+                                        $fieldV['rel_name'] = $linkFieldDef['relationship'];
+                                    }
                                     $autoRelationships[$fieldV['link']] = $fieldV;
                                     $this->autoRelationshipsRegistered[$fieldV['link']] = $fieldV['table'];
                                 }
@@ -508,7 +516,11 @@ class ExternalReporting
                                 $indexesToCreate[] = $fieldV['alias'];
 
                                 if (!empty($fieldSrc)) {
-                                    $fieldList['related'][$fieldK] = $fieldSrc . " AS {$fieldV['alias']}";
+                                    // Skip adding to related field list for auto-relationships,
+                                    // the auto-relationship view already adds the column via parentIdfieldSrc
+                                    if (empty($fieldV['isAutoRelationship'])) {
+                                        $fieldList['related'][$fieldK] = $fieldSrc . " AS {$fieldV['alias']}";
+                                    }
                                 } else {
                                     $fieldList['failedRelations'][$fieldK] = $fieldSrc . " AS {$fieldV['alias']}";
                                 }
@@ -1275,7 +1287,9 @@ class ExternalReporting
 
         $tableLabel = empty($tableLabel) ? '-' : $tableLabel;
         // **Retrieve relationship information:**
-        $rel = $db->fetchOne("select * from relationships where relationship_name='{$field['link']}'");
+        // Use the resolved relationship name if available (for cases where link field name differs from relationship name)
+        $relName = $field['rel_name'] ?? $field['link'];
+        $rel = $db->fetchOne("select * from relationships where relationship_name='{$relName}'");
 
         // **Check if necessary information is present for standard join:**
         if (!empty($rel['join_table']) && !empty($rel['join_key_lhs']) && !empty($rel['join_key_rhs'])) {
@@ -1362,21 +1376,26 @@ class ExternalReporting
         } else {
             // **Handle cases where no join table is used:**
 
-            // Check for one-to-many relationship with the current table
-            $sql = "SELECT * FROM relationships WHERE (lhs_table='{$tableName}' OR rhs_table='{$tableName}') AND (lhs_table='{$field['table']}' OR rhs_table='{$field['table']}') AND relationship_type='one-to-many'";
-            $rel = $db->fetchOne($sql);
-
-            if ($rel) {
+            // Use the relationship data already retrieved from the first query (by relationship_name).
+            // The first query already found the correct relationship; we just need to verify
+            // it is one-to-many. Avoid re-querying by table names, which is ambiguous for
+            // self-referencing relationships where both sides use the same table.
+            if ($rel && !empty($rel['relationship_type']) && $rel['relationship_type'] == 'one-to-many') {
                 // One-to-many relationship - use direct join
                 $res['field'] = "m.{$field['id_name']}";
                 $res['leftJoin'] = " LEFT JOIN {$field['table']} ON {$field['table']}.id=m.{$field['id_name']} AND {$field['table']}.deleted=0 ";
 
                 // Add metadata record
+                // For auto-relationships, source_table points to the N-side view (e.g. sda_accounts_member_of)
+                // since the parent_id column resides there, not in the main view.
+                $relSourceTable = $isAutoRelationship
+                    ? $this->truncateStringMiddle("{$this->viewPrefix}_{$tableName}_{$field['link']}", 64)
+                    : "{$this->viewPrefix}_{$tableName}";
                 $this->addMetadataRecord(
                     'sda_def_relationships',
                     [
                         'id' => $field['link'],
-                        'source_table' => "{$this->viewPrefix}_{$tableName}",
+                        'source_table' => $relSourceTable,
                         'source_column' => $field['id_name'],
                         'target_table' => "{$this->viewPrefix}_{$field['table']}",
                         'target_column' => 'id',
@@ -1384,6 +1403,11 @@ class ExternalReporting
                         'label' => "{$field['label']}|{$tableLabel}",
                     ]
                 );
+
+                // For one-to-many auto-relationships without join table, set the N-side view data
+                if ($isAutoRelationship) {
+                    $res['fieldForAutoRelationshipsNSide'] = "m.{$rel['rhs_key']}";
+                }
 
                 return $res;
 

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -608,7 +608,7 @@ class ExternalReporting
                                         'target_table' => "{$this->viewPrefix}_{$fieldV['targetModule']}",
                                         'target_column' => 'id',
                                         'info' => 'relate',
-                                        'label' => "{$fieldV['label']} ({$relatedModuleName})|{$relatedModuleName}",
+                                        'label' => "{$fieldV['label']} ({$relatedModuleName})|{$txModuleName} ({$fieldV['label']})",
                                     ]
                                 );
                             }

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -647,9 +647,33 @@ class ExternalReporting
                             ]
                         );
                         break;
+                    case 'bool':
+
+                        $fieldV['alias'] = $fieldV['name'];
+
+                        // Create listViewName for use in metadata & view creation
+                        $listViewName = substr(join('_', [$tableName, $fieldV['name'], 'stic_boolean_list']), 0, 58);
+
+                        $fieldSrc = " IFNULL({$fieldPrefix}.{$fieldV['name']} ,'') AS {$fieldName}";
+
+                        // For boolean fields, always create the enum view with fixed '1'/'0' codes
+                        // regardless of the actual keys in stic_boolean_list
+                        $this->createFixedBooleanEnumView($listViewName);
+
+                        $this->addMetadataRecord(
+                            'sda_def_enumerations',
+                            [
+                                'source_table' => "{$this->viewPrefix}_{$tableName}",
+                                'source_column' => $fieldV['name'],
+                                'master_table' => "{$this->listViewPrefix}_{$listViewName}",
+                                'info' => 'enum_list',
+                                'stic_type' => $fieldV['type'],
+                            ]
+                        );
+                        break;
+
                     case 'enum':
                     case 'dynamicenum':
-                    case 'bool':
                     case 'radioenum':
 
                         $fieldV['alias'] = $fieldV['name'];
@@ -663,9 +687,8 @@ class ExternalReporting
 
                         $createdListView = $this->createEnumView($listName, $listViewName);
 
-                        // If there is a valid drop-down list or if it corresponds to that of a boolean field
-                        // we continue, otherwise we move on to the next column
-                        if (!empty($createdListView) || $listName == 'stic_boolean_list') {
+                        // If there is a valid drop-down list we continue, otherwise we move on to the next column
+                        if (!empty($createdListView)) {
                             $listNames[] = $createdListView;
                         } else {
                             continue 2;
@@ -1802,6 +1825,30 @@ class ExternalReporting
         } else {
             return $listViewName;
         };
+    }
+
+    /**
+     * Creates a MariaDB view for boolean fields with fixed '1'/'0' codes,
+     * independent of the actual keys in stic_boolean_list.
+     * This ensures that the enum view always matches the raw DB values ('1'/'0')
+     * regardless of any modifications to the dropdown list.
+     */
+    private function createFixedBooleanEnumView($listViewName)
+    {
+        global $app_strings;
+
+        $db = DBManagerFactory::getInstance();
+        $yesLabel = $db->quote($app_strings['LBL_YES']);
+        $noLabel = $db->quote($app_strings['LBL_NO']);
+        $viewName = "{$this->listViewPrefix}_{$listViewName}";
+
+        $sqlCommand = "CREATE OR REPLACE VIEW {$viewName} AS
+            SELECT '1' as 'code', '{$yesLabel}' as 'value'
+            UNION SELECT '0', '{$noLabel}'";
+
+        if (!$db->query($sqlCommand)) {
+            $GLOBALS['log']->error('Line ' . __LINE__ . ': ' . __METHOD__ . ': ' . "Error has occurred: [{$db->last_error}] running Query: [{$sqlCommand}]");
+        }
     }
 
     /**

--- a/SticInclude/SinergiaDA.php
+++ b/SticInclude/SinergiaDA.php
@@ -2237,7 +2237,7 @@ class ExternalReporting
         if ($result !== false) {
             if ($result->num_rows > 0) {
                 while ($row = $db->fetchByassoc($result)) {
-                    $queryDelete = "DELETE FROM {$row['sda_def_columns']} WHERE `{$columnName}` = '{$row['table']}';";
+                    $queryDelete = "DELETE FROM {$row['sda_def_columns']} WHERE `{$row['column_name']}` = '{$row['table']}';";
 
                     $deleteResult = $db->query($queryDelete);
 


### PR DESCRIPTION
## Descripción
Se solucionan dos issues relacionados con SinergiaDA y se corrigen tres errores adicionales en la reconstrucción:

1. **Issue #718**: La relación auto-referencial "Miembro de" (Accounts self-referencing) estaba siendo excluida durante el rebuild. El campo `parent_name` en el módulo Accounts estaba siendo excluido globalmente via `$evenExcludedFields`, lo que impedía que la relación `member_accounts` fuera procesada correctamente.
2. **Issue #687**: Los campos relacionados (tipo `relate`) se mostraban únicamente con el nombre del campo (ej: "Asignado a"), sin incluir el nombre del módulo de destino (ej: "Asignado a (Usuarios)"). Esto causaba confusión ya que el usuario no sabía a qué módulo apuntaba el campo.
3. **Error en `checkSdaTablesInViews`**: La variable `$columnName` no estaba definida, generando queries DELETE malformadas como ``WHERE `` = '...'``
4. **Dependencia frágil de `stic_boolean_list`**: La vista de enumeración para campos booleanos se creaba a partir de las claves de `stic_boolean_list` (`'1'`/`'0'`). Si alguien modificaba esas claves (ej. a `'yes'`/`'no'`), los datos en las tablas publicadas (`'1'`/`'0'`) no coincidirían con los códigos de la vista, rompiendo los informes. Se ha creado `createFixedBooleanEnumView()` que genera la vista con códigos fijos `'1'`/`'0'` independientemente de la lista.

## Cambios realizados

### Fix 1: Relaciones auto-referenciales (Issue #718)
**Archivo:** `SticInclude/SinergiaDA.php`
- **Línea 35**: Modificada la exclusión de campos para permitir campos de auto-relaciones cuando `module == moduleName`
- **Líneas 473-478**: Añadida resolución del nombre de relación real desde la definición del campo link
- **Línea 1287-1289**: Corregida la query en `createRelateLeftJoin` para usar `rel_name ?? link`
- **Líneas 518-522**: Evitado añadir campos de auto-relaciones a `$fieldList['related']` para evitar nombres de columnas duplicados
- **Líneas 1376-1409**: Eliminada consulta ambigua en el branch sin tabla de join
- **Líneas 1404-1408**: Añadido `fieldForAutoRelationshipsNSide` para auto-relaciones one-to-many

### Fix 2: Etiquetas de campos relacionados (Issue #687)
**Archivo:** `SticInclude/SinergiaDA.php`
- **Línea 594**: Modificado el label en `sda_def_columns` para incluir el módulo relacionado
- **Línea 611**: Modificado el label en `sda_def_relationships` para usar el formato correcto

### Fix 3: Variable indefinida en `checkSdaTablesInViews`
**Archivo:** `SticInclude/SinergiaDA.php`
- **Línea 2240**: Sustituida variable indefinida `$columnName` por `$row['column_name']` para evitar queries malformadas del tipo `DELETE FROM sda_def_relationships WHERE `` = '...'`

### Fix 4: Vista de enumeración booleana con códigos fijos
**Archivo:** `SticInclude/SinergiaDA.php`
- Separado el case `bool` del bloque compartido con enum/dynamicenum/radioenum
- Eliminada condición redundante `|| $listName == 'stic_boolean_list'` en el case de enum
- Añadido nuevo método `createFixedBooleanEnumView()` que crea la vista de enumeración con códigos fijos `'1'`/`'0'` y etiquetas de `$app_strings['LBL_YES']`/`['LBL_NO']`, independientemente de las claves reales de `stic_boolean_list`

## Cómo probarlo
1. **Issue #718**: Ejecutar rebuild completo de SinergiaDA. Verificar que las relaciones auto-referenciales del tipo one-to-many se generan correctamente en `sda_def_relationships` y que las vistas asociadas contienen los datos esperados.
2. **Issue #687**: En la vista árbol de SinergiaDA, verificar que todos los campos de tipo `relate` muestran el formato `<Nombre del Campo> (<Módulo Destino>)` en lugar de solo el nombre del campo.
3. **Fix 3**: Ejecutar rebuild de SinergiaDA. Verificar que no aparecen errores FATAL en el log con queries DELETE con nombre de columna vacío.
4. **Fix 4**: Modificar las claves de `stic_boolean_list` a `yes`/`no`, ejecutar rebuild y verificar que la vista de enumeración booleana sigue teniendo `'1'`/`'0'` como códigos y que los informes booleanos se muestran correctamente.

## Tipos de cambios
- [ ] Corrección de error

**Closes:** #718, #687