### PR TITLE
Hotfix - Formularios Web Avanzados - Detección correcta de campo vacío en campos multienum

### DIFF
--- a/modules/stic_AWF_Forms/actions/Hook/SaveRecordAction.php
+++ b/modules/stic_AWF_Forms/actions/Hook/SaveRecordAction.php
@@ -344,7 +344,7 @@ class SaveRecordAction extends HookDataBlockActionDefinition {
 
             $oldValue = isset($bean->$targetField) ? $bean->$targetField : null;
             // Check if the field in the bean is empty or null
-            $isEmpty = ($oldValue === null || $oldValue === '');
+            $isEmpty = ($oldValue === null || $oldValue === '' || $oldValue === '^^');
 
             // Check if the field is boolean (in that case, consider false as empty)
             $isBoolean = ($fieldDef && isset($fieldDef['type']) && ($fieldDef['type'] === 'bool' || $fieldDef['type'] === 'boolean'));


### PR DESCRIPTION
- Closes #1240 

## Descripción
Tal y como se describe en #1240, no se detectaba correctamente que los campos de multiselección estaban vacíos para actualizar su valor. El problema era debido a que realmente el valor vacío en estos campos es almacenado como `^^` y no se tenía en cuenta.

## Pruebas
1. Crear un Formulario Web Avanzado
2. Añadir un bloque de datos para el módulo Persona y añadir el campo "Perfil trabajador"
3. Configurar la detección de duplicados con el Apellido y la acción "Ampliar"
4. Publicar el formulario
5. Llenar el formulario con el apellido de una persona existente que no tenga "Perfil de trabajador" y marcarle perfiles de trabajador
6. Verificar que se le han aplicado los cambios a la persona correspondiente
