### PR TITLE
Hotfix - Medicación - Módulos deben aparecer en la lista de búsqueda global

### DIFF
--- a/modules/stic_Medication_Log/vardefs.php
+++ b/modules/stic_Medication_Log/vardefs.php
@@ -194,7 +194,7 @@ $dictionary['stic_Medication_Log'] = array(
     'link' => true,
     'dbType' => 'varchar',
     'len' => '255',
-    'unified_search' => false,
+    'unified_search' => true,
     'full_text_search' => 
     array (
       'boost' => 3,

--- a/modules/stic_Prescription/vardefs.php
+++ b/modules/stic_Prescription/vardefs.php
@@ -308,7 +308,7 @@ $dictionary['stic_Prescription'] = array(
     'link' => true,
     'dbType' => 'varchar',
     'len' => '255',
-    'unified_search' => false,
+    'unified_search' => true,
     'full_text_search' => 
     array (
       'boost' => 3,
@@ -442,7 +442,7 @@ $dictionary['stic_Prescription'] = array(
 ),
     'optimistic_locking' => true,
     'unified_search' => true,
-    'full_text_search' => false,    
+    // 'full_text_search' => false,    
     'unified_search_default_enabled' => false,    
 );
 if (!class_exists('VardefManager')) {


### PR DESCRIPTION
- Closes #1317 

## Description
Los campos "name" de los módulos stic_Prescription y stic_Medication_Log tenían la propiedad "unified_search" a false. Esto hacía que no se puedieran añadir a la lista de módulos que deben aparecer en la búsqueda global.

## Motivation and Context
Posibilitar añadir estos módulos a la búsqueda global

## How To Test This
1. Ir al apartado de Administración "Configuración de búsqueda"
2. Comprobar que los módulos de Prescripciones y Registro de Medicación no aparecen
3. Una vez añadidos, junto con el módulo de Medicamentos, comprobar que aparecen correctamente en la búsqueda global

