### PR TITLE
Hotfix - General - Comprobación estado Usuarios en Oauth

### DIFF
--- a/custom/Extension/modules/Users/Ext/Language/ca_ES.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/ca_ES.SticLang.php
@@ -55,6 +55,7 @@ $mod_strings['LBL_PERIODIC_WORK_CALENDAR_BUTTON'] = 'Genera el Calendari laboral
 $mod_strings['LBL_OAUTH_AUTH_LOGIN_CONTAINER'] = '<h3>Inici de sessió alternatiu</h3>';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_1'] = "L'adreça de correu electrònic ";
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_2'] = " no pertany a cap usuari de SinergiaCRM. Si creieu que és un error, contacteu amb un administrador.";
+$mod_strings['LBL_OAUTH_AUTH_ERR_INACTIVE_USER'] = "L'usuari associat a aquesta adreça de correu electrònic està inactiu. Si creieu que és un error, contacteu amb un administrador.";
 
 // Autenticació OAuth - Google
 $mod_strings['LBL_OAUTH_AUTH_GOOGLE_AUTHENTICATION_TEXT'] = 'Inicia la sessió amb Google';

--- a/custom/Extension/modules/Users/Ext/Language/ca_ES.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/ca_ES.SticLang.php
@@ -56,6 +56,7 @@ $mod_strings['LBL_OAUTH_AUTH_LOGIN_CONTAINER'] = '<h3>Inici de sessió alternati
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_1'] = "L'adreça de correu electrònic ";
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_2'] = " no pertany a cap usuari de SinergiaCRM. Si creieu que és un error, contacteu amb un administrador.";
 $mod_strings['LBL_OAUTH_AUTH_ERR_INACTIVE_USER'] = "L'usuari associat a aquesta adreça de correu electrònic està inactiu. Si creieu que és un error, contacteu amb un administrador.";
+$mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_USER_TYPE'] = "L'usuari associat a aquesta adreça de correu electrònic no pot iniciar sessió mitjançant autenticació externa. Si creieu que és un error, contacteu amb un administrador.";
 
 // Autenticació OAuth - Google
 $mod_strings['LBL_OAUTH_AUTH_GOOGLE_AUTHENTICATION_TEXT'] = 'Inicia la sessió amb Google';

--- a/custom/Extension/modules/Users/Ext/Language/en_us.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/en_us.SticLang.php
@@ -56,6 +56,7 @@ $mod_strings['LBL_OAUTH_AUTH_LOGIN_CONTAINER'] = '<h3>Alternative login</h3>';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_1'] = 'The email address ';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_2'] = ' does not belong to any SinergiaCRM user. If you believe this is an error, please contact an administrator.';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INACTIVE_USER'] = 'The user associated with this email address is inactive. If you believe this is an error, please contact an administrator.';
+$mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_USER_TYPE'] = 'The user associated with this email address cannot log in via external authentication. If you believe this is an error, please contact an administrator.';
 
 // OAuth Authentication - Google
 $mod_strings['LBL_OAUTH_AUTH_GOOGLE_AUTHENTICATION_TEXT'] = 'Login with Google';

--- a/custom/Extension/modules/Users/Ext/Language/en_us.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/en_us.SticLang.php
@@ -55,6 +55,7 @@ $mod_strings['LBL_PERIODIC_WORK_CALENDAR_BUTTON'] = 'Generate Work calendar';
 $mod_strings['LBL_OAUTH_AUTH_LOGIN_CONTAINER'] = '<h3>Alternative login</h3>';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_1'] = 'The email address ';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_2'] = ' does not belong to any SinergiaCRM user. If you believe this is an error, please contact an administrator.';
+$mod_strings['LBL_OAUTH_AUTH_ERR_INACTIVE_USER'] = 'The user associated with this email address is inactive. If you believe this is an error, please contact an administrator.';
 
 // OAuth Authentication - Google
 $mod_strings['LBL_OAUTH_AUTH_GOOGLE_AUTHENTICATION_TEXT'] = 'Login with Google';

--- a/custom/Extension/modules/Users/Ext/Language/es_ES.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/es_ES.SticLang.php
@@ -55,6 +55,7 @@ $mod_strings['LBL_PERIODIC_WORK_CALENDAR_BUTTON'] = 'Generar Calendario laboral'
 $mod_strings['LBL_OAUTH_AUTH_LOGIN_CONTAINER'] = '<h3>Inicio de sesión alternativo</h3>';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_1'] = 'La dirección de correo electrónico ';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_2'] = ' no pertenece a ningún usuario de SinergiaCRM. Si considera que se trata de un error, contacte con un administrador.';
