### PR TITLE
Enhancement - MMR - Mejora en el rendimiento del filtro por Grupos de Seguridad

### DIFF
--- a/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
+++ b/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
@@ -100,44 +100,76 @@ class MassGenerateDocument {
           return true;
        }
 
-       // STIC-Custom EPS 20260610 - Batch SecurityGroups + cached roles + inline ownership
-       // Replaces per-template BeanFactory::getBean + ACLAccess + groupHasAccess (too many queries if there are too many templates)
-       // with 3 batch queries per request
-       // https://github.com/SinergiaTIC/SinergiaCRM/pull/1249
+      // STIC-Custom EPS 20260610 - Batch SecurityGroups + cached roles + inline ownership
+      // Replaces per-template BeanFactory::getBean + ACLAccess + groupHasAccess (too many queries if there are too many templates)
+      // with batch queries per request, mirroring buildAccessWhere() ACL logic
+      // https://github.com/SinergiaTIC/SinergiaCRM/pull/1249
+      // // STIC-Custom 20220516 AAM - Adding Security Suite access check and the non-role access check
+      // // STIC#734
+      // $mmrBean = BeanFactory::getBean('DHA_PlantillasDocumentos', $template_id);
+      // if (!$mmrBean->ACLAccess('ListView', $mmrBean->isOwner($current_user->id))) {
+      //    return false;
+      // }       
 
-       // Batch SecurityGroups - one query per request
-       static $accessibleRecordIds = null;
-       if ($accessibleRecordIds === null) {
-          require_once('custom/include/SticSecurityGroupsListViewOptimization.php');
-          $accessibleRecordIds = Stic_SecurityGroupsListViewOptimization::getUserAccessibleRecordIds('DHA_PlantillasDocumentos', 'list');
-       }
+      require_once('modules/ACL/ACLController.php');
+      $requireOwner = ACLController::requireOwner('DHA_PlantillasDocumentos', 'list');
+      $requireGroup = ACLController::requireSecurityGroup('DHA_PlantillasDocumentos', 'list');
 
-       // Batch ownership - one query per request
-       static $ownedRecordIds = null;
-       if ($ownedRecordIds === null) {
-          $ownedRecordIds = array();
-          $ownerSql = "SELECT id FROM dha_plantillasdocumentos "
-                    . "WHERE assigned_user_id = '{$db->quote($current_user->id)}' AND deleted = 0";
-          $ownerResult = $db->query($ownerSql);
-          while ($ownerRow = $db->fetchByAssoc($ownerResult)) {
-             $ownedRecordIds[$ownerRow['id']] = true;
-          }
-       }
+      if ($requireOwner || $requireGroup) {
+         // Batch ownership - one query per request
+         static $ownedRecordIds = null;
+         if ($ownedRecordIds === null) {
+            $ownedRecordIds = array();
+            $ownerSql = "SELECT id FROM dha_plantillasdocumentos "
+                      . "WHERE assigned_user_id = '{$db->quote($current_user->id)}' AND deleted = 0";
+            $ownerResult = $db->query($ownerSql);
+            while ($ownerRow = $db->fetchByAssoc($ownerResult)) {
+               $ownedRecordIds[$ownerRow['id']] = true;
+            }
+         }
 
-       $isOwner = isset($ownedRecordIds[$template_id]);
-       $inGroup = isset($accessibleRecordIds[$template_id]);
-       if (!$isOwner && !$inGroup) {
-          return false;
-       }
+         $isOwner = isset($ownedRecordIds[$template_id]);
+
+         if ($requireGroup) {
+            // ACL "Group" (80): owner OR group member
+            static $accessibleRecordIds = null;
+            if ($accessibleRecordIds === null) {
+               $accessibleRecordIds = $this->getUserAccessibleRecordIds();
+            }
+            $inGroup = isset($accessibleRecordIds[$template_id]);
+            if (!$isOwner && !$inGroup) {
+               return false;
+            }
+         } else {
+            // ACL "Owner" (75): only owner
+            if (!$isOwner) {
+               return false;
+            }
+         }
+      }
+      // else: ACL "All" (90)+ - no ownership/group restriction, skip to role check
 
        // No tener ningún rol asignado equivale a tener acceso a todos los roles
        if ((count($roles_with_access) == 0) || (count($roles_with_access) == 1 && empty($roles_with_access[0])))
            return true;
 
