### PR TITLE
Hotfix - Formularios Web Avanzados - Corrección del validador regex con patrones sin delimitadores

### DIFF
--- a/modules/stic_AWF_Forms/actions/Validator/RegexValidatorAction.php
+++ b/modules/stic_AWF_Forms/actions/Validator/RegexValidatorAction.php
@@ -70,6 +70,17 @@ class RegexValidatorAction extends ValidatorActionDefinition {
     public function validateBackend(mixed $value, array $params): bool {
         if (empty($value)) return true;
         if (empty($params['pattern'])) return true;
-        return preg_match($params['pattern'], (string)$value) === 1;
+
+        $pattern = trim($params['pattern']);
+
+        // Check if the pattern already has valid delimiters (e.g., starts and ends with '/')
+        // If not, automatically add them for compatibility with PHP PCRE
+        if (!preg_match('/^\/.*\/[a-z]*$/i', $pattern)) {
+            $pattern = '/' . str_replace('/', '\/', $pattern) . '/';
+        }
+
+        // Use the @ operator to suppress warnings from preg_match
+        $matchResult = @preg_match($pattern, (string)$value);
+        return $matchResult === 1;
     }
 }


### PR DESCRIPTION
- Closes #1306 

## Descripción
Este PR soluciona un problema de paridad en la validación de expresiones regulares entre el frontend (JavaScript) y el backend (PHP) dentro del componente `RegexValidatorAction`, tal y como se describe en #1306 

Anteriormente, si un usuario introducía un patrón estándar como `^[0-9]{8}$` (sin delimitadores), la validación funcionaba correctamente en el navegador gracias a `new RegExp()`, pero fallaba en el servidor porque `preg_match` de PHP exige delimitadores PCRE obligatorios (provocando un falso negativo).

## Cambios realizados
* **`modules/stic_AWF_Forms/actions/Validator/RegexValidatorAction.php`**: 
  * Se ha refactorizado el método `validateBackend()` para detectar automáticamente si la expresión regular introducida por el usuario carece de delimitadores.
  * En caso de no tenerlos (estilo JS/HTML5), el backend la normaliza de forma segura envolviéndola entre barras `/` y escapando posibles conflictos antes de ejecutar `preg_match`.

## Pruebas
1. Crear un Formulario Web Avanzado.
2. Añadir un bloque de datos con un campo de tipo Texto.
3. Aplicar una acción de validación de tipo **Validador Regex** al campo con el patrón: `^[0-9]{8}$` (pensado para validar exactamente 8 dígitos, permitiendo ceros a la izquierda).
4. Publicar el formulario y rellenar el campo con un valor válido como `01234567`.
5. Enviar el formulario.
6. Verificar que no se muestra error de validación si el formato es correcto