+$mod_strings['LBL_OAUTH_AUTH_ERR_INACTIVE_USER'] = 'El usuario asociado a esta dirección de correo electrónico está inactivo. Si considera que se trata de un error, contacte con un administrador.';
 
 // Autenticación OAuth - Google
 $mod_strings['LBL_OAUTH_AUTH_GOOGLE_AUTHENTICATION_TEXT'] = 'Iniciar sesión con Google';

--- a/custom/Extension/modules/Users/Ext/Language/es_ES.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/es_ES.SticLang.php
@@ -56,6 +56,7 @@ $mod_strings['LBL_OAUTH_AUTH_LOGIN_CONTAINER'] = '<h3>Inicio de sesión alternat
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_1'] = 'La dirección de correo electrónico ';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_2'] = ' no pertenece a ningún usuario de SinergiaCRM. Si considera que se trata de un error, contacte con un administrador.';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INACTIVE_USER'] = 'El usuario asociado a esta dirección de correo electrónico está inactivo. Si considera que se trata de un error, contacte con un administrador.';
+$mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_USER_TYPE'] = 'El usuario asociado a esta dirección de correo electrónico no puede iniciar sesión mediante autenticación externa. Si considera que se trata de un error, contacte con un administrador.';
 
 // Autenticación OAuth - Google
 $mod_strings['LBL_OAUTH_AUTH_GOOGLE_AUTHENTICATION_TEXT'] = 'Iniciar sesión con Google';

--- a/custom/Extension/modules/Users/Ext/Language/eu_ES.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/eu_ES.SticLang.php
@@ -55,6 +55,7 @@ $mod_strings['LBL_PERIODIC_WORK_CALENDAR_BUTTON'] = 'Generar Calendario laboral'
 $mod_strings['LBL_OAUTH_AUTH_LOGIN_CONTAINER'] = '<h3>Inicio de sesión alternativo</h3>';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_1'] = 'La dirección de correo electrónico ';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_2'] = ' no pertenece a ningún usuario de SinergiaCRM. Si considera que se trata de un error, contacte con un administrador.';
+$mod_strings['LBL_OAUTH_AUTH_ERR_INACTIVE_USER'] = 'El usuario asociado a esta dirección de correo electrónico está inactivo. Si considera que se trata de un error, contacte con un administrador.';
 
 // Autenticación OAuth - Google
 $mod_strings['LBL_OAUTH_AUTH_GOOGLE_AUTHENTICATION_TEXT'] = 'Iniciar sesión con Google';

--- a/custom/Extension/modules/Users/Ext/Language/eu_ES.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/eu_ES.SticLang.php
@@ -56,6 +56,7 @@ $mod_strings['LBL_OAUTH_AUTH_LOGIN_CONTAINER'] = '<h3>Inicio de sesión alternat
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_1'] = 'La dirección de correo electrónico ';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_2'] = ' no pertenece a ningún usuario de SinergiaCRM. Si considera que se trata de un error, contacte con un administrador.';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INACTIVE_USER'] = 'El usuario asociado a esta dirección de correo electrónico está inactivo. Si considera que se trata de un error, contacte con un administrador.';
+$mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_USER_TYPE'] = 'El usuario asociado a esta dirección de correo electrónico no puede iniciar sesión mediante autenticación externa. Si considera que se trata de un error, contacte con un administrador.';
 
 // Autenticación OAuth - Google
 $mod_strings['LBL_OAUTH_AUTH_GOOGLE_AUTHENTICATION_TEXT'] = 'Iniciar sesión con Google';

--- a/custom/Extension/modules/Users/Ext/Language/gl_ES.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/gl_ES.SticLang.php
@@ -56,6 +56,7 @@ $mod_strings['LBL_OAUTH_AUTH_LOGIN_CONTAINER'] = '<h3>Inicio de sesión alternat
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_1'] = 'O enderezo de correo electrónico ';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_2'] = ' non pertence a ningún usuario de SinergiaCRM. Se considera que se trata dun erro, contacte cun administrador.';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INACTIVE_USER'] = 'El usuario asociado a esta dirección de correo electrónico está inactivo. Si considera que se trata de un error, contacte con un administrador.';
+$mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_USER_TYPE'] = 'El usuario asociado a esta dirección de correo electrónico no puede iniciar sesión mediante autenticación externa. Si considera que se trata de un error, contacte con un administrador.';
 
 // Autenticación OAuth - Google
 $mod_strings['LBL_OAUTH_AUTH_GOOGLE_AUTHENTICATION_TEXT'] = 'Iniciar sesión con Google';

--- a/custom/Extension/modules/Users/Ext/Language/gl_ES.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/gl_ES.SticLang.php
@@ -55,6 +55,7 @@ $mod_strings['LBL_PERIODIC_WORK_CALENDAR_BUTTON'] = 'Xerar Calendario laboral';
 $mod_strings['LBL_OAUTH_AUTH_LOGIN_CONTAINER'] = '<h3>Inicio de sesión alternativo</h3>';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_1'] = 'O enderezo de correo electrónico ';
 $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_2'] = ' non pertence a ningún usuario de SinergiaCRM. Se considera que se trata dun erro, contacte cun administrador.';
