### PR TITLE
Hotfix - Plantillas de email - Mover el check del ACL antes de limpiar el ID

### DIFF
--- a/custom/modules/EmailTemplates/DetailView.php
+++ b/custom/modules/EmailTemplates/DetailView.php
@@ -21,6 +21,199 @@
  * You can contact SinergiaTIC Association at email address info@sinergiacrm.org.
  */
 
-require('modules/EmailTemplates/DetailView.php');
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+require_once('include/upload_file.php');
+require_once('include/DetailView/DetailView.php');
+
+//Old DetailView compares wrong session variable against new view.list.  Need to sync so that
+//the pagination on the DetailView page will show.
+if (isset($_SESSION['EMAILTEMPLATE_FROM_LIST_VIEW'])) {
+    $_SESSION['EMAIL_TEMPLATE_FROM_LIST_VIEW'] = $_SESSION['EMAILTEMPLATE_FROM_LIST_VIEW'];
+}
+
+global $app_strings;
+global $mod_strings;
+
+$focus = BeanFactory::newBean('EmailTemplates');
+
+$detailView = new DetailView();
+$offset=0;
+if (isset($_REQUEST['offset']) || isset($_REQUEST['record'])) {
+    $result = $detailView->processSugarBean("EMAIL_TEMPLATE", $focus, $offset);
+    if ($result == null) {
+        sugar_die($app_strings['ERROR_NO_RECORD']);
+    }
+    $focus=$result;
+} else {
+    header("Location: index.php?module=Accounts&action=index");
+}
+if (isset($_REQUEST['isDuplicate']) && $_REQUEST['isDuplicate'] == 'true') {
+    $focus->id = "";
+}
+
+//needed when creating a new note with default values passed in
+if (isset($_REQUEST['contact_name']) && is_null($focus->contact_name)) {
+    $focus->contact_name = $_REQUEST['contact_name'];
+}
+if (isset($_REQUEST['contact_id']) && is_null($focus->contact_id)) {
+    $focus->contact_id = $_REQUEST['contact_id'];
+}
+if (isset($_REQUEST['opportunity_name']) && is_null($focus->parent_name)) {
+    $focus->parent_name = $_REQUEST['opportunity_name'];
+}
+if (isset($_REQUEST['opportunity_id']) && is_null($focus->parent_id)) {
+    $focus->parent_id = $_REQUEST['opportunity_id'];
+}
+if (isset($_REQUEST['account_name']) && is_null($focus->parent_name)) {
+    $focus->parent_name = $_REQUEST['account_name'];
+}
+if (isset($_REQUEST['account_id']) && is_null($focus->parent_id)) {
+    $focus->parent_id = $_REQUEST['account_id'];
+}
+
+$params = array();
+$params[] = $focus->name;
+
+echo getClassicModuleTitle($focus->module_dir, $params, true);
+
+
+$GLOBALS['log']->info("EmailTemplate detail view");
+
+$xtpl=new XTemplate(get_custom_file_if_exists('modules/EmailTemplates/DetailView.html'));
+$xtpl->assign("MOD", $mod_strings);
+$xtpl->assign("APP", $app_strings);
+
+// STIC Custom EPS 20260615 - Hide Duplicate button when user lacks edit permission
+// In other modules (e.g. Accounts) the DUPLICATE button is wrapped in
+// {if $bean->aclAccess("edit")} via the sugar_button Smarty plugin.
+// EmailTemplates uses a legacy DetailView with hardcoded buttons and no ACL check
+// on the Duplicate button, causing a permissions error when Security Group users
+// try to duplicate a template they can view but not edit.
+// https://github.com/SinergiaTIC/SinergiaCRM/pull/1259
+// $buttons = array(
+//     <<<EOD
+//             <input type="submit" class="button" id="editEmailTemplatesButton" title="{$app_strings['LBL_EDIT_BUTTON_TITLE']}" accessKey="{$app_strings['LBL_EDIT_BUTTON_KEY']}" onclick="this.form.return_module.value='EmailTemplates'; this.form.return_action.value='DetailView'; this.form.return_id.value='{$focus->id}'; this.form.action.value='EditView'" value="{$app_strings['LBL_EDIT_BUTTON_LABEL']}">
+// EOD
+// ,
+//     <<<EOD
+//             <input title="{$app_strings['LBL_DUPLICATE_BUTTON_TITLE']}" accessKey="{$app_strings['LBL_DUPLICATE_BUTTON_KEY']}" class="button" onclick="this.form.return_module.value='EmailTemplates'; this.form.return_action.value='index'; this.form.isDuplicate.value=true; this.form.action.value='EditView'" type="submit" name="button" value="{$app_strings['LBL_DUPLICATE_BUTTON_LABEL']}">
+// EOD
+// ,
+//     <<<EOD
+//             <input title="{$app_strings['LBL_DELETE_BUTTON_TITLE']}" accessKey="{$app_strings['LBL_DELETE_BUTTON_KEY']}" class="button" onclick="check_deletable_EmailTemplate();" type="button" name="button" value="{$app_strings['LBL_DELETE_BUTTON_LABEL']}">
+// EOD
+// );
+$buttons = array(
+    <<<EOD
+            <input type="submit" class="button" id="editEmailTemplatesButton" title="{$app_strings['LBL_EDIT_BUTTON_TITLE']}" accessKey="{$app_strings['LBL_EDIT_BUTTON_KEY']}" onclick="this.form.return_module.value='EmailTemplates'; this.form.return_action.value='DetailView'; this.form.return_id.value='{$focus->id}'; this.form.action.value='EditView'" value="{$app_strings['LBL_EDIT_BUTTON_LABEL']}">
+EOD
+);
+if ($focus->ACLAccess('EditView')) {
+    $buttons[] = <<<EOD
+            <input title="{$app_strings['LBL_DUPLICATE_BUTTON_TITLE']}" accessKey="{$app_strings['LBL_DUPLICATE_BUTTON_KEY']}" class="button" onclick="this.form.return_module.value='EmailTemplates'; this.form.return_action.value='index'; this.form.isDuplicate.value=true; this.form.action.value='EditView'" type="submit" name="button" value="{$app_strings['LBL_DUPLICATE_BUTTON_LABEL']}">
+EOD;
+}
+$buttons[] = <<<EOD
+            <input title="{$app_strings['LBL_DELETE_BUTTON_TITLE']}" accessKey="{$app_strings['LBL_DELETE_BUTTON_KEY']}" class="button" onclick="check_deletable_EmailTemplate();" type="button" name="button" value="{$app_strings['LBL_DELETE_BUTTON_LABEL']}">
+EOD;
+// END STIC Custom
+
+require_once('include/Smarty/plugins/function.sugar_action_menu.php');
+$action_button = smarty_function_sugar_action_menu(array(
+    'id' => 'detail_header_action_menu',
+    'buttons' => $buttons,
+    'class' => 'clickMenu fancymenu',
+), $xtpl);
+
+$xtpl->assign("ACTION_BUTTON", $action_button);
+
+if (isset($_REQUEST['return_module'])) {
+    $xtpl->assign("RETURN_MODULE", $_REQUEST['return_module']);
+}
+if (isset($_REQUEST['return_action'])) {
+    $xtpl->assign("RETURN_ACTION", $_REQUEST['return_action']);
+}
+if (isset($_REQUEST['return_id'])) {
+    $xtpl->assign("RETURN_ID", $_REQUEST['return_id']);
+}
+$xtpl->assign("GRIDLINE", $gridline);
+$xtpl->assign("PRINT_URL", "index.php?".$GLOBALS['request_string']);
+$xtpl->assign("ID", $focus->id);
+$xtpl->assign("CREATED_BY", $focus->created_by_name);
+$xtpl->assign("MODIFIED_BY", $focus->modified_by_name);
+//if text only is set to true, then make sure input is checked and value set to 1
+if (isset($focus->text_only) && $focus->text_only) {
+    $xtpl->assign("TEXT_ONLY_CHECKED", "CHECKED");
+}
+$xtpl->assign("NAME", $focus->name);
+$xtpl->assign("DESCRIPTION", $focus->description);
+$xtpl->assign("SUBJECT", $focus->subject);
+$xtpl->assign("BODY", $focus->body);
+$xtpl->assign("BODY_HTML", json_encode(from_html($focus->body_html)));
+$xtpl->assign("DATE_MODIFIED", $focus->date_modified);
+$xtpl->assign("DATE_ENTERED", $focus->date_entered);
+$xtpl->assign("ASSIGNED_USER_NAME", $focus->assigned_user_name);
+
+if ($focus->type === 'workflow') {
+    $xtpl->assign("TYPE", $app_list_strings['emailTemplates_type_list'][$focus->type]);
+} else {
+    $xtpl->assign("TYPE", $app_list_strings['emailTemplates_type_list_no_workflow'][$focus->type]);
+}
+
+if ($focus->ACLAccess('EditView')) {
+    $xtpl->parse("main.edit");
+}
+if (!empty($focus->body)) {
+    $xtpl->assign('ALT_CHECKED', 'CHECKED');
+} else {
+    $xtpl->assign('ALT_CHECKED', '');
+}
+if ($focus->published == 'on') {
+    $xtpl->assign("PUBLISHED", "CHECKED");
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+////	NOTES (attachements, etc.)
+///////////////////////////////////////////////////////////////////////////////
+$note = BeanFactory::newBean('Notes');
+$where = "notes.parent_id='{$focus->id}'";
+$notes_list = $note->get_full_list("notes.name", $where, true);
+
+if (! isset($notes_list)) {
+    $notes_list = array();
+}
+
+$attachments = '';
+$notes_listCount = count($notes_list);
+for ($i=0; $i<$notes_listCount; $i++) {
+    $the_note = $notes_list[$i];
+    $attachments .= "<a href=\"index.php?entryPoint=download&id={$the_note->id}&type=Notes\">".$the_note->name."</a><br />";
+}
+
+$xtpl->assign("ATTACHMENTS", $attachments);
+
+
+global $current_user;
+if (is_admin($current_user) && $_REQUEST['module'] != 'DynamicLayout' && !empty($_SESSION['editinplace'])) {
+    $xtpl->assign("ADMIN_EDIT", "<a href='index.php?action=index&module=DynamicLayout&from_action=".$_REQUEST['action'] ."&from_module=".$_REQUEST['module'] ."&record=".$_REQUEST['record']. "'>".SugarThemeRegistry::current()->getImage("EditLayout", "border='0' align='bottom'", null, null, '.gif', $mod_strings['LBL_EDIT_LAYOUT'])."</a>");
+}
+
+$xtpl->assign("DESCRIPTION", $focus->description);
+
+$detailView->processListNavigation($xtpl, "EMAIL_TEMPLATE", $offset);
+// adding custom fields:
+require_once('modules/DynamicFields/templates/Files/DetailView.php');
+
+
+$xtpl->parse("main");
+
+$xtpl->out("main");
+
+// STIC Custom 20210816 MHP & 20240909 EPS
 echo getVersionedScript("SticInclude/js/Utils.js");
 echo getVersionedScript("custom/modules/EmailTemplates/SticUtils.js");
+// END STIC Custom

--- a/custom/modules/EmailTemplates/EditView.php
+++ b/custom/modules/EmailTemplates/EditView.php
@@ -65,6 +65,18 @@ if (isset($_REQUEST['record'])) {
     $focus->retrieve($_REQUEST['record']);
 }
 
+// STIC Custom EPS 20260615 - Fix: Check ACL before clearing ID for duplication
+// When duplicating, the ID was cleared before the ACL check, causing permission errors
+// for users with Security Group-restricted access (group-based ACL). The empty ID
+// made both isOwner() and groupHasAccess() fail, denying access even though the user
+// legitimately had access to the original record.
+// https://github.com/SinergiaTIC/SinergiaCRM/issues/XXX
+if (!$focus->ACLAccess('EditView') || (!is_admin($current_user) && isset($focus->type) && $focus->type === 'system')) {
+    ACLController::displayNoAccess(true);
+    sugar_cleanup(true);
+}
+// END STIC Custom
+
 $old_id = '';
 if (isset($_REQUEST['isDuplicate']) && $_REQUEST['isDuplicate'] == 'true') {
     $old_id = $focus->id; // for attachments down below
@@ -115,10 +127,12 @@ if (empty($focus->id)) {
 
 echo getClassicModuleTitle($focus->module_dir, $params, true);
 
-if (!$focus->ACLAccess('EditView') || (!is_admin($current_user) && isset($focus->type) && $focus->type === 'system')) {
-    ACLController::displayNoAccess(true);
-    sugar_cleanup(true);
-}
+// STIC Custom EPS 20260615 - Fix: Check ACL before clearing ID for duplication
+// if (!$focus->ACLAccess('EditView') || (!is_admin($current_user) && isset($focus->type) && $focus->type === 'system')) {
+//     ACLController::displayNoAccess(true);
+//     sugar_cleanup(true);
+// }
+// END STIC Custom
 
 $GLOBALS['log']->info("EmailTemplate detail view");
 

--- a/custom/modules/EmailTemplates/EditView.php
+++ b/custom/modules/EmailTemplates/EditView.php
@@ -70,7 +70,7 @@ if (isset($_REQUEST['record'])) {
 // for users with Security Group-restricted access (group-based ACL). The empty ID
 // made both isOwner() and groupHasAccess() fail, denying access even though the user
 // legitimately had access to the original record.
-// https://github.com/SinergiaTIC/SinergiaCRM/issues/XXX
+// https://github.com/SinergiaTIC/SinergiaCRM/pull/1259
 if (!$focus->ACLAccess('EditView') || (!is_admin($current_user) && isset($focus->type) && $focus->type === 'system')) {
     ACLController::displayNoAccess(true);
     sugar_cleanup(true);
@@ -128,6 +128,7 @@ if (empty($focus->id)) {
 echo getClassicModuleTitle($focus->module_dir, $params, true);
 
 // STIC Custom EPS 20260615 - Fix: Check ACL before clearing ID for duplication
+// https://github.com/SinergiaTIC/SinergiaCRM/pull/1259
 // if (!$focus->ACLAccess('EditView') || (!is_admin($current_user) && isset($focus->type) && $focus->type === 'system')) {
 //     ACLController::displayNoAccess(true);
 //     sugar_cleanup(true);


### PR DESCRIPTION
- Closes #1258 

## Description
Se avanza el momento en que se comprueba si el usuario tiene acceso a la plantilla. Se estaba realizando el check después de limpiar el id, lo que provocaba un error al intentar ver si tenía acceso a la plantilla con id "" (que se trasladaba directamente al consulta SQL).
Ahora se realiza el check antes de duplicar, con lo que se está accediendo al check con el ID de la plantilla a duplicar. 

Además, se modifica la DetailView para que no muestre la opción de duplicar si el usuario no tiene permiso de edición (tal como sucede en el resto de módulos).

## Motivation and Context
Corregir el error anómalo.

## How To Test This
### Corrección del error
1. Crear un Grupo de Seguridad y asignarle un usuario
2. Crear una plantilla de email y asignarla al grupo (con assigned_user diferente al usuario de prueba)
3. Configurar ACL de EmailTemplates a nivel "Grupo"
4. Iniciar sesion como el usuario del paso 1
5. Ver la plantilla en DetailView (acceso correcto via grupo)
6. Pulsar el boton "Duplicar"
7. Se carga EditView para crear una nueva plantilla

### Botón duplicar
1. Crear un Grupo de Seguridad y asignarle un usuario
2. Crear una plantilla de email y asignarla al grupo (con assigned_user diferente al usuario de prueba)
3. Configurar ACL de EmailTemplates a nivel "Grupo" en lista y detalle pero Nada en Edición
4. Iniciar sesion como el usuario del paso 1
5. Ver la plantilla en DetailView (acceso correcto via grupo)
6. Comprobar que no aparece el botón "Duplicar"
