### PR TITLE
Improvement - Formularios Web Avanzados - Mostrar escala 0-10 sin remarcado rojo-amarillo-verde según valor

### DIFF
--- a/modules/stic_AWF_Forms/core/FormHtmlGeneratorService.php
+++ b/modules/stic_AWF_Forms/core/FormHtmlGeneratorService.php
@@ -1095,9 +1095,7 @@ JS;
     },
     npsClass(i) { 
       if(this.val !== i) return 'btn-outline-secondary opacity-75';
-      if(i <= 6) return 'btn-danger text-white border-danger shadow-sm';
-      if(i <= 8) return 'btn-warning text-dark border-warning shadow-sm';
-      return 'btn-success text-white border-success shadow-sm';
+      return 'btn-primary border-primary shadow-sm';
     },
     starContainerStyle(i) {
       const baseStyle = 'width: 1.5rem; height: 1.5rem; transform-origin: center center; transition: all 0.2s ease; margin-bottom: 0.5rem;';


### PR DESCRIPTION
- Closes #1226 

## Descripción
Mediante este PR se elimina el marcado de color del valor seleccionado en el control de Escala 0-10. Tal y como se describe en #1226, el control estaba inicialmente pensado como un control NPS  ([Net Promoter Score](https://es.wikipedia.org/wiki/Net_Promoter_Score)), el cual marca tres tramos de puntuación:
- 0-6: Detractores (marcados en rojo)
- 7-8: Neutros (marcados en amarillo)
- 9-10: Promotores (marcados en verde 

Pero este no es el uso principal del control (ni se espera que lo sea). Por este motivo se elimina el remarcado en color rojo-amarillo-verde de la puntuación seleccionada. El remarcado se realizará con el color principal definido en el formulario.

## Pruebas
1. Crear un Formulario Web Avanzado
2. En el paso de "Estructura y Campos", añadir un campo no enlazado del Tipo "**Valoración**" y Subtipo "**Escala 0-10**"
3. Publicar el Formulario
4. Acceder al Formulario y rellenar el campo de Escala 0-10
5. Verificar que al marcar cualquier valor del campo, el valor queda remarcado con el color principal
6. Enviar la respuesta
7. Localizar la respuesta del formulario y visualizarla
8. Verificar que en el resumen de la respuesta recibida el valor está marcado con el color principal 
