### PR TITLE
Hotfix - Formularios Web Avanzados - Acción en caso de duplicado visualizada correctamente con el valor guardado al reabrir el formulario

### DIFF
--- a/modules/stic_AWF_Forms/ui/WizardView/steps/step2.html
+++ b/modules/stic_AWF_Forms/ui/WizardView/steps/step2.html
@@ -288,7 +288,7 @@
                           </td>
                           <!-- Duplicate Action -->
                           <td class="col-3">
-                            <select :id="`duplicateAction${item.id}${index}`" class="form-select" x-model="dupli.on_duplicate">
+                            <select :id="`duplicateAction${item.id}${index}`" class="form-select" x-model="dupli.on_duplicate" x-init="$nextTick(() => $el.value = dupli.on_duplicate)">
                               <template x-for="action in stic_AwfDuplicateDetection.on_duplicateList()" :key="action.id">
                                 <option :value="action.id" x-text="action.text"></option>
                               </template>


### PR DESCRIPTION
- Closes #1238 

## Descripción
Tal y como se describe en #1238, al reabrir la edición de un Formulario Web Avanzado, en el paso 2 "Estructura y Campos", en el apartado "Detección de duplicados" de cualquier Bloque de Datos, la "Acción en caso de duplicado" siempre se mostraba "Amplia", independientemente del valor real que tuviera.

Esto era debido a que se intentaba mostrar el valor a mostrar en el desplegable antes que éste los hubiera cargado en la vista.

La corrección implementada fuerza la asignación del valor en el control al valor guardado cuando el control ya esté del todo inicializado

## Pruebas
1. Editar un Formulario Web Avanzado
2. Añadir un Bloque de Datos enlazado
3. Indicar detección de duplicados con una acción distinta a "Amplia", por ejemplo "Ignora"
4. Guardar el formulario
5. Volver a editar el formulario y visualizar la detección de duplicados editada en el paso 3
6. Verificar que la acción se muestra correctamente