### PR TITLE
Hotfix - Recursos y reservas - Crear reserva desde distintas vistas del Calendario

### DIFF
--- a/modules/stic_Bookings_Calendar/Utils.js
+++ b/modules/stic_Bookings_Calendar/Utils.js
@@ -181,9 +181,9 @@ function loadCalendar() {
     select: function (arg) {
       window.location.assign(
         "index.php?module=stic_Bookings&action=EditView&return_action=index&return_module=stic_Bookings_Calendar&start=" +
-          arg.startStr +
+          encodeURIComponent(arg.startStr) +
           "&end=" +
-          arg.endStr +
+          encodeURIComponent(arg.endStr) +
           "&allDay=" +
           arg.allDay
       );

--- a/modules/stic_Bookings_Places_Calendar/Utils.js
+++ b/modules/stic_Bookings_Places_Calendar/Utils.js
@@ -216,9 +216,9 @@ function initializeCalendar() {
     select: function (arg) {
       window.location.assign(
         "index.php?module=stic_Bookings&action=EditView&return_action=index&return_module=stic_Bookings_Places_Calendar&start=" +
-          arg.startStr +
+          encodeURIComponent(arg.startStr) +
           "&end=" +
-          arg.endStr +
+          encodeURIComponent(arg.endStr) +
           "&allDay=" +
           arg.allDay
       );


### PR DESCRIPTION

- closes #1197 
## Description
Cuando un usuario hacía clic en el calendario "Calendario de Plazas" en una vista distinta a Mes (Semana o Día), la pantalla se quedaba en blanco en lugar de navegar al formulario de creación de reserva. En las vistas no-Mes, FullCalendar proporciona fechas en formato con hora y zona horaria (ej: `2023-01-15T09:00:00+02:00`). Los parámetros `start` y `end` no estaban codificados como URL, lo que causaba que el carácter `+` de la zona horaria se interpretara como espacio y se corrompe el valor.

## Pasos para Verificar
1. Ir a Calendario de Plazas → vista Semana → hacer clic en celda vacía → debe abrir formulario de creación
2. Ir a Calendario de Reservas → vista Día → hacer clic en celda vacía → debe abrir formulario de creación
3. Verificar que vista Mes sigue funcionando correctamente