### PR TITLE
Hotfix - Formularios Web Avanzados - El aviso de formulario cerrado muestra el texto configurado

### DIFF
--- a/modules/stic_AWF_Forms/EntryPoints/CheckStatus.php
+++ b/modules/stic_AWF_Forms/EntryPoints/CheckStatus.php
@@ -104,8 +104,5 @@ if ($status) {
     }
 }
 
-require_once 'include/utils.php';
-$message = !$isActive ? translate('LBL_THEME_CLOSED_FORM_TEXT_VALUE', 'stic_AWF_Forms') : '';
-echo json_encode(['active' => $isActive, 'message' => $message]);
-
+echo json_encode(['active' => $isActive]);
 exit;

--- a/modules/stic_AWF_Forms/core/FormHtmlGeneratorService.php
+++ b/modules/stic_AWF_Forms/core/FormHtmlGeneratorService.php
@@ -300,7 +300,7 @@ class FormHtmlGeneratorService {
                     $html .= "<div class='awf-overlay-content'>" .$this->newLine('+');
                     {
                         $html .= "<h3 class='h4 text-danger awf-field'>{$closedFormTitle}</h3>" .$this->newLine();
-                        $html .= "<p class='mb-0 lead' x-text='message'>{$closedFormText}</p>" .$this->newLine();
+                        $html .= "<p class='mb-0 lead'>{$closedFormText}</p>" .$this->newLine();
                     }
                     $html .= "</div>" .$this->newLine('-');
                 }
@@ -919,7 +919,6 @@ document.addEventListener('alpine:init', () => {
   Alpine.data('awfForm', (config) => ({
     isActive: true,
     loadTime: 0,
-    message: config.closedFormText,
     submitting: false,
     serverErrors: {},
     
@@ -928,7 +927,6 @@ document.addEventListener('alpine:init', () => {
       if (!config.isPreview && config.checkUrl) {
         fetch(config.checkUrl).then(r => r.json()).then(d => {
           this.isActive = d.active;
-          this.message = this.message === config.closedFormText ? d.message : this.message;
         }).catch(e => console.error(e));
       }
       this.prefillFromUrl();


### PR DESCRIPTION
- Closes #1213 

## Descripción
Tal y como se describe en el Issue #1213, en los Formularios Web Avanzados, en el paso 4 del assistente de edición de formularios (Maquetación), se permite modificar tanto el título como el texto del aviso de formulario cerrado. Ahora bien, si un formulario mostraba ese aviso, el título se mostraba correctamente, pero el texto siempre se mostraba el que viene por defecto: si se modificaba se seguía mostrando el texto original

## Corrección
La corrección aplicada tiene dos cambios:
1. CheckStatus.php: El EntryPoint que retorna si el formulario está activo o no ya no retorna el texto a mostrar (siempre retornaba el texto por defecto)
2. FormGeneratorService.php: El código encargado de generar el HTML del formulario ya no espera el texto y muestra (como en el título) el texto proviniente de la configuración