### PR TITLE
Improvement - Formularios Web Avanzados - Configuración del título de los Formularios y pequeñas mejoras en Maquetación

### DIFF
--- a/modules/stic_AWF_Forms/core/FormHtmlGeneratorService.php
+++ b/modules/stic_AWF_Forms/core/FormHtmlGeneratorService.php
@@ -55,7 +55,7 @@ class FormHtmlGeneratorService {
             {
                 $htmlRaw .= "<meta charset='UTF-8'>" .$this->newLine();
                 $htmlRaw .= "<meta name='viewport' content='width=device-width, initial-scale=1.0'>" .$this->newLine();
-                $htmlRaw .= "<title>Advanced Web Form</title>" .$this->newLine();
+                $htmlRaw .= "<title>" . htmlspecialchars($config->layout->web_title) . "</title>" .$this->newLine();
         
                 // External libraries (Bootstrap + Alpine)
                 $htmlRaw .= '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">' .$this->newLine();

--- a/modules/stic_AWF_Forms/core/formdefs/FormLayout.php
+++ b/modules/stic_AWF_Forms/core/formdefs/FormLayout.php
@@ -29,6 +29,8 @@ class FormLayout {
     public FormConfig $form_config;    // The configuration of the form to which it belongs
 
     public FormTheme $theme;
+    public string $web_title = 'Advanced Web Form';
+
     public string $header_html = '';
     public string $footer_html = '';
 
@@ -51,6 +53,8 @@ class FormLayout {
         $dto->form_config = $form;
 
         $dto->theme = FormTheme::fromJsonArray($dto, $data['theme'] ?? []);
+
+        $dto->web_title = $data['web_title'] ?? translate('LBL_THEME_WEB_TITLE_VALUE', 'stic_AWF_Forms');
 
         $dto->header_html = $data['header_html'] ?? '';
         $dto->footer_html = $data['footer_html'] ?? '';

--- a/modules/stic_AWF_Forms/js/stic_AwfClasses.js
+++ b/modules/stic_AWF_Forms/js/stic_AwfClasses.js
@@ -963,6 +963,8 @@ class stic_AwfLayout {
     Object.assign(this, {
       theme: new stic_AwfTheme(),      // Visual variables of the form
 
+      web_title: utils.translate('LBL_THEME_WEB_TITLE_VALUE'),  // Title of the web page
+
       header_html: '',             // Html with the header of the form
       footer_html: '',             // Html with the footer of the form
 

--- a/modules/stic_AWF_Forms/language/ca_ES.lang.php
+++ b/modules/stic_AWF_Forms/language/ca_ES.lang.php
@@ -272,6 +272,8 @@ $mod_strings = array (
   'LBL_LAYOUT_FOOTER' => 'Peu',
 
   // Layout -> Theme
+  'LBL_THEME_WEB_TITLE_TEXT' => 'Títol de la pàgina',
+  'LBL_THEME_WEB_TITLE_VALUE' => 'Formulari Web Avançat',
   'LBL_THEME_SUBMIT_BUTTON_TEXT' => "Text del botó d'enviament",
   'LBL_THEME_SUBMIT_BUTTON_TEXT_VALUE' => 'Envia',
   'LBL_THEME_MAIN_COLORS' => 'Colors',

--- a/modules/stic_AWF_Forms/language/ca_ES.lang.php
+++ b/modules/stic_AWF_Forms/language/ca_ES.lang.php
@@ -268,10 +268,10 @@ $mod_strings = array (
   'LBL_LAYOUT_FORM_DESIGN' => 'Disseny del formulari',
   'LBL_LAYOUT_PREVIEW' => 'Previsualització',
   'LBL_LAYOUT_HEADER' => 'Capçalera',
-  'LBL_LAYOUT_BODY' => 'Formulari',
   'LBL_LAYOUT_FOOTER' => 'Peu',
 
   // Layout -> Theme
+  'LBL_THEME_GENERAL' => 'General',
   'LBL_THEME_WEB_TITLE_TEXT' => 'Títol de la pàgina',
   'LBL_THEME_WEB_TITLE_VALUE' => 'Formulari Web Avançat',
   'LBL_THEME_SUBMIT_BUTTON_TEXT' => "Text del botó d'enviament",

--- a/modules/stic_AWF_Forms/language/en_us.lang.php
+++ b/modules/stic_AWF_Forms/language/en_us.lang.php
@@ -268,10 +268,10 @@ $mod_strings = array (
   'LBL_LAYOUT_FORM_DESIGN' => 'Form design',
   'LBL_LAYOUT_PREVIEW' => 'Preview',
   'LBL_LAYOUT_HEADER' => 'Header',
-  'LBL_LAYOUT_BODY' => 'Form',
   'LBL_LAYOUT_FOOTER' => 'Footer',
 
   // Layout -> Theme
+  'LBL_THEME_GENERAL' => 'General',
   'LBL_THEME_WEB_TITLE_TEXT' => 'Page title',
   'LBL_THEME_WEB_TITLE_VALUE' => 'Advanced Web Form',
   'LBL_THEME_SUBMIT_BUTTON_TEXT' => 'Submit button text',

--- a/modules/stic_AWF_Forms/language/en_us.lang.php
+++ b/modules/stic_AWF_Forms/language/en_us.lang.php
@@ -272,6 +272,8 @@ $mod_strings = array (
   'LBL_LAYOUT_FOOTER' => 'Footer',
 
   // Layout -> Theme
+  'LBL_THEME_WEB_TITLE_TEXT' => 'Page title',
+  'LBL_THEME_WEB_TITLE_VALUE' => 'Advanced Web Form',
   'LBL_THEME_SUBMIT_BUTTON_TEXT' => 'Submit button text',
   'LBL_THEME_SUBMIT_BUTTON_TEXT_VALUE' => 'Submit',
   'LBL_THEME_MAIN_COLORS' => 'Colors',

--- a/modules/stic_AWF_Forms/language/es_ES.lang.php
+++ b/modules/stic_AWF_Forms/language/es_ES.lang.php
@@ -268,10 +268,10 @@ $mod_strings = array (
   'LBL_LAYOUT_FORM_DESIGN' => 'Diseño del formulario',
   'LBL_LAYOUT_PREVIEW' => 'Previsualización',
   'LBL_LAYOUT_HEADER' => 'Cabecera',
-  'LBL_LAYOUT_BODY' => 'Formulario',
   'LBL_LAYOUT_FOOTER' => 'Pie',
 
   // Layout -> Theme
+  'LBL_THEME_GENERAL' => 'General',
   'LBL_THEME_WEB_TITLE_TEXT' => 'Título de la página',
   'LBL_THEME_WEB_TITLE_VALUE' => 'Formulario Web Avanzado',
   'LBL_THEME_SUBMIT_BUTTON_TEXT' => 'Texto del botón de envío',

--- a/modules/stic_AWF_Forms/language/es_ES.lang.php
+++ b/modules/stic_AWF_Forms/language/es_ES.lang.php
@@ -272,6 +272,8 @@ $mod_strings = array (
   'LBL_LAYOUT_FOOTER' => 'Pie',
 
   // Layout -> Theme
+  'LBL_THEME_WEB_TITLE_TEXT' => 'Título de la página',
+  'LBL_THEME_WEB_TITLE_VALUE' => 'Formulario Web Avanzado',
   'LBL_THEME_SUBMIT_BUTTON_TEXT' => 'Texto del botón de envío',
   'LBL_THEME_SUBMIT_BUTTON_TEXT_VALUE' => 'Enviar',
   'LBL_THEME_MAIN_COLORS' => 'Colores',

--- a/modules/stic_AWF_Forms/language/eu_ES.lang.php
+++ b/modules/stic_AWF_Forms/language/eu_ES.lang.php
@@ -268,10 +268,10 @@ $mod_strings = array (
   'LBL_LAYOUT_FORM_DESIGN' => 'Diseño del formulario',
   'LBL_LAYOUT_PREVIEW' => 'Previsualización',
   'LBL_LAYOUT_HEADER' => 'Cabecera',
-  'LBL_LAYOUT_BODY' => 'Formulario',
   'LBL_LAYOUT_FOOTER' => 'Pie',
 
   // Layout -> Theme
+  'LBL_THEME_GENERAL' => 'General',
   'LBL_THEME_WEB_TITLE_TEXT' => 'Título de la página',
   'LBL_THEME_WEB_TITLE_VALUE' => 'Formulario Web Avanzado',  
   'LBL_THEME_SUBMIT_BUTTON_TEXT' => 'Texto del botón de envío',

--- a/modules/stic_AWF_Forms/language/eu_ES.lang.php
+++ b/modules/stic_AWF_Forms/language/eu_ES.lang.php
@@ -272,6 +272,8 @@ $mod_strings = array (
   'LBL_LAYOUT_FOOTER' => 'Pie',
 
   // Layout -> Theme
+  'LBL_THEME_WEB_TITLE_TEXT' => 'Título de la página',
+  'LBL_THEME_WEB_TITLE_VALUE' => 'Formulario Web Avanzado',  
   'LBL_THEME_SUBMIT_BUTTON_TEXT' => 'Texto del botón de envío',
   'LBL_THEME_SUBMIT_BUTTON_TEXT_VALUE' => 'Enviar',
   'LBL_THEME_MAIN_COLORS' => 'Colores',

--- a/modules/stic_AWF_Forms/language/gl_ES.lang.php
+++ b/modules/stic_AWF_Forms/language/gl_ES.lang.php
@@ -268,10 +268,10 @@ $mod_strings = array (
   'LBL_LAYOUT_FORM_DESIGN' => 'Diseño del formulario',
   'LBL_LAYOUT_PREVIEW' => 'Previsualización',
   'LBL_LAYOUT_HEADER' => 'Cabecera',
-  'LBL_LAYOUT_BODY' => 'Formulario',
   'LBL_LAYOUT_FOOTER' => 'Pie',
 
   // Layout -> Theme
+  'LBL_THEME_GENERAL' => 'General',
   'LBL_THEME_WEB_TITLE_TEXT' => 'Título de la página',
   'LBL_THEME_WEB_TITLE_VALUE' => 'Formulario Web Avanzado',
   'LBL_THEME_SUBMIT_BUTTON_TEXT' => 'Texto del botón de envío',

--- a/modules/stic_AWF_Forms/language/gl_ES.lang.php
+++ b/modules/stic_AWF_Forms/language/gl_ES.lang.php
@@ -272,6 +272,8 @@ $mod_strings = array (
   'LBL_LAYOUT_FOOTER' => 'Pie',
 
   // Layout -> Theme
+  'LBL_THEME_WEB_TITLE_TEXT' => 'Título de la página',
+  'LBL_THEME_WEB_TITLE_VALUE' => 'Formulario Web Avanzado',
   'LBL_THEME_SUBMIT_BUTTON_TEXT' => 'Texto del botón de envío',
   'LBL_THEME_SUBMIT_BUTTON_TEXT_VALUE' => 'Enviar',
   'LBL_THEME_MAIN_COLORS' => 'Colores',

--- a/modules/stic_AWF_Forms/ui/WizardView/steps/step4.html
+++ b/modules/stic_AWF_Forms/ui/WizardView/steps/step4.html
@@ -29,17 +29,32 @@
          <div class="col-md-3 border-end bg-light overflow-auto p-3" style="max-height: calc(100vh - 200px);">
             <h3 class="mb-3" x-text="utils.translate('LBL_LAYOUT_SETTINGS')"></h3>
 
-            <!-- web_title -->
-            <div class="mb-3 row">
-                <label for="theme-web_title" class="form-label small" x-text="utils.translateForFieldLabel('LBL_THEME_WEB_TITLE_TEXT')"></label>
-                <input id="theme-web_title" type="text" x-model="formConfig.layout.web_title">
-            </div>
+            <!-- General: Title and submit -->
+            <details class="mb-3">
+                <summary class="cursor-pointer user-select-none" x-text="utils.translate('LBL_THEME_GENERAL')"></summary>
+                <div class="ps-4 g-2  mt-2">
+                    <!-- web_title -->
+                    <div class="mb-3 row">
+                        <label for="theme-web_title" class="form-label small" x-text="utils.translateForFieldLabel('LBL_THEME_WEB_TITLE_TEXT')"></label>
+                        <input id="theme-web_title" type="text" x-model="formConfig.layout.web_title">
+                    </div>
 
-            <!-- submit_button_text -->
-            <div class="mb-3 row">
-                <label for="theme-submit_button_text" class="form-label small" x-text="utils.translateForFieldLabel('LBL_THEME_SUBMIT_BUTTON_TEXT')"></label>
-                <input id="theme-submit_button_text" type="text" x-model="formConfig.layout.submit_button_text">
-            </div>
+                    <!-- submit_button_text -->
+                    <div class="mb-3 row">
+                        <label for="theme-submit_button_text" class="form-label small" x-text="utils.translateForFieldLabel('LBL_THEME_SUBMIT_BUTTON_TEXT')"></label>
+                        <input id="theme-submit_button_text" type="text" x-model="formConfig.layout.submit_button_text">
+                    </div>
+
+                    <!-- submit_full_width -->
+                    <div class="mb-3">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" id="theme-submit_full_width" x-model="formConfig.layout.theme.submit_full_width"
+                                   :true-value="'full'" :false-value="'auto'">
+                            <label class="form-check-label small" for="theme-submit_full_width" x-text="utils.translate('LBL_THEME_SUBMIT_FULL_WIDTH')"></label>
+                        </div>
+                    </div>                    
+                </div>
+            </details>
 
             <!-- Main colors -->
             <details class="mb-3">
@@ -236,14 +251,6 @@
                             <label class="form-check-label small" for="theme-equal_height_sections" x-text="utils.translate('LBL_THEME_EQUAL_HEIGHT_SECTIONS')"></label>
                         </div>
                     </div>
-                    <!-- submit_full_width -->
-                    <div class="mb-3">
-                        <div class="form-check form-switch">
-                            <input class="form-check-input" type="checkbox" id="theme-submit_full_width" x-model="formConfig.layout.theme.submit_full_width"
-                                   :true-value="'full'" :false-value="'auto'">
-                            <label class="form-check-label small" for="theme-submit_full_width" x-text="utils.translate('LBL_THEME_SUBMIT_FULL_WIDTH')"></label>
-                        </div>
-                    </div>
                 </div>
             </details>
 
@@ -395,9 +402,6 @@
 
                             <!-- Body -->
                             <div class="accordion-item">
-                                <div id="LayoutBody_Header" class="pt-3 ps-3 accordion-header card-header" aria-controls="LayoutBody_Content">
-                                    <h3 x-text="utils.translate('LBL_LAYOUT_BODY')"></h3>
-                                </div>
                                 <div id="LayoutBody_Content" class="accordion-collapse show" aria-labelledby="LayoutBody_Header">
                                     <div id="LayoutBody_Body" class="accordion-body"> 
                                         <div class="flex-fill border rounded p-2 overflow-auto">

--- a/modules/stic_AWF_Forms/ui/WizardView/steps/step4.html
+++ b/modules/stic_AWF_Forms/ui/WizardView/steps/step4.html
@@ -29,6 +29,12 @@
          <div class="col-md-3 border-end bg-light overflow-auto p-3" style="max-height: calc(100vh - 200px);">
             <h3 class="mb-3" x-text="utils.translate('LBL_LAYOUT_SETTINGS')"></h3>
 
+            <!-- web_title -->
+            <div class="mb-3 row">
+                <label for="theme-web_title" class="form-label small" x-text="utils.translateForFieldLabel('LBL_THEME_WEB_TITLE_TEXT')"></label>
+                <input id="theme-web_title" type="text" x-model="formConfig.layout.web_title">
+            </div>
+
             <!-- submit_button_text -->
             <div class="mb-3 row">
                 <label for="theme-submit_button_text" class="form-label small" x-text="utils.translateForFieldLabel('LBL_THEME_SUBMIT_BUTTON_TEXT')"></label>


### PR DESCRIPTION
- Closes #1235 

## Descripción
Este PR añade la opción de configurar el título de la página donde se aloja el Formulario Web Avanzado. Este título se puede configurar en el paso "Maquetación" del asistente de edición de Formularios Web Avanzados

También realiza pequeños cambios en la página de Maquetación del asistente de edición de Formularios Web:
1. Crea una nueva sección de configuración con el nombre "General" que agrupa:
    - Título de la página (nuevo campo)
    - Texto del botón de envío (antes aparecía fuera de la estructura de configuraciones)
    - Ancho completo del botón de envío (antes estaba en la sección "Estructura y distribución")
 2. En la pestaña de Diseño del formulario (zona central de la pantalla), se elimina la cabecera "Formulario": Antes la zona central estaba estructurada en 3 partes: Cabecera-Formulario-Pie. Ahora se ha eliminado la parte central, que ya incluye el apartado "Secciones"

## Pruebas
1. Editar un Formulario Web Avanzado
3. En el paso 4 (Maquetación), verificar que aparece la opción "Título de la página"
4. Editar el título de la página del formulario
5. Publicar el formulario
6. Acceder al formulario y verificar que el título es correcto (nombre de la pestaña en el navegador)