### PR TITLE
Hotfix - Estudio - Asignación de ids para evitar duplicados 

### DIFF
--- a/modules/ModuleBuilder/javascript/studio2.js
+++ b/modules/ModuleBuilder/javascript/studio2.js
@@ -58,8 +58,11 @@ Studio2 = {
 			DDM = YAHOO.utilDragDropMgr;
 		
 		Studio2.maxColumns = parseInt(document.getElementById('maxColumns').value);
-		Studio2.setStartId(parseInt(document.getElementById('idCount').value));
-		Studio2.setStartId(1000);
+		// STIC-Custom 20260602 EPS - set the starting id for dynamically created elements to be above any existing element ids to avoid conflicts
+		// Studio2.setStartId(parseInt(document.getElementById('idCount').value));
+		// Studio2.setStartId(1000);
+		Studio2.setStartId((parseInt(document.getElementById('idCount').value) || 5000) + 1000); // Set 5000 if no idCount is found to avoid conflicts with existing elements, but allow for a large number of existing elements before conflicts arise with the dynamically generated ids
+		// END STIC-Custom
 		Studio2.fieldwidth = parseInt(document.getElementById('fieldwidth').value);
 		Studio2.panelNumber = parseInt(document.getElementById('nextPanelId').value);
 		Studio2.isIE = SUGAR.isIE;


### PR DESCRIPTION
- Closes #1194 

## Description
Se elimina el valor hardcoded que se asignaba para la lista de ids, evitando que se produzcan duplicados cuando la vista es muy grande.
Se asigna el idCount que se recupera (más 1000 como medida de seguridad ya que antes se asignaba este valor hardcoded) y en caso de no encontrarse se incia con 5000.

## Motivation and Context
Evitar los problemas de ids duplicados en vistas muy grandes

## How To Test This
1.- Crear una vista muy grande (como la de pkv_Fisioterapia) con más de 200 campos y múltiples paneles
2.- Comprobar que se pueden añadir paneles, filas y campos en cualquier posición correcta (especial antención hacia el final de la vista que es donde se producía el error)

