### PR TITLE
Hotfix - Recursos y Reservas - Add missing require

### DIFF
--- a/modules/stic_Bookings/controller.php
+++ b/modules/stic_Bookings/controller.php
@@ -169,6 +169,7 @@ class stic_BookingsController extends SugarController
 
     public function action_loadExistingResources()
     {
+        require_once 'modules/stic_Bookings/Utils.php';
         $bookingId = $_REQUEST['bookingId'] ?? null;
         
         if (empty($bookingId)) {


### PR DESCRIPTION

## Description
En #1032 se han realizado cambios para que los literales de Plazas se vean igual a lo largo de los distintos módulos / lugares desde los que se accede a ellos. 
Uno de estos cambios ha provocado que falte incluir un fichero en ciertas ocasiones.
Se añade el requiere necesario

## Motivation and Context
Corregir el error introducido.

## How To Test This
1.- Crear una reserva de plazas
2.- Entrar a la edición de la reserva creada
3.- Comprobar que aparece la lista de recursos

