### PR TITLE
Improvement - Formularios Web Avanzados - Incremento del tamaño de edición del texto de ayuda de un campo

### DIFF
--- a/modules/stic_AWF_Forms/ui/WizardView/steps/step2.html
+++ b/modules/stic_AWF_Forms/ui/WizardView/steps/step2.html
@@ -693,7 +693,7 @@
                           </div>
                         </template>
                         <!-- Description -->
-                        <div class="col-3">
+                        <div class="col-6">
                           <div class="d-flex justify-content-between align-items-end mb-1">
                             <label for="modalField_Description" class="form-label" x-text="utils.translateForFieldLabel('LBL_FIELD_DESCRIPTION')"></label>
                             <!-- Add link to description -->


### PR DESCRIPTION
## Descripción
Este PR aporta una modificación mínima en el asistente de edición de Formularios Web Avanzados: En el paso 2 (Estructura y campos), en la edición de un campo de un bloque de datos, se ha incrementado el tamaño del input para indicar el Texto de ayuda del campo. 
Este texto de ayuda acostumbra a ser una frase que con el tamaño de edición anterior se veía un fragmento muy pequeño.

## Pruebas
1. Editar un Formulario Web Avanzado
2. En el paso 2 "Estructura y campos", editar un campo de un bloque de datos
3. Verificar que en el modal de edición del campo, el Texto de ayuda ocupa más espacio