### PR TITLE
Enhancement - SecurityGroups - Improve ListView load time

### DIFF
--- a/custom/Extension/application/Ext/LogicHooks/SticSecurityGroupsOptimization.php
+++ b/custom/Extension/application/Ext/LogicHooks/SticSecurityGroupsOptimization.php
@@ -1,0 +1,18 @@
+<?php
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+if (!isset($hook_array) || !is_array($hook_array)) {
+    $hook_array = array();
+}
+if (!isset($hook_array['before_acl_query']) || !is_array($hook_array['before_acl_query'])) {
+    $hook_array['before_acl_query'] = array();
+}
+$hook_array['before_acl_query'][] = array(
+    1,
+    'Optimize security group EXISTS subquery for list views',
+    'custom/include/SticSecurityGroupsListViewOptimization.php',
+    'Stic_SecurityGroupsListViewOptimization',
+    'optimizeGroupWhere'
+);

--- a/custom/include/SticSecurityGroupsListViewOptimization.php
+++ b/custom/include/SticSecurityGroupsListViewOptimization.php
@@ -1,0 +1,143 @@
+<?php
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+class Stic_SecurityGroupsListViewOptimization
+{
+    public function optimizeGroupWhere($bean, $event, $arguments)
+    {
+        if ($arguments->view !== 'list') {
+            return;
+        }
+
+        if (!isset($arguments->conditions['group'])) {
+            return;
+        }
+
+        global $sugar_config;
+        $userId = $arguments->user->id;
+        $db = DBManagerFactory::getInstance();
+
+        if ($bean->module_dir === 'Users'
+            && !is_admin($arguments->user)
+            && isset($sugar_config['securitysuite_filter_user_list'])
+            && $sugar_config['securitysuite_filter_user_list']
+        ) {
+            $groupIds = $this->getUserGroupIds($userId);
+            if (empty($groupIds)) {
+                return;
+            }
+            $groupIdList = $this->formatInList($groupIds);
+            $arguments->conditions['group'] = " users.id in (
+                select sec.user_id from securitygroups_users sec
+                inner join securitygroups secg on sec.securitygroup_id = secg.id and secg.deleted = 0
+                where sec.deleted = 0 and sec.securitygroup_id in ({$groupIdList})
+            )";
+            return;
+        }
+
+        $groupIds = $this->getUserGroupIds($userId);
+        if (empty($groupIds)) {
+            return;
+        }
+
+        $groupIdList = $this->formatInList($groupIds);
+        $tableName = $bean->table_name;
+        $module = $bean->module_dir;
+
+        if ($module === 'SecurityGroups') {
+            $arguments->conditions['group'] = " {$tableName}.id in (
+                select secg.id from securitygroups secg
+                inner join securitygroups_users secu on secg.id = secu.securitygroup_id and secu.deleted = 0
+                    and secu.user_id = '{$db->quote($userId)}'
+                where secg.deleted = 0 and secg.id in ({$groupIdList})
+            )";
+            return;
+        }
+
+        $simplifiedExists = "EXISTS (SELECT 1 FROM securitygroups_records secr
+            WHERE secr.record_id = {$tableName}.id
+                AND secr.deleted = 0
+                AND secr.module = '{$module}'
+                AND secr.securitygroup_id IN ({$groupIdList}))";
+
+        $ownerWhere = $bean->getOwnerWhere($userId);
+        if (!empty($ownerWhere)) {
+            $arguments->conditions['group'] = " ({$ownerWhere} OR {$simplifiedExists}) ";
+        } else {
+            $arguments->conditions['group'] = $simplifiedExists;
+        }
+    }
+
+    private function getUserGroupIds($userId)
+    {
+        $db = DBManagerFactory::getInstance();
+        $quotedUserId = $db->quote($userId);
+
+        $query = "SELECT secu.securitygroup_id
+            FROM securitygroups_users secu
+            INNER JOIN securitygroups secg ON secg.id = secu.securitygroup_id AND secg.deleted = 0
+            WHERE secu.user_id = '{$quotedUserId}' AND secu.deleted = 0";
+
+        $result = $db->query($query);
+        $groupIds = array();
+        while ($row = $db->fetchByAssoc($result)) {
+            $groupIds[] = $row['securitygroup_id'];
+        }
+        return $groupIds;
+    }
+
+    private function formatInList($groupIds)
+    {
+        $db = DBManagerFactory::getInstance();
+        $quoted = array();
+        foreach ($groupIds as $id) {
+            $quoted[] = $db->quote($id);
+        }
+        return "'" . implode("','", $quoted) . "'";
+    }
+
+    public static function getUserAccessibleRecordIds($module, $action = 'list')
+    {
+        global $current_user, $sugar_config, $db;
+
+        $ids = array();
+
+        $query = "SELECT DISTINCT secr.record_id "
+            . "FROM securitygroups_records secr "
+            . "INNER JOIN securitygroups_users secu "
+            . "  ON secr.securitygroup_id = secu.securitygroup_id "
+            . "  AND secu.deleted = 0 "
+            . "  AND secu.user_id = '{$db->quote($current_user->id)}' ";
+
+        if (!empty($action)
+            && isset($sugar_config['securitysuite_strict_rights'])
+            && $sugar_config['securitysuite_strict_rights'] == true
+        ) {
+            $query .= "INNER JOIN securitygroups_acl_roles sar "
+                . "  ON secr.securitygroup_id = sar.securitygroup_id AND sar.deleted = 0 "
+                . "INNER JOIN acl_roles_actions ara "
+                . "  ON sar.role_id = ara.role_id AND ara.deleted = 0 "
+                . "INNER JOIN acl_actions aa "
+                . "  ON ara.action_id = aa.id AND aa.deleted = 0 "
+                . "  AND aa.category = '{$db->quote($module)}' AND aa.name = '{$db->quote($action)}' ";
+        }
+
+        $query .= "WHERE secr.deleted = 0 AND secr.module = '{$db->quote($module)}'";
+
+        if (!empty($action)
+            && isset($sugar_config['securitysuite_strict_rights'])
+            && $sugar_config['securitysuite_strict_rights'] == true
+        ) {
+            $query .= " AND ara.access_override = 80";
+        }
+
+        $result = $db->query($query);
+        while ($row = $db->fetchByAssoc($result)) {
+            $ids[$row['record_id']] = true;
+        }
+
+        return $ids;
+    }
+}

