### PR TITLE
Hotfix - Formularios Web Avanzados - Mostrar barra de desplazamiento en selector de acciones

### DIFF
--- a/modules/stic_AWF_Forms/ui/WizardView/steps/step3.html
+++ b/modules/stic_AWF_Forms/ui/WizardView/steps/step3.html
@@ -222,7 +222,7 @@
                                         <!-- Action -->
                                         <div>
                                             <label for="ModalAction-action" class="form-label" x-text="utils.translateForFieldLabel('LBL_ACTION')"></label>
-                                            <select id="ModalAction-action" class="form-select" size="5" x-model="$store.actionEditor.selectedActionDefName" 
+                                            <select id="ModalAction-action" class="form-select overflow-auto" size="5" x-model="$store.actionEditor.selectedActionDefName" 
                                                     @change="$store.actionEditor.onActionChange()">
                                                 <template x-for="def in $store.actionEditor.filteredActions" :key="def.name">
                                                     <option :value="def.name" x-text="def.title"></option>


### PR DESCRIPTION
- Closes #1287 

## Descripción
Tal y como se describe en #1287, el selector de acciones del editor de Formularios Web Avanzados no mostraba la barra de scoll si había más acciones de las que se estan visibles en el listado (en este caso 5).
El problema estaba en que el control `<select>` no tenía definida la propiedad css `overflow`.

## Pruebas
1. Crear un Formulario Web Avanzado
2. Añadir un Bloque de datos (cualquiera)
3. En el paso de Lógica y Automatismos, abrir el modal de selección de acciones accediendo a "Añadir una acción"
4. Inspeccionar el selector de acciones con las herramientas de desarrollador del navegador
5. Duplicar los nodos `<option>` hasta tener más de 5 elementos (al duplicar aparecerán con el nombre vacío)
6. Verificar que aparece la barra de scroll lateral que indica que hay más elementos que los visibles