### PR TITLE
Hotfix - Formularios Web Avanzados - Expandir/contraer correctamente acciones en edición de formularios

### DIFF
--- a/modules/stic_AWF_Forms/ui/WizardView/steps/step3.html
+++ b/modules/stic_AWF_Forms/ui/WizardView/steps/step3.html
@@ -51,7 +51,8 @@
             <div class="accordion">
                 <template x-for="action in actions" :key="action.id">
                     <div class="accordion-item" x-data="{opened:false}" x-show="action.is_user_selectable || showAllActions">
-                        <div :id="action.id+'_Header'" class="mt-1 mb-1 pe-2 btn accordion-header accordion-button p-0 align-items-center" :class="{'collapsed': !opened}">
+                        <div :id="action.id+'_Header'" class="mt-1 mb-1 pe-2 btn accordion-header accordion-button p-0 align-items-center" :class="{'collapsed': !opened}"
+                             @click.self="$el.querySelector('[data-bs-toggle]').click()">
                             <div class="d-flex flex-grow-1 align-items-center py-3 ps-3 pe-2" role="button" @click="opened = !opened"
                                  data-bs-toggle="collapse" :data-bs-target="'#'+action.id+'_Content'" :aria-controls="action.id+'_Content'">
                                 <!-- Condition -->


### PR DESCRIPTION
## Descripción
Se observa que en el paso 3 (Lógica y automatismos) del asistente de edición de Formularios Web Avanzados,  al clicar una acción mediante el botón derecho con la flecha (_chevron_), no se expandía/contraía la acción. 
En cambio sí se hace si se clica en el título de la acción.

## Pruebas
1. Editar un Formulario Web Avanzado
2. En el paso 3 "Lógica y automatismos", crear una acción
3. Verificar que la acción se expande/contrae al hacer click en la flechita (chevron) de la derecha