### PR TITLE
Improvement - Firmas - Permitir función de parseo personalizada en plantillas PDF

### DIFF
--- a/modules/stic_Signatures/Utils.php
+++ b/modules/stic_Signatures/Utils.php
@@ -441,11 +441,10 @@ class stic_SignaturesUtils
         // The parse_template function requires an array of beans
         $beanArray = [$bean->module_dir => $bean->id];
 
-        // AAES - BFD - Custom Edit
+        // Enable custom parsing in templates
         if (file_exists('custom/modules/stic_Signatures/customParseTemplate.php')){
             require_once 'custom/modules/stic_Signatures/customParseTemplate.php';
         }
-        //END AAES - BFD - Custom Edit
 
         // First parse: Parse the template using the record's data
         $converted = templateParser::parse_template($text, $beanArray);

--- a/modules/stic_Signatures/Utils.php
+++ b/modules/stic_Signatures/Utils.php
@@ -441,6 +441,12 @@ class stic_SignaturesUtils
         // The parse_template function requires an array of beans
         $beanArray = [$bean->module_dir => $bean->id];
 
+        // AAES - BFD - Custom Edit
+        if (file_exists('custom/modules/stic_Signatures/customParseTemplate.php')){
+            require_once 'custom/modules/stic_Signatures/customParseTemplate.php';
+        }
+        //END AAES - BFD - Custom Edit
+
         // First parse: Parse the template using the record's data
         $converted = templateParser::parse_template($text, $beanArray);
         $header = templateParser::parse_template($header, $beanArray);


### PR DESCRIPTION
### Descripción
Se añade la posibilidad de utilizar una función personalizada para el parseo de plantillas PDF en el módulo de Firmas (`stic_Signatures`). Si existe el archivo `custom/modules/stic_Signatures/customParseTemplate.php`, se carga automáticamente antes del parseo estándar de la plantilla, permitiendo extender o modificar la lógica de sustitución de variables.

### Cambios realizados
- **`modules/stic_Signatures/Utils.php`**: Se añade una comprobación de existencia del archivo `custom/modules/stic_Signatures/customParseTemplate.php` y se incluye mediante `require_once` si está presente, justo antes de la llamada a `templateParser::parse_template()`.

### Pruebas a realizar
1. **Sin archivo custom**: Verificar que el parseo de plantillas PDF en Firmas funciona con normalidad (sin regresión).
2. **Con archivo custom**: Crear el archivo `custom/modules/stic_Signatures/customParseTemplate.php` con una función personalizada y verificar que se ejecuta correctamente antes del parseo estándar.
3. **Parseo de variables**: Confirmar que las variables de la plantilla se siguen sustituyendo correctamente tras la carga del archivo personalizado.
4. **Generación de PDF**: Validar que los documentos PDF generados desde Firmas mantienen el formato y contenido esperado.