### PR TITLE
Enhancement - Dashboard - Actualizar dashlet URL y activar para todos los usuarios

### DIFF
--- a/SticUpdates/Releases/enhancement/updateNewsDashlet/pre_install.txt
+++ b/SticUpdates/Releases/enhancement/updateNewsDashlet/pre_install.txt
@@ -1,0 +1,1 @@
+SticUpdates/Scripts/AddSticNewsDashletToAllUsers.php

--- a/SticUpdates/Scripts/AddSticNewsDashletToAllUsers.php
+++ b/SticUpdates/Scripts/AddSticNewsDashletToAllUsers.php
@@ -21,36 +21,44 @@ $sticDashlet = array(
 );
 
 
-foreach ($userBeanArray as $userBean) {
-    $dashletId = false;
-    require_once 'modules/UserPreferences/UserPreference.php';
-    $userBean = new UserPreference($userBean);
-    $foundInDashlet = false;
-    $dashletArray = $userBean->getPreference('dashlets', 'Home');
+if (empty($userBeanArray)) {
+    $GLOBALS['log']->debug('No users found. Skipping SticNewsDashlet installation.');
+} else {
+    foreach ($userBeanArray as $userBean) {
+        $dashletId = false;
+        require_once 'modules/UserPreferences/UserPreference.php';
+        $userBean = new UserPreference($userBean);
+        $foundInDashlet = false;
+        $dashletArray = $userBean->getPreference('dashlets', 'Home');
 
-    foreach($dashletArray as $key => $dashlet) {
-        if ($dashlet['className'] === 'SticNewsDashlet') {
-            $dashletId = $key;
-            $GLOBALS['log']->debug('Dashlet found in User dashboard');       
-            break;
+        if (is_array($dashletArray)) {
+            foreach ($dashletArray as $key => $dashlet) {
+                if ($dashlet['className'] === 'SticNewsDashlet') {
+                    $dashletId = $key;
+                    $GLOBALS['log']->debug('Dashlet found in User dashboard');
+                    break;
+                }
+            }
         }
-    }
-    if (!$dashletId) {
-        $dashletId = create_guid();
-        $GLOBALS['log']->debug('Dashlet not found in Dashlet array. We will add it...'); 
-        $dashletArray[$dashletId]= $sticDashlet;
-        $userBean->setPreference('dashlets', $dashletArray, 'Home');
-        $GLOBALS['log']->debug('Dashlet added in Dashlet array'); 
-    }
-    $pages = $userBean->getPreference('pages', 'Home');
+        if (!$dashletId) {
+            $dashletId = create_guid();
+            $GLOBALS['log']->debug('Dashlet not found in Dashlet array. We will add it...');
+            $dashletArray[$dashletId] = $sticDashlet;
+            $userBean->setPreference('dashlets', $dashletArray, 'Home');
+            $GLOBALS['log']->debug('Dashlet added in Dashlet array');
+        }
 
-    if (in_array($dashletId, $pages[0]['columns'][1]['dashlets'])) {
-        $GLOBALS['log']->debug('Dashlet found in Page array');   
-    } else {
-        $GLOBALS['log']->debug('Dashlet not found in Page. We will add it...'); 
-        array_unshift($pages[0]['columns'][1]['dashlets'], $dashletId);
-        $userBean->setPreference('pages', $pages, 'Home');
-        $GLOBALS['log']->debug('Dashlet added in Page array'); 
+        $pages = $userBean->getPreference('pages', 'Home');
+        if (is_array($pages) && isset($pages[0]['columns'][1]['dashlets']) && is_array($pages[0]['columns'][1]['dashlets'])) {
+            if (in_array($dashletId, $pages[0]['columns'][1]['dashlets'])) {
+                $GLOBALS['log']->debug('Dashlet found in Page array');
+            } else {
+                $GLOBALS['log']->debug('Dashlet not found in Page. We will add it...');
+                array_unshift($pages[0]['columns'][1]['dashlets'], $dashletId);
+                $userBean->setPreference('pages', $pages, 'Home');
+                $GLOBALS['log']->debug('Dashlet added in Page array');
+            }
+        }
+        $userBean->savePreferencesToDB();
     }
-    $userBean->savePreferencesToDB();
 }

--- a/config.php
+++ b/config.php
@@ -675,6 +675,13 @@ $sugar_config = array(
                 'scopes' => '',
             ),
     ),
+    // STIC-Custom XJO 20260707 - Update news dashlet URL
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/1305
+    'stic_news_dashlet_url' => array(
+        'es_ES' => 'https://www.sinergiatic.org/es/sinergiatic-news/',
+        'ca_ES' => 'https://www.sinergiatic.org/sinergiatic-news/',
+        'en_us' => 'https://www.sinergiatic.org/sinergiatic-news/',
+    ),
     // END STIC-Custom
 
     // STIC-Custom 20260427 JBL - Config for redirection method in web forms (Lead or Person capture) (POST or GET)

--- a/custom/modules/Home/Dashlets/SticNewsDashlet/SticNewsDashlet.php
+++ b/custom/modules/Home/Dashlets/SticNewsDashlet/SticNewsDashlet.php
@@ -27,23 +27,17 @@ require_once('include/Dashlets/Dashlet.php');
 class SticNewsDashlet extends Dashlet { 
     public $displayTpl = 'custom/modules/Home/Dashlets/SticNewsDashlet/display.tpl';
     public $configureTpl = 'custom/modules/Home/Dashlets/SticNewsDashlet/configure.tpl';
-    public $defaultURL = 'https://sinergiacrm.org/develop/es/sinergiacrm-news/'; // En suiteCRM esto podría estar en sugar_config
+    public $defaultURL;
     public $url;
 
     function __construct($id, $options = null) {
+        global $sugar_config, $current_language;
         parent::__construct($id);
 
-        $language = $GLOBALS['current_language'];
-        switch($language) {
-            case 'ca_ES':
-                $this->defaultURL = 'https://www.sinergiatic.org/actualitat-sinergiacrm-news/';
-                break;
-            case 'es_ES':
-            case 'en_us':
-            default:
-                $this->defaultURL = 'https://www.sinergiatic.org/es/actualidad-sinergiacrm-news/';
-                break;
-        }
+        // Gets default user language and defaults to English if not found
+        $stic_news_dashlet_url = $sugar_config['stic_news_dashlet_url'];
+        $this->defaultURL = !empty($current_language) ? $stic_news_dashlet_url[$current_language] : $stic_news_dashlet_url['en_us'];
+        
         $this->isConfigurable = false; // Dashlet won't be configurable
         
         if(empty($options['title'])) { 
@@ -112,6 +106,15 @@ class SticNewsDashlet extends Dashlet {
     }
 
     function display(){
-        return parent::display() . "<iframe class='teamNoticeBox' title='{$this->title}' src='{$this->url}' height='{$this->height}px'></iframe>";
+
+        $timestamp = time();
+
+        return parent::display() . "
+        <iframe 
+            class='teamNoticeBox'
+            title='{$this->title}'
+            src='{$this->url}?{$timestamp}'
+            height='{$this->height}px'>
+        </iframe>";
     }
 }


### PR DESCRIPTION
## Descripción
Actualiza el Dashlet de SinergiaCRM News cambiando la URL e implementando una URL por defecto en configuración. Además, se añade un script para añadir el Dashlet a todos los usuarios que no lo tengan ya en el Dashboard.

**Cambios:**
- Mueve la URL del iframe del News Dashlet a `$sugar_config`, permitiendo una fuente centralizada de configuración
- Añade un parámetro tiempo a la URL del iframe (`?t={timestamp}`) para invalidar la caché del navegador.
- Ejecuta un script que añade el dashlet a los usuarios de forma automatizada.

## Motivación y contexto
Este PR plantea una mejora en la manera en que se proporciona a los usuarios información sobre las últimas novedades de sinergiaCRM y actualiza el sistema de carga del dashlet para que se actualice de forma inmediata cuando haya cambios en la lista de noticias. Además, se restablece el dashlet para todos los usuarios.

## Pruebas

**Nuevo dashlet**
1. Navega al dasboard donde está el dashlet
2. Borrar la caché (Ctrl+Shift+R / Cmd+Shift+R) o borra y añade de nuevo el Dashlet.
3. Confirma que el dashlet carga la nueva página.
4. Confirma que el dashlet carga la página en el idioma correcto según el idioma seteado en el CRM.
5. Abre las dev tools y verifica que la URL del iframe incluye un timestamp
6. Cambia `$sugar_config['stic_news_dashlet_url']` en `config_override` y comprueba que carga la URL que hayas puesto en el override.

**Actualizar dashlet a los usuarios**
1. Navega al dasboard donde está el dashlet
2. Elimina el dashlet.
3. Comprueba en BBDD que el dashlet ja no está registrado para este usuario
4. Ejecuta el script `AddSticNewsDashletToAllUsers.php`
5. Comprueba que en BBDD vuelve a estar.
6. Para que se pueda ver, hay que hacer logout y login de nuevo. Confirma que el dashlet está en el dashboard.