-       // Cached user roles - one query per request
+       // STIC-Custom EPS 20260610
+       // Cached user roles - one query per request (roles are stored at an array)
+      // $sql = "SELECT t1.id 
+      //         FROM acl_roles t1 
+      //         INNER JOIN acl_roles_users t2 ON 
+      //           t2.user_id = '{$current_user->id}' AND t2.role_id = t1.id AND t2.deleted = 0 
+      //         WHERE t1.deleted = 0 ";
+      // $dataset = $db->query($sql);
+      // while ($row = $db->fetchByAssoc($dataset)) {
+      //    if (in_array($row['id'], $roles_with_access)) { 
+      //       return true;
+      //    }
+      // }
        static $userRoles = null;
        if ($userRoles === null) {
           $userRoles = array();
+       // END STIC-Custom EPS 20260610
           $roleSql = "SELECT t1.id FROM acl_roles t1 "
                    . "INNER JOIN acl_roles_users t2 ON "
                    . "t2.user_id = '{$db->quote($current_user->id)}' AND t2.role_id = t1.id AND t2.deleted = 0 "
@@ -153,11 +185,36 @@ class MassGenerateDocument {
              return true;
           }
        }
+       // END STIC-Custom EPS 20260610
      
        return false;
-       // END STIC-Custom EPS 20260610
     }
    
