### PR TITLE
Hotfix - Formularios Web Avanzados - Mostrar todas las relaciones distintas 1-N entre los mismos bloques de datos

### DIFF
--- a/modules/stic_AWF_Forms/Utils.php
+++ b/modules/stic_AWF_Forms/Utils.php
@@ -225,6 +225,12 @@ class stic_AWF_FormsUtils {
                     $vname = $def['vname'] ?? '';
                     $linkFieldName = '';
                     $relType = $def['relationship_type'] ?? 'many-to-many';
+
+                    // Ignore parent_type relationships
+                    if (($def['relationship_role_column'] ?? '') === 'parent_type') {
+                        $processed[$relName] = true;
+                        continue;
+                    }
                 } else {
                     $relName = $def['relationship'];
                     $lhs = $moduleName;
@@ -447,25 +453,6 @@ class stic_AWF_FormsUtils {
             }
         }
 
-        // Deduplicate by target module + text: if multiple relationships point to the same module_dest
-        // AND have the same text/label, keep only the first non-virtual one (avoids duplicate
-        // Notes/Tasks entries in module selectors). Relationships with different text to the same
-        // module are genuinely distinct (e.g. stic_Personal_Environment has two separate 1-N
-        // relationships to Contacts) and must be kept.
-        // Virtual relationships (is_virtual_relate = true) are always kept, since they represent
-        // distinct standalone relate fields that coexist with canonical relationships to the same module.
-        $seenKeyMap = [];
-        foreach ($result as $relName => $relData) {
-            $dest = $relData['module_dest'];
-            $text = $relData['text'];
-            $isVirtual = $relData['is_virtual_relate'] ?? false;
-            $key = $dest . '|' . $text;
-            if (isset($seenKeyMap[$key]) && !$isVirtual) {
-                unset($result[$relName]);
-            } else {
-                $seenKeyMap[$key] = true;
-            }
-        }
 
         return self::$relationshipsCache[$cacheKey] = $result;
     }

--- a/modules/stic_AWF_Forms/Utils.php
+++ b/modules/stic_AWF_Forms/Utils.php
@@ -447,18 +447,23 @@ class stic_AWF_FormsUtils {
             }
         }
 
-        // Deduplicate by target module: if multiple relationships point to the same module_dest,
-        // keep only the first non-virtual one (avoids duplicate Notes/Tasks entries in module selectors).
+        // Deduplicate by target module + text: if multiple relationships point to the same module_dest
+        // AND have the same text/label, keep only the first non-virtual one (avoids duplicate
+        // Notes/Tasks entries in module selectors). Relationships with different text to the same
+        // module are genuinely distinct (e.g. stic_Personal_Environment has two separate 1-N
+        // relationships to Contacts) and must be kept.
         // Virtual relationships (is_virtual_relate = true) are always kept, since they represent
         // distinct standalone relate fields that coexist with canonical relationships to the same module.
-        $seenDest = [];
+        $seenKeyMap = [];
         foreach ($result as $relName => $relData) {
             $dest = $relData['module_dest'];
+            $text = $relData['text'];
             $isVirtual = $relData['is_virtual_relate'] ?? false;
-            if (isset($seenDest[$dest]) && !$isVirtual) {
+            $key = $dest . '|' . $text;
+            if (isset($seenKeyMap[$key]) && !$isVirtual) {
                 unset($result[$relName]);
             } else {
-                $seenDest[$dest] = true;
+                $seenKeyMap[$key] = true;
             }
         }
 


### PR DESCRIPTION
- Closes #1343 

---
## Descripción
Tal y como se describe en #1343, en el proceso de edición de un Formulario Web Avanzado no se mostraban todas las relaciones existentes, si un módulo tenía más de una relación 1-N con otro módulo, únicamente aparecía una de ellas. 
Este problema se veía especialmente en el módulo "Entorno personal", que tiene dos relaciones 1-N con "Personas":
- `stic_personal_environment_contacts`
- `stic_personal_environment_contacts_1`

## Cambios realizados
Se ha analizado porqué podrían aparecer posibles relaciones "duplicadas" en los bloques de datos y se ha observado que se podrían incluir las relaciones de tipo "`parent_type`", aunque este tipo de relaciones no están soportadas para definirse entre bloques de datos.
Se ha modificado la función `getRelationshipsFromDictionary` en `modules/stic_AWF_Forms/Utils.php`, ignorando las relaciones del tipo `parent_type` a la vez que se ha eliminado el código que eliminaba las relaciones supuestamente "duplicadas" del listado de posibles relaciones del bloque de datos.

## Pruebas
1. Ir a Formularios Web Avanzados y crear/editar un formulario
2. Paso 2: añadir un Bloque de Datos con módulo "Persona"
3. Añadir un segundo Bloque de Datos con módulo "Entorno Personal"
4. Desde el bloque de "Entorno Personal" abrir el diálogo para añadir una nueva relación
> Verificar que aparecen las dos relaciones con Persona: "Persona Base" y "Persona del entorno".
5. Repetir desde el bloque de "Persona": abrir el diálogo para añadir una nueva relación
> Verificar que aparecen las dos relaciones con Entorno Personal: "Entorno personal de la persona atendida" y "Relaciones de entorno personal de las cuales la persona forma parte".
6. Desde el bloque de "Persona", verificar que aparece una única vez la relación con "Notas" y "Tareas"