--- a/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
+++ b/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
@@ -81,6 +81,13 @@ class MassGenerateDocument {
     function current_user_has_access_to_template($template_id, $roles_with_access){
        global $current_user, $db;
 
+      // STIC-Custom 20220516 AAM - This code needs to be run after the Security Suite check
+      // STIC#734
+      // // No tener ningún rol asignado equivale a tener acceso a todos los roles
+      // if ((count($roles_with_access) == 0) || (count($roles_with_access) == 1 && empty($roles_with_access[0])))
+      // return true;
+      // END STIC
+
        if ($current_user->isAdmin()){
           return true;
        }
@@ -93,19 +100,19 @@ class MassGenerateDocument {
           return true;
        }
 
-       // STIC-Custom OC 20260610 - Batch SecurityGroups + cached roles + inline ownership
-       // Replaces per-template BeanFactory::getBean + ACLAccess + groupHasAccess (~1300 queries)
+       // STIC-Custom EPS 20260610 - Batch SecurityGroups + cached roles + inline ownership
+       // Replaces per-template BeanFactory::getBean + ACLAccess + groupHasAccess (too many queries if there are too many templates)
        // with 3 batch queries per request
        // https://github.com/SinergiaTIC/SinergiaCRM/pull/XXX
 
-       // Plan A: Batch SecurityGroups - one query per request
+       // Batch SecurityGroups - one query per request
        static $accessibleRecordIds = null;
        if ($accessibleRecordIds === null) {
           require_once('custom/include/SticSecurityGroupsListViewOptimization.php');
           $accessibleRecordIds = Stic_SecurityGroupsListViewOptimization::getUserAccessibleRecordIds('DHA_PlantillasDocumentos', 'list');
        }
 
-       // Plan C: Batch ownership - one query per request
+       // Batch ownership - one query per request
        static $ownedRecordIds = null;
        if ($ownedRecordIds === null) {
           $ownedRecordIds = array();
@@ -127,7 +134,7 @@ class MassGenerateDocument {
        if ((count($roles_with_access) == 0) || (count($roles_with_access) == 1 && empty($roles_with_access[0])))
            return true;
 
-       // Plan B: Cached user roles - one query per request
+       // Cached user roles - one query per request
        static $userRoles = null;
        if ($userRoles === null) {
           $userRoles = array();
@@ -148,7 +155,7 @@ class MassGenerateDocument {
        }
      
        return false;
-       // END STIC-Custom OC
+       // END STIC-Custom EPS 20260610
     }
    
    ///////////////////////////////////////////////////////////////////////////////////////////////////         

--- a/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
+++ b/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
@@ -77,10 +77,10 @@ class MassGenerateDocument {
       return $html;
    }
    
-///////////////////////////////////////////////////////////////////////////////////////////////////         
-    function current_user_has_access_to_template($template_id, $roles_with_access){
-       global $current_user, $db;
-
+   ///////////////////////////////////////////////////////////////////////////////////////////////////         
+   function current_user_has_access_to_template($template_id, $roles_with_access){
+      global $current_user, $db;
+      
       // STIC-Custom 20220516 AAM - This code needs to be run after the Security Suite check
       // STIC#734
       // // No tener ningún rol asignado equivale a tener acceso a todos los roles
@@ -88,75 +88,45 @@ class MassGenerateDocument {
       // return true;
       // END STIC
 
-       if ($current_user->isAdmin()){
+      if ($current_user->isAdmin()){
+         return true;
+      }
+      
+      if ($current_user->isAdminForModule('DHA_PlantillasDocumentos')){
+         return true;
+      }
+      
+      if ($current_user->isDeveloperForModule('DHA_PlantillasDocumentos')){
+         return true;
+      }
+
+      // STIC-Custom 20220516 AAM - Adding Security Suite access check and the non-role access check
+      // STIC#734
+      $mmrBean = BeanFactory::getBean('DHA_PlantillasDocumentos', $template_id);
+      if (!$mmrBean->ACLAccess('ListView', $mmrBean->isOwner($current_user->id))) {
+         return false;
+      }
+
+      // Following lines have been moved here from above
+      // No tener ningún rol asignado equivale a tener acceso a todos los roles
+      if ((count($roles_with_access) == 0) || (count($roles_with_access) == 1 && empty($roles_with_access[0])))
           return true;
-       }
-       
-       if ($current_user->isAdminForModule('DHA_PlantillasDocumentos')){
-          return true;
-       }
-       
-       if ($current_user->isDeveloperForModule('DHA_PlantillasDocumentos')){
-          return true;
-       }
-
-       // STIC-Custom EPS 20260610 - Batch SecurityGroups + cached roles + inline ownership
-       // Replaces per-template BeanFactory::getBean + ACLAccess + groupHasAccess (too many queries if there are too many templates)
-       // with 3 batch queries per request
-       // https://github.com/SinergiaTIC/SinergiaCRM/pull/1249
-
-       // Batch SecurityGroups - one query per request
-       static $accessibleRecordIds = null;
-       if ($accessibleRecordIds === null) {
-          require_once('custom/include/SticSecurityGroupsListViewOptimization.php');
-          $accessibleRecordIds = Stic_SecurityGroupsListViewOptimization::getUserAccessibleRecordIds('DHA_PlantillasDocumentos', 'list');
-       }
-
-       // Batch ownership - one query per request
-       static $ownedRecordIds = null;
-       if ($ownedRecordIds === null) {
-          $ownedRecordIds = array();
-          $ownerSql = "SELECT id FROM dha_plantillasdocumentos "
-                    . "WHERE assigned_user_id = '{$db->quote($current_user->id)}' AND deleted = 0";
-          $ownerResult = $db->query($ownerSql);
-          while ($ownerRow = $db->fetchByAssoc($ownerResult)) {
-             $ownedRecordIds[$ownerRow['id']] = true;
-          }
-       }
-
-       $isOwner = isset($ownedRecordIds[$template_id]);
-       $inGroup = isset($accessibleRecordIds[$template_id]);
-       if (!$isOwner && !$inGroup) {
-          return false;
-       }
-
-       // No tener ningún rol asignado equivale a tener acceso a todos los roles
-       if ((count($roles_with_access) == 0) || (count($roles_with_access) == 1 && empty($roles_with_access[0])))
-           return true;
-
-       // Cached user roles - one query per request
-       static $userRoles = null;
-       if ($userRoles === null) {
-          $userRoles = array();
-          $roleSql = "SELECT t1.id FROM acl_roles t1 "
-                   . "INNER JOIN acl_roles_users t2 ON "
-                   . "t2.user_id = '{$db->quote($current_user->id)}' AND t2.role_id = t1.id AND t2.deleted = 0 "
-                   . "WHERE t1.deleted = 0";
-          $roleResult = $db->query($roleSql);
-          while ($roleRow = $db->fetchByAssoc($roleResult)) {
-             $userRoles[] = $roleRow['id'];
-          }
-       }
-
-       foreach ($userRoles as $roleId) {
-          if (in_array($roleId, $roles_with_access)) {
-             return true;
-          }
-       }
-     
-       return false;
-       // END STIC-Custom EPS 20260610
-    }
+      // END STIC
+      
+      $sql = "SELECT t1.id 
+              FROM acl_roles t1 
+              INNER JOIN acl_roles_users t2 ON 
+                t2.user_id = '{$current_user->id}' AND t2.role_id = t1.id AND t2.deleted = 0 
+              WHERE t1.deleted = 0 ";
+      $dataset = $db->query($sql);
+      while ($row = $db->fetchByAssoc($dataset)) {
+         if (in_array($row['id'], $roles_with_access)) { 
+            return true;
+         }
+      }
+    
+      return false;
+   }   
    
    ///////////////////////////////////////////////////////////////////////////////////////////////////         
    function role_enabled_level($role_id){

--- a/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
+++ b/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
@@ -103,7 +103,7 @@ class MassGenerateDocument {
        // STIC-Custom EPS 20260610 - Batch SecurityGroups + cached roles + inline ownership
        // Replaces per-template BeanFactory::getBean + ACLAccess + groupHasAccess (too many queries if there are too many templates)
        // with 3 batch queries per request
-       // https://github.com/SinergiaTIC/SinergiaCRM/pull/XXX
+       // https://github.com/SinergiaTIC/SinergiaCRM/pull/1249
 
        // Batch SecurityGroups - one query per request
        static $accessibleRecordIds = null;

--- a/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
+++ b/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
@@ -77,56 +77,79 @@ class MassGenerateDocument {
       return $html;
    }
    
-   ///////////////////////////////////////////////////////////////////////////////////////////////////         
-   function current_user_has_access_to_template($template_id, $roles_with_access){
-      global $current_user, $db;
-      
-      // STIC-Custom 20220516 AAM - This code needs to be run after the Security Suite check
-      // STIC#734
-      // // No tener ningún rol asignado equivale a tener acceso a todos los roles
-      // if ((count($roles_with_access) == 0) || (count($roles_with_access) == 1 && empty($roles_with_access[0])))
-      // return true;
-      // END STIC
+///////////////////////////////////////////////////////////////////////////////////////////////////         
+    function current_user_has_access_to_template($template_id, $roles_with_access){
+       global $current_user, $db;
 
-      if ($current_user->isAdmin()){
-         return true;
-      }
-      
-      if ($current_user->isAdminForModule('DHA_PlantillasDocumentos')){
-         return true;
-      }
-      
-      if ($current_user->isDeveloperForModule('DHA_PlantillasDocumentos')){
-         return true;
-      }
-
-      // STIC-Custom 20220516 AAM - Adding Security Suite access check and the non-role access check
-      // STIC#734
-      $mmrBean = BeanFactory::getBean('DHA_PlantillasDocumentos', $template_id);
-      if (!$mmrBean->ACLAccess('ListView', $mmrBean->isOwner($current_user->id))) {
-         return false;
-      }
-
-      // Following lines have been moved here from above
-      // No tener ningún rol asignado equivale a tener acceso a todos los roles
-      if ((count($roles_with_access) == 0) || (count($roles_with_access) == 1 && empty($roles_with_access[0])))
+       if ($current_user->isAdmin()){
           return true;
-      // END STIC
-      
-      $sql = "SELECT t1.id 
-              FROM acl_roles t1 
-              INNER JOIN acl_roles_users t2 ON 
-                t2.user_id = '{$current_user->id}' AND t2.role_id = t1.id AND t2.deleted = 0 
-              WHERE t1.deleted = 0 ";
-      $dataset = $db->query($sql);
-      while ($row = $db->fetchByAssoc($dataset)) {
-         if (in_array($row['id'], $roles_with_access)) { 
-            return true;
-         }
-      }
-    
-      return false;
-   }   
+       }
+       
+       if ($current_user->isAdminForModule('DHA_PlantillasDocumentos')){
+          return true;
+       }
+       
+       if ($current_user->isDeveloperForModule('DHA_PlantillasDocumentos')){
+          return true;
+       }
+
+       // STIC-Custom OC 20260610 - Batch SecurityGroups + cached roles + inline ownership
+       // Replaces per-template BeanFactory::getBean + ACLAccess + groupHasAccess (~1300 queries)
+       // with 3 batch queries per request
+       // https://github.com/SinergiaTIC/SinergiaCRM/pull/XXX
+
+       // Plan A: Batch SecurityGroups - one query per request
+       static $accessibleRecordIds = null;
+       if ($accessibleRecordIds === null) {
+          require_once('custom/include/SticSecurityGroupsListViewOptimization.php');
+          $accessibleRecordIds = Stic_SecurityGroupsListViewOptimization::getUserAccessibleRecordIds('DHA_PlantillasDocumentos', 'list');
+       }
+
+       // Plan C: Batch ownership - one query per request
+       static $ownedRecordIds = null;
+       if ($ownedRecordIds === null) {
+          $ownedRecordIds = array();
+          $ownerSql = "SELECT id FROM dha_plantillasdocumentos "
+                    . "WHERE assigned_user_id = '{$db->quote($current_user->id)}' AND deleted = 0";
+          $ownerResult = $db->query($ownerSql);
+          while ($ownerRow = $db->fetchByAssoc($ownerResult)) {
+             $ownedRecordIds[$ownerRow['id']] = true;
+          }
+       }
+
+       $isOwner = isset($ownedRecordIds[$template_id]);
+       $inGroup = isset($accessibleRecordIds[$template_id]);
+       if (!$isOwner && !$inGroup) {
+          return false;
+       }
+
+       // No tener ningún rol asignado equivale a tener acceso a todos los roles
+       if ((count($roles_with_access) == 0) || (count($roles_with_access) == 1 && empty($roles_with_access[0])))
+           return true;
+
+       // Plan B: Cached user roles - one query per request
+       static $userRoles = null;
+       if ($userRoles === null) {
+          $userRoles = array();
+          $roleSql = "SELECT t1.id FROM acl_roles t1 "
+                   . "INNER JOIN acl_roles_users t2 ON "
+                   . "t2.user_id = '{$db->quote($current_user->id)}' AND t2.role_id = t1.id AND t2.deleted = 0 "
+                   . "WHERE t1.deleted = 0";
+          $roleResult = $db->query($roleSql);
+          while ($roleRow = $db->fetchByAssoc($roleResult)) {
+             $userRoles[] = $roleRow['id'];
+          }
+       }
+
+       foreach ($userRoles as $roleId) {
+          if (in_array($roleId, $roles_with_access)) {
+             return true;
+          }
+       }
+     
+       return false;
+       // END STIC-Custom OC
+    }
    
    ///////////////////////////////////////////////////////////////////////////////////////////////////         
    function role_enabled_level($role_id){


### PR DESCRIPTION
## Description
Optimiza las consultas de SecurityGroups en el filtrado ACL de vistas de lista 
Relacionado con #1254 

### Optimización 1: Consulta ACL de vista de lista (hook before_acl_query)
El método por defecto groupHasAccess() de SecurityGroups genera una subconsulta con múltiples JOINs para la cláusula WHERE de cada vista de lista. El hook optimizeGroupWhere() intercepta before_acl_query y la reemplaza con un patrón EXISTS ... securitygroup_id IN (...) más eficiente, obteniendo los SecurityGroups del usuario una sola vez y reutilizándolos en la cláusula WHERE.
- Nueva clase Stic_SecurityGroupsListViewOptimization con el método optimizeGroupWhere()
- Gestiona casos especiales: filtrado del módulo Usuarios, el propio módulo SecurityGroups, condiciones de propietario (owner WHERE)
- Registrado vía LogicHook before_acl_query en custom/Extension/application/Ext/LogicHooks/SticSecurityGroupsOptimization.php

## Motivation and Context
Reducir los tiempos de carga de la vista de lista en determinados escenarios en que hay muchos grupos de seguridad.

## How To Test This
### (CRÍTICO) Comprobar que las optimizaciones no rompen nada 
1.- Crear un entorno de pruebas con distintos grupos de seguridad y usuarios
  1.1.- Crear varios GS y varios usuarios. Mínimo un usuario con un GS1, otro con GS2 y otro con GS1 y GS2.
  1.2.- Crear registros en stic_Registrations (o el módulo deseado). Algunos con Gs, otros sin, otros con varios grupos
  1.3.- Crear rol para limitar el acceso a stic_Registrations
2.- Pruebas sin rol asignado
  2.1.- No limitar el acceso a stic_Registrations por rol y observar que cualquier usuario ve todos los registros
3.- Pruebas con "privilegios estrictos" en Configuración de Grupos de Seguridad
  3.1.- Asignar el rol limitador a los usuarios
  3.2.- Comprobar que cada usuario ve los registros y las plantillas que le correponde por grupos
  3.3.- comprobar que el admini lo sigue viendo todo
4.- Pruevas sin "privilegios estrictos": Comprobar que se comporta, en este caso, igual que en (3).
5.- Tanto con privilegios estrictos como sin privilegios estrictos, comprobar que cuando el rol se asigna a través del GS, sigue funcionando como hasta ahora

### Comprobar que las optimizaciones mejoran los tiempos
1.- Disponer de una BBDD en que haya varios centenares o miles de GS, millones de registros en securitygroups_records 
2.- Comprobar que después de aplicar el PR el rendimiento mejora sensiblemente 


