### PR TITLE
Hotfix - Actividades - Ocultar botón "Nuevo Cliente Potencial" según disponibilidad de Interesados

### DIFF
--- a/custom/modules/Calls/views/view.edit.php
+++ b/custom/modules/Calls/views/view.edit.php
@@ -23,6 +23,7 @@
 
 require_once 'modules/Calls/views/view.edit.php';
 require_once 'SticInclude/Views.php';
+require_once 'modules/MySettings/TabController.php';
 
 class CustomCallsViewEdit extends CallsViewEdit
 {
@@ -54,7 +55,13 @@ class CustomCallsViewEdit extends CallsViewEdit
 
         SticViews::display($this);
 
-        // Write here you custom code
+        global $beanList, $moduleList, $current_user;
+        $tc = new TabController();
+        $displayTabs = $tc->get_tabs($current_user)[0];
+        $leadAccess = in_array('Leads', $moduleList) && isset($displayTabs['Leads']) && isset($beanList['Leads']) && ACLController::checkAccess('Leads', 'edit', true);
+        if (!$leadAccess) {
+            echo '<style>#create_invitee_as_lead{display:none!important}</style>';
+        }
     }
 
 }

--- a/custom/modules/Meetings/views/view.edit.php
+++ b/custom/modules/Meetings/views/view.edit.php
@@ -23,6 +23,7 @@
 
 require_once 'modules/Meetings/views/view.edit.php';
 require_once 'SticInclude/Views.php';
+require_once 'modules/MySettings/TabController.php';
 
 class CustomMeetingsViewEdit extends MeetingsViewEdit
 {
@@ -54,7 +55,13 @@ class CustomMeetingsViewEdit extends MeetingsViewEdit
 
         SticViews::display($this);
 
-        // Write here you custom code
+        global $beanList, $moduleList, $current_user;
+        $tc = new TabController();
+        $displayTabs = $tc->get_tabs($current_user)[0];
+        $leadAccess = in_array('Leads', $moduleList) && isset($displayTabs['Leads']) && isset($beanList['Leads']) && ACLController::checkAccess('Leads', 'edit', true);
+        if (!$leadAccess) {
+            echo '<style>#create_invitee_as_lead{display:none!important}</style>';
+        }
     }
 
 }


### PR DESCRIPTION
- Closes #1274 
## Descripción

Se oculta el botón "Nuevo Cliente Potencial" (Create Lead) en la sección de asistentes de las vistas de edición de Reuniones y Llamadas cuando el módulo Interesados no está disponible para el usuario actual. La comprobación incluye:

- Interesados deshabilitado del listado de módulos del sistema
- El usuario no tiene permisos de edición sobre Interesados (vía roles)


## Cómo probarlo

1. Acceder a la vista de edición de una Reunión o Llamada con un usuario que tenga Interesados visible y con permisos de edición → El botón "Nuevo Cliente Potencial" debe aparecer.
2. Administración → Seleccionar Pestañas de Módulos y Subpaneles→Deshabilitar Interesados → El botón debe ocultarse.
3. Asignar un rol que deniegue el acceso de edición a Interesados → El botón debe ocultarse para usuarios no administradores.
4. Verificar que el botón sigue funcionando correctamente cuando Interesados está disponible.

