### PR TITLE
Hotfix - Firmas - Mostrar todas las relaciones con Usuarios en la ruta del firmante

### DIFF
--- a/modules/stic_Signatures/Utils.php
+++ b/modules/stic_Signatures/Utils.php
@@ -174,11 +174,6 @@ class stic_SignaturesUtils
             if ($module == 'Leads') {
                 continue;
             }
-            
-            // Exclude Users module except for assigned_user_id field when main module is also Users
-            if ($moduleName != 'Users' && $module == 'Users' && $moduleField != 'assigned_user_id') {
-                continue;
-            }
            
             $app_list_strings['stic_signatures_signer_path_list'][$key] = $value;
         }


### PR DESCRIPTION
## Descripcion

Este cambio corrige la limitación en el desplegable de "Ruta del firmante" del módulo de Firmas (stic_Signatures) que solo mostraba el campo "Asignado a" (assigned_user_id) cuando el firmante era un Usuario.

Antes del cambio, si existían otras relaciones entre el módulo principal y Usuarios (ej. Gerente de Cuenta, Creado Por, etc.), estas no aparecían en el desplegable, impossibilitando seleccionar firmantes basados en esas relaciones.

El cambio elimina la condición de filtrado en `populateSignerPathListString()` que excluía explícitamente las relaciones con Users excepto para `assigned_user_id`.

## Motivacion y contexto

El issue #1326 reporta que al crear un proceso de firmas basado en usuarios, solamente está disponible el campo "Asignado a" para elegir el firmante. Si hay otras relaciones creadas entre el módulo principal y usuarios, no se muestran, independientemente de que usuarios esté en el lado 1 de la relación y el módulo principal de la firma en el lado n.

Esto limita la flexibilidad de los procesos de firmas, ya que los usuarios no pueden seleccionar firmantes basándose en relaciones como "Gerente de Cuenta", "Creado Por", u otras relaciones relevantes con Usuarios.

## Como probarlo

1. Ir a SinergiaCRM
2. Navegar a Firmas (stic_Signatures)
3. Hacer clic en "Crear"
4. Seleccionar una plantilla PDF
5. Seleccionar un módulo principal (ej. Accounts) que tenga relaciones con Users (además de assigned_user_id)
6. Verificar que ahora TODAS las relaciones con Usuarios aparecen en el desplegable de "Ruta del firmante"
7. Seleccionar una relación diferente a "Asignado a" y verificar que el proceso de firmas funciona correctamente

## Tipos de cambios

- [x] Correccion de error
- [ ] Nueva funcionalidad
- [ ] Cambio incompatible

Closes #1326