### PR TITLE
Enhancement - Usuarios - Bloquear usuario tras N intentos de logins fallidos

### DIFF
--- a/config.php
+++ b/config.php
@@ -684,4 +684,13 @@ $sugar_config = array(
     // https://github.com/SinergiaTIC/SinergiaCRM/pull/1014
     'stic_async_list_count' => false, 
     // END STIC-Custom
+
+    // STIC Custom 20260611 ART -
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    'userlockout' => array(
+        'enabled' => 0,
+        'maxfailedlogins' => '5',
+        'automaticunlocktime' => '2',
+    ),
+    // END STIC-Custom
 );

--- a/config.php
+++ b/config.php
@@ -685,8 +685,8 @@ $sugar_config = array(
     'stic_async_list_count' => false, 
     // END STIC-Custom
 
-    // STIC Custom 20260611 ART -
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // STIC-Custom 20260611 ART - User Lockout Settings
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/1242
     'userlockout' => array(
         'enabled' => 0,
         'maxfailedlogins' => '5',

--- a/custom/Extension/modules/Administration/Ext/Language/ca_ES.SticLang.php
+++ b/custom/Extension/modules/Administration/Ext/Language/ca_ES.SticLang.php
@@ -105,3 +105,18 @@ $mod_strings['ERR_SYS_GEN_PWD_TPL_NOT_SELECTED'] = "Indiqueu la plantilla de cor
 $mod_strings['LBL_OAUTH_AUTHENTICATION_TITLE'] = 'Autenticació OAuth';
 $mod_strings['LBL_OAUTH_AUTH_ENABLE'] = "Activa l'autenticació OAuth";
 $mod_strings['LBL_OAUTH_AUTH_ENABLE_HELP'] = "Si activeu aquesta opció, els usuaris podran autenticar-se mitjançant OAuth 2.0, a més de poder fer-ho amb usuari i contrasenya. Després d'activar aquesta opció s'haurà de configurar, com a mínim, un dels proveïdors externs. Per a més informació, consulteu la <a href='https://wiki.sinergiatic.org/index.php?title=Usuarios,_Roles,_Grupos_de_seguridad_y_Registro_de_cambios#Autenticaci%C3%B3n_OAuth' target='_blank'>documentació</a>.";
+
+// User lockout settings
+$mod_strings['LBL_USER_LOCKOUT'] = 'Bloqueig d\'usuaris';
+$mod_strings['LBL_MAX_FAILED_LOGINS'] = 'Màxim d\'intents fallits';
+$mod_strings['LBL_MAX_FAILED_LOGINS_HELP'] = 'El nombre d\'intents fallits abans que un usuari tingui el seu compte bloquejat.';
+$mod_strings['LBL_AUTO_UNLOCK_TIME'] = 'Temps de desbloqueig automàtic';
+$mod_strings['LBL_AUTO_UNLOCK_TIME_HELP'] = 'El nombre de minuts que triga un compte d\'usuari a desbloquejar-se automàticament.';
+$mod_strings['LBL_AUTO_UNLOCK_TIME_UNITS'] = 'minuts';
+$mod_strings['ERR_MAX_FAILED_LOGINS'] = 'Si us plau, especifiqueu un valor vàlid per al nombre màxim d\'intents fallits';
+$mod_strings['ERR_AUTOMATIC_UNLOCK_TIME'] = 'Si us plau, especifiqueu un valor vàlid per al temps de desbloqueig automàtic';
+$mod_strings['LBL_ENABLE_MAX_FAILED_LOGINS'] = 'Bloquejar usuaris després d\'un nombre d\'intents fallits';
+$mod_strings['LBL_AUTO_UNLOCK'] = 'Desbloquejar automàticament els usuaris bloquejats';
+$mod_strings['LBL_AUTO_UNLOCK_HELP'] = 'Desbloquejar els usuaris bloquejats després d\'un temps configurable';
+$mod_strings['LBL_ENABLE_USER_LOCKOUT'] = 'Habilitar bloqueig d\'usuaris';
+$mod_strings['LBL_ENABLE_USER_LOCKOUT_HELP'] = 'Habilitar o deshabilitar completament el sistema de bloqueig d\'usuaris després intentos fallits d\'accés.';

--- a/custom/Extension/modules/Administration/Ext/Language/en_us.SticLang.php
+++ b/custom/Extension/modules/Administration/Ext/Language/en_us.SticLang.php
@@ -105,3 +105,18 @@ $mod_strings['ERR_SYS_GEN_PWD_TPL_NOT_SELECTED'] = 'Set the email template that 
 $mod_strings['LBL_OAUTH_AUTHENTICATION_TITLE'] = 'OAuth authentication';
 $mod_strings['LBL_OAUTH_AUTH_ENABLE'] = 'Enable OAuth authentication';
 $mod_strings['LBL_OAUTH_AUTH_ENABLE_HELP'] = 'When enabling this option users will be able to authenticate using OAuth 2.0, in addition to using a username and password. After enabling it at least one of the external providers must be configured. For more information, see the <a href="https://wiki.sinergiatic.org/index.php?title=Usuarios,_Roles,_Grupos_de_seguridad_y_Registro_de_cambios#Autenticaci%C3%B3n_OAuth" target="_blank">documentation</a>.';
+
+// User lockout settings
+$mod_strings['LBL_USER_LOCKOUT'] = 'User Lockout';
+$mod_strings['LBL_MAX_FAILED_LOGINS'] = 'Max failed logins';
+$mod_strings['LBL_MAX_FAILED_LOGINS_HELP'] = 'The number of failed logins before a user will have their account locked.';
+$mod_strings['LBL_AUTO_UNLOCK_TIME'] = 'Automatic user unlock time';
+$mod_strings['LBL_AUTO_UNLOCK_TIME_HELP'] = 'The number of minutes it takes for a user account to be automatically unlocked.';
+$mod_strings['LBL_AUTO_UNLOCK_TIME_UNITS'] = 'minutes';
+$mod_strings['ERR_MAX_FAILED_LOGINS'] = 'Please specify a valid value for the number of max failed logins';
+$mod_strings['ERR_AUTOMATIC_UNLOCK_TIME'] = 'Please specify a valid value for the automatic unlock time';
+$mod_strings['LBL_ENABLE_MAX_FAILED_LOGINS'] = 'Lock users after a number of failed logins';
+$mod_strings['LBL_AUTO_UNLOCK'] = 'Automatically unlock locked users';
+$mod_strings['LBL_AUTO_UNLOCK_HELP'] = 'Unlock locked users after a configurable amount of time';
+$mod_strings['LBL_ENABLE_USER_LOCKOUT'] = 'Enable User Lockout';
+$mod_strings['LBL_ENABLE_USER_LOCKOUT_HELP'] = 'Enable or disable the entire user lockout system after failed login attempts.';

--- a/custom/Extension/modules/Administration/Ext/Language/es_ES.SticLang.php
+++ b/custom/Extension/modules/Administration/Ext/Language/es_ES.SticLang.php
@@ -105,3 +105,18 @@ $mod_strings['ERR_SYS_GEN_PWD_TPL_NOT_SELECTED'] = 'Especificar la plantilla de 
 $mod_strings['LBL_OAUTH_AUTHENTICATION_TITLE'] = 'Autenticación OAuth';
 $mod_strings['LBL_OAUTH_AUTH_ENABLE'] = 'Activar autenticación OAuth';
 $mod_strings['LBL_OAUTH_AUTH_ENABLE_HELP'] = 'Al activar esta opción los usuarios podrán autenticarse mediante OAuth 2.0, además de hacerlo con usuario y contraseña. Después de activarla se deberá configurar por lo menos uno de los proveedores externos. Para más información, consulte la <a href="https://wiki.sinergiatic.org/index.php?title=Usuarios,_Roles,_Grupos_de_seguridad_y_Registro_de_cambios#Autenticaci%C3%B3n_OAuth" target="_blank">documentación</a>.';
+
+// User lockout settings
+$mod_strings['LBL_USER_LOCKOUT'] = 'Bloqueo de usuario';
+$mod_strings['LBL_MAX_FAILED_LOGINS'] = 'Intentos fallidos máximos';
+$mod_strings['LBL_MAX_FAILED_LOGINS_HELP'] = 'El número de intentos fallidos antes de que se bloquee la cuenta de un usuario.';
+$mod_strings['LBL_AUTO_UNLOCK_TIME'] = 'Tiempo de desbloqueo automático';
+$mod_strings['LBL_AUTO_UNLOCK_TIME_HELP'] = 'El número de minutos que tarda en desbloquearse automáticamente la cuenta de un usuario.';
+$mod_strings['LBL_AUTO_UNLOCK_TIME_UNITS'] = 'minutos';
+$mod_strings['ERR_MAX_FAILED_LOGINS'] = 'Por favor, especifique un valor válido para el número máximo de intentos fallidos de inicio de sesión';
+$mod_strings['ERR_AUTOMATIC_UNLOCK_TIME'] = 'Por favor, especifique un valor válido para el tiempo de desbloqueo automático';
+$mod_strings['LBL_ENABLE_MAX_FAILED_LOGINS'] = 'Bloquear usuarios después de un número de intentos fallidos de inicio de sesión';
+$mod_strings['LBL_AUTO_UNLOCK'] = 'Desbloquear automáticamente a los usuarios bloqueados';
+$mod_strings['LBL_AUTO_UNLOCK_HELP'] = 'Desbloquear a los usuarios bloqueados después de un tiempo configurable';
+$mod_strings['LBL_ENABLE_USER_LOCKOUT'] = 'Activar bloqueo de usuario';
+$mod_strings['LBL_ENABLE_USER_LOCKOUT_HELP'] = 'Activar o desactivar completamente el sistema de bloqueo de usuarios tras intentos fallidos de inicio de sesión.';

--- a/custom/Extension/modules/Users/Ext/Language/ca_ES.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/ca_ES.SticLang.php
@@ -104,3 +104,10 @@ $mod_strings['LBL_IMPERSONATION_MONITORING_ITEM_SUMMARY_2'] = ' amb ID ';
 // Model 182
 $mod_strings['LBL_STIC_M182_ISSUING_ORGANIZATION'] = 'Emissió del Model 182';
 $mod_strings['LBL_STIC_M182_ISSUING_ORGANIZATION_INFO'] = "Indica per a quines organitzacions l'usuari podrà generar el Model 182. La llista es genera dinàmicament a partir dels <a href='index.php?module=stic_Settings' target='_blank'>paràmetres de configuració</a>.";
+
+// User lockout
+$mod_strings['ERR_USER_IS_LOCKED_OUT'] = 'Aquest usuari ha estat bloquejat i no pot iniciar la sessió utilitzant la seva contrasenya actual. Si voleu ser desbloquejat, aviseu l\'administrador.';
+$mod_strings['LBL_USER_LOCKOUT_COUNTDOWN'] = '⛔ Usuari bloquejat. Es desbloquejarà automàticament en {minutes} min {seconds} seg.';
+$mod_strings['LBL_USER_LOCKOUT_FINISHED_REFRESHING'] = '✅ El temps de bloqueig ha finalitzat. Actualitzant...';
+$mod_strings['LBL_USER_UNLOCKED_REFRESHING'] = '✅ Usuari desbloquejat. Actualitzant...';
+$mod_strings['ERR_USER_IS_LOCKED_OUT_DETAILVIEW'] = 'Aquest usuari ha estat bloquejat a causa de múltiples intents fallits d\'inici de sessió. Podeu desbloquejar-lo utilitzant l\'acció "Desbloquejar usuari".';

--- a/custom/Extension/modules/Users/Ext/Language/en_us.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/en_us.SticLang.php
@@ -105,3 +105,12 @@ $mod_strings['LBL_IMPERSONATION_MONITORING_ITEM_SUMMARY_2'] = ' with ID ';
 $mod_strings['LBL_STIC_M182_ISSUING_ORGANIZATION'] = 'Issuing of Modelo 182';
 $mod_strings['LBL_STIC_M182_ISSUING_ORGANIZATION_INFO'] = 'Indicates for which organizations the user will be able to generate the Modelo 182. The list is dynamically generated from the <a href="index.php?module=stic_Settings" target="_blank">configuration parameters</a>.';
 
+// User lockout
+$mod_strings['LBL_UNLOCK_USER'] = 'Unlock user';
+$mod_strings['LBL_USER_UNLOCKED_MSG'] = 'User unlocked';
+$mod_strings['LBL_USER_LOCKOUT_COUNTDOWN'] = '⛔ User locked out. It will be automatically unlocked in {minutes} min {seconds} sec.';
+$mod_strings['LBL_USER_LOCKOUT_FINISHED_REFRESHING'] = '✅ Lockout period finished. Refreshing...';
+$mod_strings['LBL_USER_UNLOCKED_REFRESHING'] = '✅ User unlocked. Refreshing...';
+$mod_strings['ERR_USER_IS_LOCKED_OUT'] = 'This user has been locked out and cannot log in using their current password. If you want to be unlocked, please contact the administrator.';
+$mod_strings['ERR_USER_IS_LOCKED_OUT_DETAILVIEW'] = 'This user has been locked out due to multiple failed login attempts. You can unlock them using the "Unlock user" action.';
+

--- a/custom/Extension/modules/Users/Ext/Language/es_ES.SticLang.php
+++ b/custom/Extension/modules/Users/Ext/Language/es_ES.SticLang.php
@@ -104,3 +104,10 @@ $mod_strings['LBL_IMPERSONATION_MONITORING_ITEM_SUMMARY_2'] = ' con ID ';
 // Modelo 182
 $mod_strings['LBL_STIC_M182_ISSUING_ORGANIZATION'] = 'Emisión del Modelo 182';
 $mod_strings['LBL_STIC_M182_ISSUING_ORGANIZATION_INFO'] = 'Indica para qué organizaciones podrá el usuario generar el Modelo 182. La lista se genera dinámicamente a partir de los <a href="index.php?module=stic_Settings" target="_blank">parámetos de configuración</a>.';
+
+// User lockout
+$mod_strings['LBL_USER_LOCKOUT_COUNTDOWN'] = '⛔ Usuario bloqueado. Se desbloqueará automáticamente en {minutes} min {seconds} seg.';
+$mod_strings['LBL_USER_LOCKOUT_FINISHED_REFRESHING'] = '✅ El tiempo de bloqueo ha finalizado. Actualizando...';
+$mod_strings['LBL_USER_UNLOCKED_REFRESHING'] = '✅ Usuario desbloqueado. Actualizando...';
+$mod_strings['ERR_USER_IS_LOCKED_OUT'] = 'Este usuario ha sido bloqueado y no puede iniciar la sesión utilizando su contraseña actual. Si quiere ser desbloqueado, avise al administrador.';
+$mod_strings['ERR_USER_IS_LOCKED_OUT_DETAILVIEW'] = 'Este usuario ha sido bloqueado debido a múltiples intentos fallidos de inicio de sesión. Puede desbloquearlo en la acción "Desbloquear usuario".';

--- a/custom/modules/Users/SticUtils.js
+++ b/custom/modules/Users/SticUtils.js
@@ -49,6 +49,8 @@ switch (viewTypeUsers()) {
         break;
     
     case "detail":
+        bootstrapUserLockoutUi();
+
         if (editACL){    
             // Define button content
             var buttons = {
@@ -100,6 +102,159 @@ function onClickWorkCalendarPeriodicCreationButton() {
     document.MassUpdate.module.value='stic_Work_Calendar';
     document.MassUpdate.submit();
   }
+
+/**
+ * Initializes lockout countdown timer and unlock button
+ */
+function bootstrapUserLockoutUi() {
+    initUserLockoutUi();
+}
+
+/**
+ * Gets translation text with fallback
+ */
+function getUsersLang(labelKey, fallback) {
+    var text = SUGAR.language.get(module, labelKey);
+    if (!text || text === labelKey) {
+        return fallback || labelKey;
+    }
+    return text;
+}
+
+/**
+ * Replaces template placeholders with countdown values
+ */
+function formatLockoutText(template, values) {
+    return template
+        .replace('{minutes}', String(values.minutes))
+        .replace('{seconds}', String(values.seconds));
+}
+
+/**
+ * Stops lockout countdown timer if running
+ */
+function stopUserLockoutCountdown() {
+    if (window.sticUserLockoutCountdownTimer) {
+        window.clearInterval(window.sticUserLockoutCountdownTimer);
+        window.sticUserLockoutCountdownTimer = null;
+    }
+}
+
+/**
+ * Renders countdown timer and unlock button
+ */
+function initUserLockoutUi() {
+    var $stateNode = $('#stic-user-lockout-state');
+    if ($stateNode.length !== 1) {
+        sticHideUserLockoutUi();
+        return;
+    }
+
+    // Create unlock button for admins
+    var showUnlockButton = String($stateNode.attr('data-show-unlock-button')) === '1';
+    if (showUnlockButton && $('#unlock_user_button').length === 0) {
+        var unlockButton = {
+            id: "unlock_user_button",
+            title: SUGAR.language.get(module, "LBL_UNLOCK_USER"),
+            onclick: "sticPerformUnlockUser();",
+        };
+        createDetailViewButton(unlockButton);
+    }
+
+    var $countdownNode = $('#stic-user-lockout-countdown');
+    if ($countdownNode.length !== 1) {
+        return;
+    }
+
+    var remainingSeconds = parseInt($stateNode.attr('data-remaining-seconds'), 10);
+    if (isNaN(remainingSeconds) || remainingSeconds <= 0) {
+        return;
+    }
+
+    if ($stateNode.attr('data-countdown-started') === '1') {
+        return;
+    }
+    $stateNode.attr('data-countdown-started', '1');
+
+    stopUserLockoutCountdown();
+
+    var countdownTpl = getUsersLang('LBL_USER_LOCKOUT_COUNTDOWN', '⛔ User locked out. It will be automatically unlocked in {minutes} min {seconds} sec.');
+
+    // Update countdown text every second
+    function renderCountdown(seconds) {
+        var minutes = Math.floor(seconds / 60);
+        var secs = seconds % 60;
+        var paddedSeconds = secs < 10 ? '0' + secs : secs;
+        $countdownNode.text(formatLockoutText(countdownTpl, {
+            minutes: minutes,
+            seconds: paddedSeconds
+        }));
+    }
+
+    renderCountdown(remainingSeconds);
+
+    // Decrement countdown, reload page when done
+    window.sticUserLockoutCountdownTimer = window.setInterval(function() {
+        remainingSeconds -= 1;
+        if (remainingSeconds <= 0) {
+            stopUserLockoutCountdown();
+            $countdownNode.text(getUsersLang('LBL_USER_LOCKOUT_FINISHED_REFRESHING', '✅ Lockout period finished. Refreshing...'));
+            $stateNode.attr('data-remaining-seconds', '0');
+            window.setTimeout(function() {
+                window.location.reload();
+            }, 1200);
+            return;
+        }
+
+        renderCountdown(remainingSeconds);
+        $stateNode.attr('data-remaining-seconds', String(remainingSeconds));
+    }, 1000);
+}
+
+/**
+ * Submits unlock request to server and reloads DetailView
+ */
+function sticPerformUnlockUser() {
+    // Stop any running countdown timer
+    stopUserLockoutCountdown();
+
+    // Remove the unlock button immediately
+    $('#unlock_user_button').remove();
+
+    // Show a brief transitional message before the page navigates away
+    var $countdownNode = $('#stic-user-lockout-countdown');
+    if ($countdownNode.length) {
+        $countdownNode.text(getUsersLang('LBL_USER_UNLOCKED_REFRESHING', '✅ User unlocked. Refreshing...'));
+    }
+
+    var $form = $('form[name="DetailView"]');
+    var record = $form.find('[name="record"]').val() || STIC.record.id;
+    var sugarToken = $form.find('[name="sugar_token"]').val() || '';
+
+    var params = new URLSearchParams();
+    params.append('module', 'Users');
+    params.append('action', 'unlockuser');
+    params.append('record', record);
+    params.append('sugar_token', sugarToken);
+
+    fetch('index.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString()
+    }).finally(function() {
+        window.location.href = 'index.php?module=Users&action=DetailView&record=' + encodeURIComponent(record);
+    });
+}
+
+/**
+ * Removes lockout UI elements from page
+ */
+function sticHideUserLockoutUi() {
+    stopUserLockoutCountdown();
+    $('#stic-user-lockout-countdown').text('').hide();
+    $('#stic-user-lockout-state').remove();
+    $('#unlock_user_button').remove();
+}
 
 /**
  * This function is a helper to determine the current view type

--- a/custom/modules/Users/controller.php
+++ b/custom/modules/Users/controller.php
@@ -70,4 +70,52 @@ class CustomUsersController extends UsersController
             die('Failed to stop impersonation.');
         }
     }
+
+    /**
+    * Action to manually unlock a user account by an admin user
+    * This is used when the automatic unlock period has not yet expired but an admin wants to unlock the user immediately
+    */
+    public function action_unlockuser()
+    {
+        global $current_user;
+        $record = $_REQUEST['record'] ?? '';
+
+        if (!is_admin($current_user) || empty($record)) {
+            SugarApplication::redirect('index.php?module=Users&record=' . $record . '&action=DetailView');
+            return;
+        }
+
+        $user = BeanFactory::newBean('Users');
+        $user->retrieve($record);
+        if (empty($user->id)) {
+            SugarApplication::redirect('index.php?module=Users&action=index');
+            return;
+        }
+
+        $db = DBManagerFactory::getInstance();
+        $userId = $db->quote($user->id);
+
+        // Load existing preferences to preserve non-lockout settings
+        $result = $db->query("SELECT contents FROM user_preferences WHERE assigned_user_id = '{$userId}' AND category = 'global' AND deleted = 0");
+        $row = $db->fetchByAssoc($result);
+        $prefs = $row ? unserialize(base64_decode($row['contents'])) : [];
+
+        // Clear lockout-related keys
+        unset($prefs['user_locked_out'], $prefs['user_locked_out_time'], $prefs['lockout'], $prefs['loginfailed']);
+
+        // Persist updated preferences
+        $encoded = base64_encode(serialize($prefs));
+        $db->query("DELETE FROM user_preferences WHERE assigned_user_id = '{$userId}' AND category = 'global'");
+        $db->query("INSERT INTO user_preferences (id, assigned_user_id, category, contents, deleted) VALUES ('{$userId}-global', '{$userId}', 'global', '{$encoded}', 0)");
+
+        // Clear session cache for this user's preferences
+        $prefKey = $user->user_name . '_PREFERENCES';
+        if (isset($_SESSION[$prefKey]['global'])) {
+            $_SESSION[$prefKey]['global'] = $prefs;
+        }
+
+        $GLOBALS['log']->debug(__METHOD__ . '(' . __LINE__ . ') ### User ' . $user->user_name . ' unlocked manually ###');
+
+        return;
+    }
 }

--- a/custom/modules/Users/views/view.detail.php
+++ b/custom/modules/Users/views/view.detail.php
@@ -44,7 +44,62 @@ class CustomUsersViewDetail extends UsersViewDetail
 
     public function display()
     {
-        echo '<script> editACL = '. ACLController::checkAccess('stic_Work_Calendar', 'edit', true) .' </script>';            
+        global $current_user, $sugar_config;
+
+        echo '<script> editACL = '. ACLController::checkAccess('stic_Work_Calendar', 'edit', true) .' </script>';
+        
+        // Show lockout status with countdown timer or unlock message for admins
+        if (is_admin($current_user) || $current_user->isAdminForModule('Users')) {
+            // Check if user is locked out and calculate remaining time
+            $lockoutPref = $this->bean->getPreference('user_locked_out');
+            $isLockedOut = !empty($lockoutPref) && $lockoutPref !== '0' && $lockoutPref !== 0 && $lockoutPref !== false;
+
+            $lockoutTime = (int) $this->bean->getPreference('user_locked_out_time');
+            $unlockMinutes = (int) ($sugar_config['userlockout']['automaticunlocktime'] ?? 0);
+            $autoUnlockEnabled = $unlockMinutes > 0;
+            $timeRemaining = 0;
+
+            if ($isLockedOut && $autoUnlockEnabled && $lockoutTime > 0) {
+                $timeRemaining = (($lockoutTime + ($unlockMinutes * 60)) - time());
+            }
+
+            // Auto-unlock when unlock period expires
+            if ($isLockedOut && $autoUnlockEnabled && $timeRemaining <= 5) {
+                $this->bean->setPreference('user_locked_out', '0');
+                $this->bean->setPreference('user_locked_out_time', '');
+                $this->bean->setPreference('lockout', '');
+                $this->bean->setPreference('loginfailed', '0');
+                $this->bean->savePreferencesToDB();
+                SugarApplication::redirect('index.php?module=Users&action=DetailView&record=' . $this->bean->id);
+            }
+
+            // Render lockout message with countdown timer
+            if ($isLockedOut) {
+                $showUnlockButton = (is_admin($current_user) || $current_user->isAdminForModule('Users')) ? 1 : 0;
+
+                if ($autoUnlockEnabled && $timeRemaining > 0) {
+                    $timeRemaining = (int) $timeRemaining;
+                    $minutes = floor($timeRemaining / 60);
+                    $seconds = $timeRemaining % 60;
+                    $countdownTpl = translate('LBL_USER_LOCKOUT_COUNTDOWN', 'Users');
+                    $countdownText = str_replace(
+                        ['{minutes}', '{seconds}'],
+                        [(string) $minutes, str_pad((string) $seconds, 2, '0', STR_PAD_LEFT)],
+                        $countdownTpl
+                    );
+                    echo '<p class="error">' .
+                        '<span id="stic-user-lockout-countdown">' . $countdownText . '</span>' .
+                        '<span id="stic-user-lockout-state" data-show-unlock-button="' . $showUnlockButton . '" data-remaining-seconds="' . $timeRemaining . '" style="display:none"></span>' .
+                        '</p>';
+                } else {
+                    echo '<p class="error">' .
+                        '⛔ ' . translate('ERR_USER_IS_LOCKED_OUT_DETAILVIEW', 'Users') .
+                        '<span id="stic-user-lockout-state" data-show-unlock-button="' . $showUnlockButton . '" data-remaining-seconds="0" style="display:none"></span>' .
+                        '</p>';
+                }
+            }
+        }
+
         parent::display();
 
         SticViews::display($this);

--- a/modules/Administration/PasswordManager.tpl
+++ b/modules/Administration/PasswordManager.tpl
@@ -260,8 +260,8 @@
 									{/if}
 									</table>
 
-									{* STIC-Custom ART 20260612 - User Lockout Settings *}
-									{* https://github.com/SinergiaTIC/SinergiaCRM/pull/ *}
+									{* STIC-Custom 20260612 ART - User Lockout Settings *}
+									{* https://github.com/SinergiaTIC/SinergiaCRM/pull/1242 *}
 									<table id="userLockId" name="userLockName" width="100%" border="0" cellspacing="1" cellpadding="0" class="edit view">
 										<tr>
 											<th align="left" scope="row" colspan="2"><h4>{$MOD.LBL_USER_LOCKOUT}</h4></th>
@@ -662,8 +662,8 @@ document.getElementById('forgotpassword_checkbox').checked=true;
 
 {literal}
 <script>
-// STIC-Custom ART 20260612 - User Lockout Settings
-// https://github.com/SinergiaTIC/SinergiaCRM/pull/
+// STIC-Custom 20260612 ART - User Lockout Settings
+// https://github.com/SinergiaTIC/SinergiaCRM/pull/1242
 // Function to toggle display of lockout settings rows based on checkbox state
 function toggleLockoutRow(checkboxSelector, rowSelector, inputSelector) {
 	if($(checkboxSelector).is(':checked')){
@@ -723,8 +723,8 @@ function addcheck(form){{/literal}
 	// STIC#737
 	addToValidate('ConfigurePasswordSettings', 'passwordsetting_generatepasswordtmpl', 'string', form.generatepasswordtmpl.value == '',"{$MOD.ERR_SYS_GEN_PWD_TPL_NOT_SELECTED}" );
 	// END STIC-Custom
-	// STIC-Custom ART 20260612 - User Lockout Settings
-	// https://github.com/SinergiaTIC/SinergiaCRM/pull/
+	// STIC-Custom 20260612 ART - User Lockout Settings
+	// https://github.com/SinergiaTIC/SinergiaCRM/pull/1242
 	addToValidate('ConfigurePasswordSettings', 'userlockout_maxfailedlogins', 'int', false,"{$MOD.ERR_MAX_FAILED_LOGINS} ");
   	addToValidate('ConfigurePasswordSettings', 'userlockout_automaticunlocktime', 'int', false,"{$MOD.ERR_AUTOMATIC_UNLOCK_TIME} ");
 	// END STIC-Custom

--- a/modules/Administration/PasswordManager.tpl
+++ b/modules/Administration/PasswordManager.tpl
@@ -260,7 +260,59 @@
 									{/if}
 									</table>
 
-
+									{* STIC-Custom ART 20260612 - User Lockout Settings *}
+									{* https://github.com/SinergiaTIC/SinergiaCRM/pull/ *}
+									<table id="userLockId" name="userLockName" width="100%" border="0" cellspacing="1" cellpadding="0" class="edit view">
+										<tr>
+											<th align="left" scope="row" colspan="2"><h4>{$MOD.LBL_USER_LOCKOUT}</h4></th>
+										</tr>
+										<tr>
+											<td width="25%" scope="row">{$MOD.LBL_ENABLE_USER_LOCKOUT}:&nbsp{sugar_help text=$MOD.LBL_ENABLE_USER_LOCKOUT_HELP WIDTH=400}</td>
+											<td scope="row" width="25%" >
+												<input type='hidden' name='userlockout_enabled' value='0'>
+												<input type='checkbox' id="enableUserLockout" name='userlockout_enabled' value='1' {if $config.userlockout.enabled}checked="checked"{/if} onchange="toggleUserLockoutSettings(this)">&nbsp;
+											</td>
+											<td></td>
+											<td></td>
+										</tr>
+										<tr id="userLockoutSettingsRow">
+											<td colspan="4">
+												<table width="100%" border="0" cellspacing="1" cellpadding="0" style="display:{if $config.userlockout.enabled}block{else}none{/if}" id="userLockoutSettings">
+													<tr>
+														<td width="25%" scope="row">{$MOD.LBL_ENABLE_MAX_FAILED_LOGINS}:</td>
+														<td scope="row" width="25%" >
+															<input type='checkbox' id="maxFailedLogin" {if $config.userlockout.maxfailedlogins}checked="checked"{/if}>&nbsp;
+														</td>
+														<td></td>
+														<td></td>
+													</tr>
+										<tr id="maxFailedLoginsRow">
+											<td width="25%" scope="row">{$MOD.LBL_MAX_FAILED_LOGINS}:&nbsp{sugar_help text=$MOD.LBL_MAX_FAILED_LOGINS_HELP WIDTH=400}</td>
+											<td scope="row" width="25%">
+												<input type='text' maxlength="3" style="width:2em" id='userlockout_maxfailedlogins' name='userlockout_maxfailedlogins'  value='{$config.userlockout.maxfailedlogins}'>
+											</td>
+											<td></td>
+											<td></td>
+										</tr>
+										<tr>
+											<td width="25%" scope="row">{$MOD.LBL_AUTO_UNLOCK}:&nbsp{sugar_help text=$MOD.LBL_AUTO_UNLOCK_HELP WIDTH=400}</td>
+											<td scope="row" width="25%" >
+												<input type='checkbox' id="autoUnlock" {if $config.userlockout.automaticunlocktime}checked="checked"{/if}>&nbsp;
+											</td>
+											<td>&nbsp;</td><td>&nbsp;</td>
+										</tr>
+										<tr id="autoUnlockRow">
+											<td width="25%" scope="row">{$MOD.LBL_AUTO_UNLOCK_TIME}:&nbsp{sugar_help text=$MOD.LBL_AUTO_UNLOCK_TIME_HELP WIDTH=400}</td>
+											<td scope="row" width="25%" >
+												<input type='text' maxlength="10" style="width:5em" id='userlockout_automaticunlocktime' name='userlockout_automaticunlocktime'  value='{$config.userlockout.automaticunlocktime}'>&nbsp;<span>{$MOD.LBL_AUTO_UNLOCK_TIME_UNITS}</span>
+											</td>
+											<td>&nbsp;</td><td>&nbsp;</td>
+										</tr>
+												</table>
+											</td>
+										</tr>
+									</table>
+									{* END STIC-Custom *}
 
 
 						<table id="emailTemplatesId" name="emailTemplatesName" width="100%" border="0" cellspacing="1" cellpadding="0" class="edit view">
@@ -610,6 +662,52 @@ document.getElementById('forgotpassword_checkbox').checked=true;
 
 {literal}
 <script>
+// STIC-Custom ART 20260612 - User Lockout Settings
+// https://github.com/SinergiaTIC/SinergiaCRM/pull/
+// Function to toggle display of lockout settings rows based on checkbox state
+function toggleLockoutRow(checkboxSelector, rowSelector, inputSelector) {
+	if($(checkboxSelector).is(':checked')){
+			$(rowSelector).show();
+		}else{
+		$(rowSelector).hide();
+		$(inputSelector).val(0);
+	}
+}
+
+// Function to initialize lockout settings on page load
+function initUserLockoutSettings() {
+	$('#maxFailedLogin').change(function() {
+		toggleLockoutRow('#maxFailedLogin', '#maxFailedLoginsRow', '#userlockout_maxfailedlogins');
+	});
+
+	$('#autoUnlock').change(function() {
+		toggleLockoutRow('#autoUnlock', '#autoUnlockRow', '#userlockout_automaticunlocktime');
+	});
+
+	toggleLockoutRow('#maxFailedLogin', '#maxFailedLoginsRow', '#userlockout_maxfailedlogins');
+	toggleLockoutRow('#autoUnlock', '#autoUnlockRow', '#userlockout_automaticunlocktime');
+}
+
+initUserLockoutSettings();
+
+// Function to toggle display of all lockout settings when enabling/disabling user lockout
+function toggleUserLockoutSettings(checkbox) {
+  var settingsDiv = document.getElementById('userLockoutSettings');
+  if (checkbox.checked) {
+    settingsDiv.style.display = 'block';
+  } else {
+    settingsDiv.style.display = 'none';
+    // Reset all lockout settings when disabled
+    document.getElementById('maxFailedLogin').checked = false;
+    document.getElementById('userlockout_maxfailedlogins').value = 0;
+    document.getElementById('autoUnlock').checked = false;
+    document.getElementById('userlockout_automaticunlocktime').value = 0;
+    $('#maxFailedLoginsRow').hide();
+    $('#autoUnlockRow').hide();
+  }
+}
+// END STIC-Custom
+
 function addcheck(form){{/literal}
 	addForm('ConfigurePasswordSettings');
 
@@ -624,6 +722,11 @@ function addcheck(form){{/literal}
 	// STIC-Custom 20220523 MHP - Add validation to check that the email template is set
 	// STIC#737
 	addToValidate('ConfigurePasswordSettings', 'passwordsetting_generatepasswordtmpl', 'string', form.generatepasswordtmpl.value == '',"{$MOD.ERR_SYS_GEN_PWD_TPL_NOT_SELECTED}" );
+	// END STIC-Custom
+	// STIC-Custom ART 20260612 - User Lockout Settings
+	// https://github.com/SinergiaTIC/SinergiaCRM/pull/
+	addToValidate('ConfigurePasswordSettings', 'userlockout_maxfailedlogins', 'int', false,"{$MOD.ERR_MAX_FAILED_LOGINS} ");
+  	addToValidate('ConfigurePasswordSettings', 'userlockout_automaticunlocktime', 'int', false,"{$MOD.ERR_AUTOMATIC_UNLOCK_TIME} ");
 	// END STIC-Custom
    {literal}}{/literal}
 

--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
@@ -79,6 +79,32 @@ class SugarAuthenticate
         $this->userAuthenticate = new $this->userAuthenticateClass();
     }
 
+    // STIC-Custom 20260612 ART - User Lockout Settings 
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    /**
+     * Given a user returns true if this user is currently locked out based on the user_locked_out and
+     * on whether the unlock time has passed, if set.
+     *
+     * @see SugarAuthenticate::loginAuthenticate()
+     * @param User $user
+     *
+     * @return bool
+     */
+	public function isUserLockedOut(User $user){
+        global $sugar_config;
+	    if(!$user->getPreference('user_locked_out')){
+	        return false;
+        }
+        if(empty($sugar_config['userlockout']['automaticunlocktime'])){
+	       return true;
+        }
+        $unlockCutoff = time() - ($sugar_config['userlockout']['automaticunlocktime'] * 60);
+        if($user->getPreference('user_locked_out_time') < $unlockCutoff){
+            return false;
+        }
+        return true;
+    }
+    // END STIC-Custom
 
 
     /**
@@ -92,7 +118,11 @@ class SugarAuthenticate
      */
     public function loginAuthenticate($username, $password, $fallback=false, $PARAMS = array())
     {
-        global $mod_strings;
+        // STIC-Custom 20260612 ART - User Lockout Settings 
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // global $mod_strings;
+        global $mod_strings, $sugar_config;
+        // END STIC-Custom
         unset($_SESSION['login_error']);
         $usr= new user();
         $usr_id=$usr->retrieve_user_id($username);
@@ -100,6 +130,17 @@ class SugarAuthenticate
         $_SESSION['login_error']='';
         $_SESSION['waiting_error']='';
         $_SESSION['hasExpiredPassword']='0';
+
+        // STIC-Custom 20260612 ART - User Lockout Settings 
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // Check if user lockout feature is enabled
+        if (!empty($sugar_config['userlockout']['enabled'])) {
+            if ($this->isUserLockedOut($usr)) {
+                $_SESSION['login_error'] = translate('ERR_USER_IS_LOCKED_OUT', 'Users');
+                return false;
+            }
+        }
+        // END STIC-Custom
         if ($this->userAuthenticate->loadUserOnLogin($username, $password, $fallback, $PARAMS)) {
             require_once('modules/Users/password_utils.php');
             if (hasPasswordExpired($username)) {
@@ -108,16 +149,41 @@ class SugarAuthenticate
             // now that user is authenticated, reset loginfailed
             if ($usr->getPreference('loginfailed') != '' && $usr->getPreference('loginfailed') != 0) {
                 $usr->setPreference('loginfailed', '0');
+                // STIC-Custom 20260612 ART - User Lockout Settings 
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                $usr->setPreference('user_locked_out', false);
+                $usr->setPreference('user_locked_out_time', '');
+                // END STIC-Custom
                 $usr->savePreferencesToDB();
             }
             return $this->postLoginAuthenticate();
         } else {
             //if(!empty($usr_id) && $res['lockoutexpiration'] > 0){
             if (!empty($usr_id)) {
-                if (($logout=$usr->getPreference('loginfailed'))=='') {
+                // STIC-Custom 20260612 ART - User Lockout Settings 
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // if (($logout=$usr->getPreference('loginfailed'))=='') {
+                //     $usr->setPreference('loginfailed', '1');
+                // } else {
+                //     $usr->setPreference('loginfailed', $logout+1);
+				if (($logout=$usr->getPreference('loginfailed'))=='') {
                     $usr->setPreference('loginfailed', '1');
-                } else {
-                    $usr->setPreference('loginfailed', $logout+1);
+                }else{
+	        		$usr->setPreference('loginfailed',$logout+1);
+				}
+                
+                // Only apply lockout logic if feature is enabled
+                if (!empty($sugar_config['userlockout']['enabled']) && 
+                    !empty($sugar_config['userlockout']['maxfailedlogins']) &&
+                    ($logout + 1) >= $sugar_config['userlockout']['maxfailedlogins']
+                ) {
+                    $usr->setPreference('user_locked_out', true);
+                    $usr->setPreference('user_locked_out_time', time());
+
+                    $_SESSION['login_error'] = translate('ERR_USER_IS_LOCKED_OUT', 'Users');
+                } elseif (empty($_SESSION['login_error'])) {
+                    $_SESSION['login_error'] = translate('ERR_INVALID_PASSWORD', 'Users');
+                // END STIC-Custom
                 }
                 $usr->savePreferencesToDB();
             }

--- a/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
+++ b/modules/Users/authentication/SugarAuthenticate/SugarAuthenticate.php
@@ -80,7 +80,7 @@ class SugarAuthenticate
     }
 
     // STIC-Custom 20260612 ART - User Lockout Settings 
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/1242
     /**
      * Given a user returns true if this user is currently locked out based on the user_locked_out and
      * on whether the unlock time has passed, if set.
@@ -119,7 +119,7 @@ class SugarAuthenticate
     public function loginAuthenticate($username, $password, $fallback=false, $PARAMS = array())
     {
         // STIC-Custom 20260612 ART - User Lockout Settings 
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1242
         // global $mod_strings;
         global $mod_strings, $sugar_config;
         // END STIC-Custom
@@ -132,7 +132,7 @@ class SugarAuthenticate
         $_SESSION['hasExpiredPassword']='0';
 
         // STIC-Custom 20260612 ART - User Lockout Settings 
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1242
         // Check if user lockout feature is enabled
         if (!empty($sugar_config['userlockout']['enabled'])) {
             if ($this->isUserLockedOut($usr)) {
@@ -150,7 +150,7 @@ class SugarAuthenticate
             if ($usr->getPreference('loginfailed') != '' && $usr->getPreference('loginfailed') != 0) {
                 $usr->setPreference('loginfailed', '0');
                 // STIC-Custom 20260612 ART - User Lockout Settings 
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/1242
                 $usr->setPreference('user_locked_out', false);
                 $usr->setPreference('user_locked_out_time', '');
                 // END STIC-Custom
@@ -161,7 +161,7 @@ class SugarAuthenticate
             //if(!empty($usr_id) && $res['lockoutexpiration'] > 0){
             if (!empty($usr_id)) {
                 // STIC-Custom 20260612 ART - User Lockout Settings 
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/1242
                 // if (($logout=$usr->getPreference('loginfailed'))=='') {
                 //     $usr->setPreference('loginfailed', '1');
                 // } else {


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/140

## Description
Se ha implementado un sistema completo de bloqueo y desbloqueo de cuentas de usuario tras múltiples intentos fallidos de inicio de sesión.

### Configuración (Administración → Gestor de contraseñas)
Se ha añadido una nueva sección **"Bloqueo de usuario"** con las siguientes opciones:

- **Activar bloqueo de usuario**: activa o desactiva completamente el sistema.
- **Bloquear usuarios después de X intentos fallidos**: número máximo de intentos antes del bloqueo.
- **Desbloquear automáticamente a los usuarios bloqueados**: permite configurar un tiempo tras el que el usuario se desbloquea solo.
- **Tiempo de desbloqueo automático**: número de minutos hasta el desbloqueo automático.

### Comportamiento en el login
- Cuando el sistema de bloqueo está activo y un usuario supera el número máximo de intentos fallidos configurado, su cuenta queda bloqueada y no puede iniciar sesión.
- Se muestra un mensaje de error informativo al usuario bloqueado.
- Si está configurado el desbloqueo automático, el sistema comprueba el tiempo transcurrido desde el bloqueo y desbloquea la cuenta automáticamente al intentar iniciar sesión una vez transcurrido ese tiempo.

### Vista detalle de usuario (solo administradores)
- Si el usuario visualizado está bloqueado, se muestra un aviso destacado en la parte superior de la vista detalle.
- Si hay desbloqueo automático activo, el aviso incluye una **cuenta atrás en tiempo real** (minutos y segundos) hasta el desbloqueo.
- Cuando el contador llega a cero, la página se recarga automáticamente.
- Se muestra un botón **"Desbloquear usuario"** que permite al administrador desbloquear la cuenta de forma inmediata, sin esperar al tiempo automático.

### Desbloqueo manual por un administrador
El administrador puede desbloquear un usuario de tres formas:

1. **Botón "Desbloquear usuario"** en la vista detalle del usuario bloqueado.
2. **Reactivar el usuario**: si un usuario pasa de estado *Inactivo* a *Activo*, el bloqueo se limpia automáticamente al guardar.
3. **Cambio de contraseña**: al guardar un usuario con una nueva contraseña, el contador de intentos fallidos y el estado de bloqueo se resetean.

## Motivation and Context
Mejorar la seguridad del sistema previniendo ataques de fuerza bruta sobre las contraseñas de los usuarios, bloqueando la cuenta tras un número configurable de intentos fallidos y permitiendo su recuperación de forma automática o manual por parte del administrador.

## How To Test This
### Configuración inicial
1. Ir a **Administración → Gestor de contraseñas**.
2. En la sección *Bloqueo de usuario*, activar el bloqueo, establecer por ejemplo **3 intentos máximos** y **2 minutos de desbloqueo automático**.
3. Guardar.

### Bloqueo automático
4. Cerrar sesión e intentar iniciar sesión con un usuario válido pero con una contraseña incorrecta **3 veces seguidas**.
5. Verificar que aparece el mensaje de error de cuenta bloqueada y que ya no es posible iniciar sesión ni con la contraseña correcta.

### Vista detalle y cuenta atrás
6. Con un usuario administrador, ir a la vista detalle del usuario bloqueado.
7. Comprobar que aparece el aviso de bloqueo con la cuenta atrás en tiempo real.
8. Esperar a que el contador llegue a cero y verificar que la página se recarga y el aviso desaparece.

### Desbloqueo manual
9. Bloquear de nuevo el usuario (repetir paso 4-5).
10. Ir a la vista detalle como administrador y pulsar el botón **"Desbloquear usuario"**.
11. Verificar que el aviso desaparece y que el usuario puede iniciar sesión correctamente.

### Desbloqueo por reactivación
12. Con el usuario bloqueado, ir a su ficha como administrador, cambiar el estado a *Inactivo* y guardar.
13. Volver a poner el estado a *Activo* y guardar.
14. Verificar que el usuario puede iniciar sesión sin que haya aviso de bloqueo.

### Desactivar el sistema
15. En **Administración → Gestor de contraseñas**, desactivar el bloqueo de usuario y guardar.
16. Verificar que los intentos fallidos ya no bloquean la cuenta.
