### PR TITLE
Hotfix - Formularios Web Avanzados - Corrección en las acciones con registros guardados después de editar el formulario

### DIFF
--- a/modules/stic_AWF_Forms/js/stic_AwfClasses.js
+++ b/modules/stic_AWF_Forms/js/stic_AwfClasses.js
@@ -2009,6 +2009,12 @@ class stic_AwfConfiguration {
       !a.is_automatic || !regeneratedActionNames.includes(a.name)
     );
     
+    // Preserve old save_action_ids so manual actions' requisite_actions stay valid
+    const oldSaveActionIds = {};
+    this.data_blocks.forEach(b => {
+        if (b.save_action_id) oldSaveActionIds[b.id] = b.save_action_id;
+    });
+
     // Reset saved action IDs on blocks before regenerating
     this.data_blocks.forEach(b => b.save_action_id = "");
 
@@ -2076,7 +2082,7 @@ class stic_AwfConfiguration {
             selectedOption: ''
           };
         }
-        const newAction = this.addAction(actionDef, params, '0');
+        const newAction = this.addAction(actionDef, params, '0', oldSaveActionIds[block.id]);
         if (newAction) {
           block.save_action_id = newAction.id;
           newAction.text = `${utils.translate('LBL_SAVE_RECORD_ACTION_TITLE')}: ${block.text}`;
@@ -2326,7 +2332,7 @@ class stic_AwfConfiguration {
    * @param {string} flowId Id of the flow where action will be added (ex: '0' for main flow)
    * @returns {stic_AwfAction} The new action
    */
-  addAction(actionDef, params = {}, flowId = '0') {
+  addAction(actionDef, params = {}, flowId = '0', existingId = null) {
     const flow = this.flows.find(f => f.id == flowId);
     if (!flow) {
       console.error(`Flow with ID ${flowId} not found.`);
@@ -2337,6 +2343,7 @@ class stic_AwfConfiguration {
     const defaultOrder = actionDef.isTerminal ? 999 : (actionDef.order ?? 0);
 
     const newAction = new stic_AwfAction({
+      ...(existingId ? { id: existingId } : {}),
       name: actionDef.name,
       title: actionDef.title, 
       text: actionDef.title,


### PR DESCRIPTION
## Descripción
En #1295 se implementó el guardado topológico de las relaciones de los bloques de datos en los Formularios Web Avanzados. Los registros se guardan correctamente en orden, pero al ejecutar alguna acción manual que necesitase un registro guardado se producía un error: 
```
Action 'RedirectToRecordAction' (id: ...) requires action with id '...' but it was not executed. Possible topological sort issue.
```
Esto se producía si se recalculaban las acciones automáticas del formulario (al editar un formulario existente o al cambiar al paso 2 nuevamente): El proceso de regeneración de las acciones, el método `regenerateAutomaticActions()` en `stic_AwfClasses.js` eliminaba y recreaba las acciones de guardado (`SaveRecordAction`) con **nuevos IDs**. Las acciones manuales  contienen información de sus acciones requisitos, para saber si pueden o no ejecutarse (todas sus acciones requisitos deben haberse ejecutado correctamente), pero al cambiar los IDs de las acciones, como el ID referenciado es antiguo y no existe en el flujo actual deduce que no se han ejecutado las acciones necesarias para poderse ejecutar y produce error.

## Solución implementada 
Se han preservado los IDs de las acciones de guardado cuando se regeneran automáticamente: Si la acción de guardado ya existía, se reutiliza su ID anterior.

## Pruebas
1. Crear un Formulario Web Avanzado
2. En el paso 2, añadir un Bloque de Datos para Persona (sin añadir nuevos campos)
3. En el paso 3, añadir una acción de "Añadir a una Lista de Público Objetivo" y seleccionar la persona (y cualquier LPO)
4. Volver al paso 2:
    1. Añadir más campos al Bloque de datos de Persona (por ejemplo el correo electrónico)
    2. Añadir una relación con Organización (creará un nuevo bloque de datos y los relacionará)
7. Ir al último paso y publicar el Formulario
8. Llenar el formulario
> Verificar que:
> 1. No se produce error ni después de introducir los datos ni en la respuesta
> 2. La persona creada se ha añadido a la LPO