+   // STIC-Custom EPS 20260610
+   public function getUserAccessibleRecordIds()
+    {
+        global $current_user, $db;
+
+        $ids = array();
+
+        $query = "SELECT DISTINCT secr.record_id "
+            . "FROM securitygroups_records secr "
+            . "INNER JOIN securitygroups_users secu "
+            . "  ON secr.securitygroup_id = secu.securitygroup_id "
+            . "  AND secu.deleted = 0 "
+            . "  AND secu.user_id = '{$db->quote($current_user->id)}' "
+            . "WHERE secr.deleted = 0 AND secr.module = 'DHA_PlantillasDocumentos'";
+
+        $result = $db->query($query);
+        while ($row = $db->fetchByAssoc($result)) {
+            $ids[$row['record_id']] = true;
+        }
+
+        return $ids;
+    }
+   // END STIC-Custom EPS 20260610
+
+
    ///////////////////////////////////////////////////////////////////////////////////////////////////         
    function role_enabled_level($role_id){
       // Ver lista dha_plantillasdocumentos_enable_roles_dom

--- a/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
+++ b/modules/DHA_PlantillasDocumentos/MassGenerateDocument.php
@@ -77,10 +77,10 @@ class MassGenerateDocument {
       return $html;
    }
    
-   ///////////////////////////////////////////////////////////////////////////////////////////////////         
-   function current_user_has_access_to_template($template_id, $roles_with_access){
-      global $current_user, $db;
-      
+///////////////////////////////////////////////////////////////////////////////////////////////////         
+    function current_user_has_access_to_template($template_id, $roles_with_access){
+       global $current_user, $db;
+
       // STIC-Custom 20220516 AAM - This code needs to be run after the Security Suite check
       // STIC#734
       // // No tener ningún rol asignado equivale a tener acceso a todos los roles
@@ -88,45 +88,75 @@ class MassGenerateDocument {
       // return true;
       // END STIC
 
-      if ($current_user->isAdmin()){
-         return true;
-      }
-      
-      if ($current_user->isAdminForModule('DHA_PlantillasDocumentos')){
-         return true;
-      }
-      
-      if ($current_user->isDeveloperForModule('DHA_PlantillasDocumentos')){
-         return true;
-      }
-
-      // STIC-Custom 20220516 AAM - Adding Security Suite access check and the non-role access check
-      // STIC#734
-      $mmrBean = BeanFactory::getBean('DHA_PlantillasDocumentos', $template_id);
-      if (!$mmrBean->ACLAccess('ListView', $mmrBean->isOwner($current_user->id))) {
-         return false;
-      }
-
-      // Following lines have been moved here from above
-      // No tener ningún rol asignado equivale a tener acceso a todos los roles
-      if ((count($roles_with_access) == 0) || (count($roles_with_access) == 1 && empty($roles_with_access[0])))
+       if ($current_user->isAdmin()){
           return true;
-      // END STIC
-      
-      $sql = "SELECT t1.id 
-              FROM acl_roles t1 
-              INNER JOIN acl_roles_users t2 ON 
-                t2.user_id = '{$current_user->id}' AND t2.role_id = t1.id AND t2.deleted = 0 
-              WHERE t1.deleted = 0 ";
-      $dataset = $db->query($sql);
-      while ($row = $db->fetchByAssoc($dataset)) {
-         if (in_array($row['id'], $roles_with_access)) { 
-            return true;
-         }
-      }
-    
-      return false;
-   }   
+       }
+       
+       if ($current_user->isAdminForModule('DHA_PlantillasDocumentos')){
+          return true;
+       }
+       
+       if ($current_user->isDeveloperForModule('DHA_PlantillasDocumentos')){
+          return true;
+       }
+
+       // STIC-Custom EPS 20260610 - Batch SecurityGroups + cached roles + inline ownership
+       // Replaces per-template BeanFactory::getBean + ACLAccess + groupHasAccess (too many queries if there are too many templates)
+       // with 3 batch queries per request
+       // https://github.com/SinergiaTIC/SinergiaCRM/pull/1249
+
+       // Batch SecurityGroups - one query per request
+       static $accessibleRecordIds = null;
+       if ($accessibleRecordIds === null) {
+          require_once('custom/include/SticSecurityGroupsListViewOptimization.php');
+          $accessibleRecordIds = Stic_SecurityGroupsListViewOptimization::getUserAccessibleRecordIds('DHA_PlantillasDocumentos', 'list');
+       }
+
+       // Batch ownership - one query per request
+       static $ownedRecordIds = null;
+       if ($ownedRecordIds === null) {
+          $ownedRecordIds = array();
+          $ownerSql = "SELECT id FROM dha_plantillasdocumentos "
+                    . "WHERE assigned_user_id = '{$db->quote($current_user->id)}' AND deleted = 0";
+          $ownerResult = $db->query($ownerSql);
+          while ($ownerRow = $db->fetchByAssoc($ownerResult)) {
+             $ownedRecordIds[$ownerRow['id']] = true;
+          }
+       }
+
+       $isOwner = isset($ownedRecordIds[$template_id]);
+       $inGroup = isset($accessibleRecordIds[$template_id]);
+       if (!$isOwner && !$inGroup) {
+          return false;
+       }
+
+       // No tener ningún rol asignado equivale a tener acceso a todos los roles
+       if ((count($roles_with_access) == 0) || (count($roles_with_access) == 1 && empty($roles_with_access[0])))
+           return true;
+
+       // Cached user roles - one query per request
+       static $userRoles = null;
+       if ($userRoles === null) {
+          $userRoles = array();
+          $roleSql = "SELECT t1.id FROM acl_roles t1 "
+                   . "INNER JOIN acl_roles_users t2 ON "
+                   . "t2.user_id = '{$db->quote($current_user->id)}' AND t2.role_id = t1.id AND t2.deleted = 0 "
+                   . "WHERE t1.deleted = 0";
+          $roleResult = $db->query($roleSql);
+          while ($roleRow = $db->fetchByAssoc($roleResult)) {
+             $userRoles[] = $roleRow['id'];
+          }
+       }
+
+       foreach ($userRoles as $roleId) {
+          if (in_array($roleId, $roles_with_access)) {
+             return true;
+          }
+       }
+     
+       return false;
+       // END STIC-Custom EPS 20260610
+    }
    
    ///////////////////////////////////////////////////////////////////////////////////////////////////         
    function role_enabled_level($role_id){


### PR DESCRIPTION
## Description
Relacionado con #1249 
Se añade cache a la consulta de plantillas disponibles para un usuario. En lugar de ejecutar las consultas para cada petición, se obtienen en una sóla consulta las plantillas disponibles según los grupos del usuario y el resto de peticiones se responden con los datos recuperados en esa primera consulta.

Replace per-template BeanFactory::getBean + ACLAccess + groupHasAccess with 3 batch queries per request in current_user_has_access_to_template()
- Batch SecurityGroups via getUserAccessibleRecordIds()
- Cached user roles (static per request)
- Inline ownership check via batch query

### Optimización 2: Consultas de acceso a plantillas DHA (Plan A+B+C)
MassGenerateDocument::current_user_has_access_to_template() llamaba a BeanFactory::getBean() + ACLAccess() + SecurityGroup::groupHasAccess() por cada plantilla (661 plantillas = ~1.297 consultas). Con securitysuite_strict_rights=true, cada llamada añade 3 JOINs extra.
#### Batch SecurityGroups
Nuevo método estático getUserAccessibleRecordIds($module, $action) obtiene todos los IDs de registros accesibles en una sola consulta, respetando los JOINs condicionales de securitysuite_strict_rights.
#### Roles de usuario en caché
Variable estática $userRoles almacena en caché la consulta de roles ACL por petición en lugar de ejecutarla por cada plantilla.
#### Propiedad en línea
Variable estática $ownedRecordIds reemplaza BeanFactory::getBean() + isOwner() por plantilla con una sola consulta batch.

## Motivation and Context
Mejorar el tiempo de respuesta cuando la lista de plantillas debe filtrarse por grupos de seguridad y existen muchas (>100) plantillas para un determinado módulo (lo que ralentizaba tanto la vista de lista como de detalle).

## How To Test This
### (CRÍTICO) Comprobar que las optimizaciones no rompen nada 
1.- Crear un entorno de pruebas con distintos grupos de seguridad y usuarios
  1.1.- Crear varios GS y varios usuarios. Mínimo un usuario con un GS1, otro con GS2 y otro con GS1 y GS2.
  1.2.- Crear plantillas MMR para el módulo de stic_Registrations y asignarles también los GS (>100 plantillas)
  1.3.- Crear rol para limitar el acceso a plantillas MMR
2.- Pruebas sin rol asignado
  2.1.- No limitar el acceso a plantillas MMR por rol y observar que cualquier usuario ve todos los registros
3.- Pruebas con "privilegios estrictos" en Configuración de Grupos de Seguridad
  3.1.- Asignar el rol limitador a los usuarios
  3.2.- Comprobar que cada usuario ve las plantillas que le correponde por grupos
  3.3.- Comprobar que en las vistas de lista y detalle del módulo para el que se han dado de alta las plantillas, aparecen las plantillas que debe
  3.4.- comprobar que el admin lo sigue viendo todo
4.- Pruevas sin "privilegios estrictos": Comprobar que se comporta, en este caso, igual que en (3).
5.- Tanto con privilegios estrictos como sin privilegios estrictos, comprobar que cuando el rol se asigna a través del GS, sigue funcionando como hasta ahora

### Comprobar que las optimizaciones mejoran los tiempos
1.- Disponer de una BBDD en que haya varios centenares o miles de GS, millones de registros en securitygroups_records y múltiples (>100) plantillas MMR para un determinado módulo 
2.- Comprobar que después de aplicar el PR el rendimiento mejora sensiblemente 

## Información adicional
Existen 2 funciones paaara gestionar el acceso según grupos de seguridad: getGroupWhere() y groupHasAccess() 
Se ha usado el paralelismo con getGroupWhere que es el que se usa en las vistas de lista. Esto hace que el comportamiento, como sucede con la vista de lista no sea exactamente el mismo que en edit / view / delete cuando los stright rights están aplicados (no se mira el rol que llega a través del grupo).