### PR TITLE
Hotfix - Recursos y Reservas - Asegurar visibilidad de la categoría de recursos en el selector del calendario

### DIFF
--- a/modules/stic_Bookings_Calendar/tpls/filter.tpl
+++ b/modules/stic_Bookings_Calendar/tpls/filter.tpl
@@ -51,7 +51,7 @@
             border: 0 solid rgba(0, 0, 0, 0);
         }
         
-        .option-optgroup {
+        .selectize-control .selectize-dropdown-content .option-optgroup {
             position: relative;
             font-weight: bold;
             background-color: #353535 !important;


### PR DESCRIPTION
## Descripcion

- solves #1203 

Se corrige un problema de contraste en el filtro de recursos del Calendario de Reservas. Las categorías de tipo de recurso (optgroup headers) se mostraban con texto negro sobre fondo casi negro (#353535), lo que las hacía prácticamente ilegibles.

## Cambio realizado

Se ha modificado `modules/stic_Bookings_Calendar/tpls/filter.tpl` para aumentar la especificidad del selector `.option-optgroup` de (0,1,0) a (0,3,0), igualando la especificidad de la regla del tema.

## Cómo probarlo

1. Ir al módulo Calendario de Reservas (stic_Bookings_Calendar).
2. Hacer clic en el campo de filtro de recursos para desplegar las opciones.
3. Verificar que los encabezados de categoría (tipo de recurso) tienen texto BLANCO sobre fondo oscuro (#353535) y son legibles.
4. Verificar que el resto de elementos del desplegable (recursos individuales) mantienen su color original.

## Tipos de cambios

- [x] Correccion de error
- [ ] Nueva funcionalidad
- [ ] Cambio incompatible

## Archivos modificados

- `modules/stic_Bookings_Calendar/tpls/filter.tpl` (1 línea modificada - especificidad CSS)

