### PR TITLE
Hotfix - Flujos de trabajo - Condiciones de FdT sobre campos relacionados custom

### DIFF
--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -783,7 +783,7 @@ class AOW_WorkFlow extends Basic
 
                 // STIC-Custom 20260604 PCS - Load relationship if relate field ID is empty
                 // https://github.com/SinergiaTIC/SinergiaCRM/pull/1223
-                if ($field === null && $data['type'] === 'relate' && isset($data['link'])) {
+                if (empty($field) && $data['type'] === 'relate' && isset($data['link'])) {
                     $condition_bean->load_relationship($data['link']);
                     $relatedBeans = $condition_bean->{$data['link']}->getBeans();
                     if (!empty($relatedBeans)) {

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -780,6 +780,18 @@ class AOW_WorkFlow extends Basic
                 // $field = $condition_bean->$field;
                 $field = $condition_bean->$field ?? null;
                 // END STIC Custom
+
+                // STIC-Custom 20260604 PCS - Load relationship if relate field ID is empty
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                if ($field === null && $data['type'] === 'relate' && isset($data['link'])) {
+                    $condition_bean->load_relationship($data['link']);
+                    $relatedBeans = $condition_bean->{$data['link']}->getBeans();
+                    if (!empty($relatedBeans)) {
+                        $relatedBean = reset($relatedBeans);
+                        $field = $relatedBean->id;
+                    }
+                }
+                // END STIC-Custom
                 
                 if (in_array($data['type'], $dateFields)) {
                     $field = strtotime($field);

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -782,7 +782,7 @@ class AOW_WorkFlow extends Basic
                 // END STIC Custom
 
                 // STIC-Custom 20260604 PCS - Load relationship if relate field ID is empty
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/1223
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/1232
                 if (empty($field) && $data['type'] === 'relate' && isset($data['link'])) {
                     $condition_bean->load_relationship($data['link']);
                     $relatedBeans = $condition_bean->{$data['link']}->getBeans();

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -782,11 +782,6 @@ class AOW_WorkFlow extends Basic
                 // END STIC Custom
 
                 // STIC-Custom 20260604 PCS - Load relationship if relate field ID is empty
-                // Issue #1222: Workflow conditions on custom related fields fail because
-                // the relationship is not loaded before evaluating the condition.
-                // When a bean is loaded programmatically (callbacks, hooks, CLI, imports),
-                // relate fields with source => non-db have null ID. This fallback loads
-                // the relationship to get the correct ID for condition evaluation.
                 // https://github.com/SinergiaTIC/SinergiaCRM/pull/1223
                 if ($field === null && $data['type'] === 'relate' && isset($data['link'])) {
                     $condition_bean->load_relationship($data['link']);

--- a/modules/AOW_WorkFlow/AOW_WorkFlow.php
+++ b/modules/AOW_WorkFlow/AOW_WorkFlow.php
@@ -782,7 +782,12 @@ class AOW_WorkFlow extends Basic
                 // END STIC Custom
 
                 // STIC-Custom 20260604 PCS - Load relationship if relate field ID is empty
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // Issue #1222: Workflow conditions on custom related fields fail because
+                // the relationship is not loaded before evaluating the condition.
+                // When a bean is loaded programmatically (callbacks, hooks, CLI, imports),
+                // relate fields with source => non-db have null ID. This fallback loads
+                // the relationship to get the correct ID for condition evaluation.
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/1223
                 if ($field === null && $data['type'] === 'relate' && isset($data['link'])) {
                     $condition_bean->load_relationship($data['link']);
                     $relatedBeans = $condition_bean->{$data['link']}->getBeans();


### PR DESCRIPTION
- closes #1222 
## Resumen
Corrección de la evaluación de condiciones en flujos de trabajo para campos relacionados custom (`relate` con `source => non-db`) que siempre fallaban porque la relación no se cargaba antes de acceder al campo ID.

En `AOW_WorkFlow::check_valid_bean()`, al evaluar condiciones sobre campos relate, el código accedía directamente a `$condition_bean->$field` sin cargar la relación primero. Como los campos relate con `source => non-db` almacenan su ID en una tabla de relación separada, el valor del campo era siempre `null` cuando el bean se cargaba programáticamente (formulario de captación).

## Solución
Se ha añadido la relación cuando el campo ID del relate está vacío (`null`):

```php
// STIC-Custom 20260604 - Cargar relación si el campo ID del relate está vacío
if ($field === null && $data['type'] === 'relate' && isset($data['link'])) {
    $condition_bean->load_relationship($data['link']);
    $relatedBeans = $condition_bean->{$data['link']}->getBeans();
    if (!empty($relatedBeans)) {
        $relatedBean = reset($relatedBeans);
        $field = $relatedBean->id;
    }
}
```

## Pasos para probar la solución


1. Crear una relación custom 1-N entre **Project** y **stic_Payments** (Pagos)
   - Studio → stic_Payments → Relationships → Create Relationship
   - O crear manualmente en `custom/Extension/modules/stic_Payments/Ext/Vardefs/`

2. Crear un proyecto de prueba llamado "Libros sin olvido"

3. Crear un Compromiso de Pago (CP) asociado al proyecto "Libros sin olvido"

4. **FdT 1** (Calcular campos):
   - Módulo: Pagos
   - Disparador: Al guardar
   - Condiciones: Ninguna
   - Acción: Calcular campos → Copiar campo Proyecto desde CP al Pago

5. **FdT 2** (Modificar campos - el que fallaba):
   - Módulo: Pagos
   - Disparador: Al guardar
   - Condiciones:
     - Estado = Pagado
     - Método de pago = Tarjeta Redsys
     - Proyecto = "Libros sin olvido" (campo relacionado custom)
   - Acción: Modificar campos → Descripción = "EJECUTADO en PAGADO"

 **Prueba 1: Guardar desde código (caso que fallaba)**

6. Ejecutar desde un formulario de captación de fondos 
7. **Resultado esperado:** El FdT 2 se ejecuta y la descripción del pago se actualiza a "EJECUTADO en PAGADO"

**Prueba 2: Guardar desde interfaz de usuario**

8. Editar el mismo pago desde EditView y cambiar el estado a "Pagado"
9. **Resultado esperado:** El FdT 2 se ejecuta correctamente (comportamiento existente)

 **Prueba 3: Condición que NO debe cumplirse**

10. Cambiar la condición del FdT 2 a Proyecto = "Otro proyecto"
11. Guardar el pago
12. **Resultado esperado:** El FdT 2 NO se ejecuta (la condición es correcta)

**Prueba 4: FdT sin condiciones sobre campos relacionados**

13. Crear un FdT sin condiciones que modifique un campo
14. Guardar un pago
15. **Resultado esperado:** El FdT se ejecuta 
---