+$mod_strings['LBL_OAUTH_AUTH_ERR_INACTIVE_USER'] = 'El usuario asociado a esta dirección de correo electrónico está inactivo. Si considera que se trata de un error, contacte con un administrador.';
 
 // Autenticación OAuth - Google
 $mod_strings['LBL_OAUTH_AUTH_GOOGLE_AUTHENTICATION_TEXT'] = 'Iniciar sesión con Google';

--- a/modules/Users/authentication/OAuthAuthenticate/OAuthAuthenticate.php
+++ b/modules/Users/authentication/OAuthAuthenticate/OAuthAuthenticate.php
@@ -212,6 +212,10 @@ class OAuthAuthenticate extends SugarAuthenticate
                     $_SESSION['login_error'] = $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_1'] . $email . $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_EMAIL_2'];
                     return false;
                 }
+                if($userBean->status == 'Inactive') {
+                    $_SESSION['login_error'] = $mod_strings['LBL_OAUTH_AUTH_ERR_INACTIVE_USER'];
+                    return false;
+                }
                 $this->userAuthenticate->loadUserOnSession($userBean->id);
 
 	            return $this->postLoginAuthenticate();

--- a/modules/Users/authentication/OAuthAuthenticate/OAuthAuthenticate.php
+++ b/modules/Users/authentication/OAuthAuthenticate/OAuthAuthenticate.php
@@ -216,6 +216,10 @@ class OAuthAuthenticate extends SugarAuthenticate
                     $_SESSION['login_error'] = $mod_strings['LBL_OAUTH_AUTH_ERR_INACTIVE_USER'];
                     return false;
                 }
+                if($userBean->portal_only == '1' || $userBean->is_group == '1') {
+                    $_SESSION['login_error'] = $mod_strings['LBL_OAUTH_AUTH_ERR_INVALID_USER_TYPE'];
+                    return false;
+                }
                 $this->userAuthenticate->loadUserOnSession($userBean->id);
 
 	            return $this->postLoginAuthenticate();


### PR DESCRIPTION

## Descripcion

Se corrige un fallo de seguridad en el flujo de autenticacion OAuth que no aplicaba las mismas restricciones que la autenticacion estandar por usuario/contraseña.

El metodo `OAuthAuthenticate::loginAuthenticate` solo verificaba que el usuario existiera por email, sin comprobar `status`, `portal_only` ni `is_group`. En cambio, `SugarAuthenticateUser::authenticateUser` filtra estas tres condiciones en la query SQL:

```sql
(portal_only IS NULL OR portal_only !='1') AND (is_group IS NULL OR is_group !='1') AND status !='Inactive'
```

Se añaden las tres validaciones al flujo OAuth para que sea consistente.

### Cambios

- `modules/Users/authentication/OAuthAuthenticate/OAuthAuthenticate.php`: +8 lineas. Nuevas comprobaciones de `status == 'Inactive'`, `portal_only == '1'` e `is_group == '1'`.
- `custom/Extension/modules/Users/Ext/Language/*.SticLang.php`: +2 lineas por idioma. Etiquetas `LBL_OAUTH_AUTH_ERR_INACTIVE_USER` y `LBL_OAUTH_AUTH_ERR_INVALID_USER_TYPE`.

## Motivacion y contexto

La autenticacion por contraseña bloquea correctamente a usuarios inactivos, usuarios de portal y grupos. Sin embargo, el login via OAuth (Google/Microsoft) no aplicaba ninguna de estas validaciones, permitiendo el acceso indebido de estos tipos de usuario.

## Como probarlo

1. Habilitar autenticacion OAuth con Google o Microsoft.
2. Probar cada caso:

   **Usuario inactivo (status = Inactive)**:
   - Intentar login via OAuth. Debe mostrar el mensaje de usuario inactivo y denegar acceso.

   **Usuario portal (portal_only = 1)**:
   - Intentar login via OAuth. Debe mostrar el mensaje de tipo de usuario no valido y denegar acceso.

   **Grupo (is_group = 1)**:
   - Intentar login via OAuth. Debe mostrar el mensaje de tipo de usuario no valido y denegar acceso.

3. Verificar que un usuario normal (Activo, sin portal_only ni is_group) puede hacer login via OAuth sin problemas.
4. Verificar que el login estandar por usuario/contraseña sigue funcionando correctamente.

## Tipos de cambios

- [x] Correccion de error
- [ ] Nueva funcionalidad
- [ ] Cambio incompatible