### PR TITLE
Hotfix - Formularios Web Avanzados - Validación correcta del valor false en campos de casilla de selección

### DIFF
--- a/modules/stic_AWF_Forms/EntryPoints/ResponseHandler.php
+++ b/modules/stic_AWF_Forms/EntryPoints/ResponseHandler.php
@@ -670,7 +670,7 @@ class ResponseHandler
                     case 'boolean':
                     case 'select_checkbox':
                     case 'select_switch':
-                        if (!filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
+                        if (filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === null) {
                             $errors['errorDescriptions'][$inputKeyInForm] = translate('LBL_FIELD', 'stic_AWF_Responses') ." '{$label}': ". 
                                                                             translate('LBL_ERROR_BOOL_FIELD', 'stic_AWF_Responses');
                             $errors['errors'][$inputKeyInForm] = translate('LBL_ERROR_BOOL_FIELD', 'stic_AWF_Responses');


### PR DESCRIPTION
- Closes #1347 
---

## Descripción
Tal y como se describe en #1347, si en un Formulario Web Avanzado se incluye un campo booleano y éste se representa como una casilla de validación (checkbox), al rellenar el formulario y enviarlo, el proceso de validación de datos recibidos fallaba e indicaba que "el valor debe ser cierto o falso", impidiendo el envío del formulario

## Solución implementada
La función `validateSubmission` de la clase `ResponseHandler` valida la respuesta recibida según el tipo de datos. Para los tipos de datos `bool`, `boolean`, `select_checkbox` y `select_switch` contenía un error:
```php
if (!filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
```
La función retorna el valor convertido a bool (`FILTER_VALIDATE_BOOLEAN`) e indicará que hay error como `null` (`FILTER_NULL_ON_FAILURE`). Con esta condición, los valores `false` son tomados como errores.
La corrección aplicada modifica la condición:
```php
if (filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === null) {
```
