### PR TITLE
Hotfix - Recursos y Reservas - Quitar tooltip vacío en Calendario de plazas

### DIFF
--- a/modules/stic_Bookings_Places_Calendar/Utils.js
+++ b/modules/stic_Bookings_Places_Calendar/Utils.js
@@ -170,6 +170,9 @@ function initializeCalendar() {
           }
         }
       }
+      if (body.trim() === "") {
+        return;
+      }
       $(info.el).qtip({
         content: {
           title: title,


### PR DESCRIPTION
- closes #1199 
## Description
En el Calendario de Plazas (`stic_Bookings_Places_Calendar`), al pasar el cursor por días sin reservas, aparecía un globo tooltip con el título "Detalles Adicionales" pero con contenido vacío.
El problema estaba en `modules/stic_Bookings_Places_Calendar/Utils.js:173-175`. La función creaba el tooltip para cada día con datos de disponibilidad sin verificar si existía contenido. Cuando no había reservas (`occupiedInfo` vacío), `body` permanecía como string vacío pero el globo se mostraba igual.


## How To Test This

1. Acceder al módulo Calendario de Plazas (stic_Bookings_Places_Calendar)
2. Seleccionar un período donde existan tanto días con reservas como días sin reservas
3. Pasar el cursor sobre un día sin reservas
4. Confirmar que NO aparece ningún globo tooltip
5. Pasar el cursor sobre un día con al menos una reserva
6. Confirmar que SÍ aparece el globo con los "Detalles Adicionales" y la información de la reserva

