### PR TITLE
Hotfix - General - Dynamicenum en QuickCreate de subpaneles

### DIFF
--- a/include/SugarFields/Fields/Dynamicenum/SugarFieldDynamicenum.js
+++ b/include/SugarFields/Fields/Dynamicenum/SugarFieldDynamicenum.js
@@ -54,6 +54,10 @@ function addLoadEvent(func) {
 
 function loadDynamicEnum(field, subfield) {
     if (field != '') {
+        // STIC-Custom 20260604 ART - DynamicEnum in quickcreateviews
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        var el = null;
+        // END STIC-Custom
 
         // STIC-Custom - JCH - 2022-09-26 - Add specific method for retrieving parent list value in view list.
         // STIC#865
@@ -72,30 +76,74 @@ function loadDynamicEnum(field, subfield) {
                 var moduleName = module_sugar_grp1;
         //END STIC-Custom
                 var dynamicFieldName = $('form#EditView select').attr('id');
-                var el = $('<input></input>',{
+        // STIC-Custom 20260604 ART - DynamicEnum in quickcreateviews
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        //         var el = $('<input></input>',{
+        //         id:recordId+dynamicFieldName,
+        //         type: 'hidden',
+        //         value: getParentValueFromDynamicEnum(moduleName, recordId, dynamicFieldName)
+        //     }).appendTo($('#'+subfield).parent());
+        //     updateDynamicEnum(recordId+dynamicFieldName, subfield)
+        // } else {
+        //     var el = document.getElementById(field);
+        // }      
+        // // END STIC-Custom
+
+        // if (el) {
+        //     if (el.addEventListener) {
+        //         el.addEventListener("change", function () {
+        //             updateDynamicEnum(field, subfield)
+        //         }, false);
+        //         updateDynamicEnum(field, subfield)
+        //     } else if (el.attachEvent) {
+        //         el.attachEvent("onchange", function () {
+        //             updateDynamicEnum(field, subfield)
+        //         });
+        //         updateDynamicEnum(field, subfield)
+        //     }
+        // }
+                el = $('<input></input>',{
                 id:recordId+dynamicFieldName,
                 type: 'hidden',
                 value: getParentValueFromDynamicEnum(moduleName, recordId, dynamicFieldName)
             }).appendTo($('#'+subfield).parent());
             updateDynamicEnum(recordId+dynamicFieldName, subfield)
         } else {
-            var el = document.getElementById(field);
-        }      
-        // END STIC-Custom
+            
+            // In subpanel quickcreate forms there can be duplicated IDs in the page
+            // (same technical field name in parent module and subpanel module)
+            // Resolve the parent field from the same form as the dynamic child first
+            var subfieldElement = document.getElementById(subfield);
+            if (subfieldElement) {
+                var parentForm = subfieldElement.form || $(subfieldElement).closest('form')[0];
+                if (parentForm && parentForm.elements && parentForm.elements[field]) {
+                    el = parentForm.elements[field];
+                    if (el && el.length && !el.tagName) {
+                        el = el[0];
+                    }
+                }
+            }
+
+            // Backward compatible fallback
+            if (!el) {
+                el = document.getElementById(field);
+            }
+        }
 
         if (el) {
             if (el.addEventListener) {
                 el.addEventListener("change", function () {
-                    updateDynamicEnum(field, subfield)
+                    updateDynamicEnum(el, subfield)
                 }, false);
-                updateDynamicEnum(field, subfield)
+                updateDynamicEnum(el, subfield)
             } else if (el.attachEvent) {
                 el.attachEvent("onchange", function () {
-                    updateDynamicEnum(field, subfield)
+                    updateDynamicEnum(el, subfield)
                 });
-                updateDynamicEnum(field, subfield)
+                updateDynamicEnum(el, subfield)
             }
         }
+        // END STIC-Custom
     }
 }
 
@@ -104,7 +152,18 @@ function updateDynamicEnum(field, subfield) {
 
     if (document.getElementById(subfield) != null) {
         var selector = document.getElementById(subfield);
-        var de_key = document.getElementById(field).value;
+        // STIC-Custom 20260604 ART - DynamicEnum in quickcreateviews
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // var de_key = document.getElementById(field).value;
+        // Get the value of the parent field to filter the dynamicenum values
+        var parentField = (typeof field === 'string') ? document.getElementById(field) : field;
+
+        if (!parentField) {
+            return;
+        }
+
+        var de_key = parentField.value;
+        // END STIC-Custom
 
         var current = [];
         for (var i = 0; i < selector.length; i++) {

--- a/include/SugarFields/Fields/Dynamicenum/SugarFieldDynamicenum.js
+++ b/include/SugarFields/Fields/Dynamicenum/SugarFieldDynamicenum.js
@@ -55,7 +55,7 @@ function addLoadEvent(func) {
 function loadDynamicEnum(field, subfield) {
     if (field != '') {
         // STIC-Custom 20260604 ART - DynamicEnum in quickcreateviews
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1217
         var el = null;
         // END STIC-Custom
 
@@ -77,7 +77,7 @@ function loadDynamicEnum(field, subfield) {
         //END STIC-Custom
                 var dynamicFieldName = $('form#EditView select').attr('id');
         // STIC-Custom 20260604 ART - DynamicEnum in quickcreateviews
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1217
         //         var el = $('<input></input>',{
         //         id:recordId+dynamicFieldName,
         //         type: 'hidden',
@@ -153,7 +153,7 @@ function updateDynamicEnum(field, subfield) {
     if (document.getElementById(subfield) != null) {
         var selector = document.getElementById(subfield);
         // STIC-Custom 20260604 ART - DynamicEnum in quickcreateviews
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1217
         // var de_key = document.getElementById(field).value;
         // Get the value of the parent field to filter the dynamicenum values
         var parentField = (typeof field === 'string') ? document.getElementById(field) : field;

--- a/modules/DynamicFields/DynamicField.php
+++ b/modules/DynamicFields/DynamicField.php
@@ -754,7 +754,7 @@ class DynamicField
                         is_string($field->ext3) ? htmlspecialchars_decode($field->ext3, ENT_QUOTES) : $field->ext3;
                 } else {
                     // STIC-Custom 20260604 ART - Prevent warnings when $field->$property is not defined (null) and avoid saving empty values as default ones in the _override file
-                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/1217
                     // $to_save[$property] =
                     //     is_string($field->$property) ? htmlspecialchars_decode($field->$property, ENT_QUOTES) : $field->$property;
                     $propertyValue = $field->$property ?? null;
@@ -801,7 +801,7 @@ class DynamicField
                 // STIC#679
                 // STIC#949
                 // STIC-Custom 20260604 ART - Prevent warnings when $field->$property is not defined (null) and avoid saving empty values as default ones in the _override file
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/1217
                 // if ($property == 'display_default' && is_null($field->display_default)) {
                 //     $to_save['display_default'] = $field->default;
                 if ($property == 'display_default' && is_null($field->display_default ?? null)) {

--- a/modules/DynamicFields/DynamicField.php
+++ b/modules/DynamicFields/DynamicField.php
@@ -753,8 +753,14 @@ class DynamicField
                     $to_save[$property] =
                         is_string($field->ext3) ? htmlspecialchars_decode($field->ext3, ENT_QUOTES) : $field->ext3;
                 } else {
+                    // STIC-Custom 20260604 ART - Prevent warnings when $field->$property is not defined (null) and avoid saving empty values as default ones in the _override file
+                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                    // $to_save[$property] =
+                    //     is_string($field->$property) ? htmlspecialchars_decode($field->$property, ENT_QUOTES) : $field->$property;
+                    $propertyValue = $field->$property ?? null;
                     $to_save[$property] =
-                        is_string($field->$property) ? htmlspecialchars_decode($field->$property, ENT_QUOTES) : $field->$property;
+                        is_string($propertyValue) ? htmlspecialchars_decode($propertyValue, ENT_QUOTES) : $propertyValue;
+                    // END STIC-Custom
                 }
 
                 // The property duplicate_merge is dependent of the property duplicate_merge_dom_value.
@@ -794,8 +800,13 @@ class DynamicField
                 // In that case we set the same value as the default property
                 // STIC#679
                 // STIC#949
-                if ($property == 'display_default' && is_null($field->display_default)) {
-                    $to_save['display_default'] = $field->default;
+                // STIC-Custom 20260604 ART - Prevent warnings when $field->$property is not defined (null) and avoid saving empty values as default ones in the _override file
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // if ($property == 'display_default' && is_null($field->display_default)) {
+                //     $to_save['display_default'] = $field->default;
+                if ($property == 'display_default' && is_null($field->display_default ?? null)) {
+                    $to_save['display_default'] = $field->default ?? null;
+                // END STIC-Custom
                 }
             }
             // STIC-custom PCS 20230509 - Adding code for avoid not saving HTML fields.


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/1215

## Description
Este PR corrige un problema de sincronización de `dynamicenum` en los QuickCreate de subpanel cuando el nombre del campo padre está duplicado en otra parte de la vista (por ejemplo, mismo nombre técnico en el módulo padre y en el módulo del subpanel).

## Motivation and Context
En QuickCreate de subpanel, `dynamicenum` utilizaba búsqueda global por ID para el campo padre. Si la página contenía nombres técnicos/IDs duplicados, podía seleccionar un campo padre incorrecto y las opciones dependientes quedaban vacías o no se actualizaban.

Este cambio acota primero la resolución del campo padre al formulario local, evitando colisiones y preservando el comportamiento existente mediante fallback.

1. En `loadDynamicEnum(field, subfield)`:
   - Se prioriza resolver el campo padre desde el mismo formulario que contiene el campo hijo dinámico (`subfield`).
   - Se mantiene `document.getElementById(field)` como fallback compatible hacia atrás.

2. En `updateDynamicEnum(field, subfield)`:
   - Se soporta tanto un `id` de campo (string) como una referencia DOM del campo padre.
   - Se añade una salida de seguridad si no se puede resolver el campo padre.

3. En el flujo de DynamicFields:
   - Se asegura compatibilidad en el comportamiento de metadatos/overrides del ciclo de vida de campos personalizados para que el render de QuickCreate mantenga una configuración consistente de dynamicenum cuando los campos se actualizan desde Studio.

## How To Test This
1. Crear en `Contacts` un campo con nombre técnico `origen_c` (enum o bool, por ejemplo). O incluso, se puede coger el campo existente `stic_identification_type_c`.
2. Crear en `stic_Journal` dos campos:
   - `origen_c` (enum) o `stic_identification_type_c` (si se escoge el campo existente). Añadir los siguientes valores:
```
(Valor vacío)
ValorA
ValorB
ValorC
```

   - `suborigen_c` (dynamicenum). Añadir los siguientes valores:
```
(Valor vacío)
ValorA_Subvalor1
ValorA_Subvalor2
ValorA_Subvalor3
ValorB_Subvalor1
ValorB_Subvalor2
ValorC_Subvalor1
ValorC_Subvalor2
ValorC_Subvalor3
```

3. Añadir los campos en el QuickCreate de `stic_Journal`.
4. Ir a un registro de `Contacts` y “Crear un nuevo diario” desde el subpanel.
5. Cambiar `origen_c` en el QuickCreate.
6. Comprobar que `suborigen_c` se rellena/filtra correctamente.
7. Abrir el mismo caso en `EditView` y comprobar que también funciona.