### PR TITLE
Hotfix - Formularios Web Avanzados - Corrección error ejecución acciones en formularios previos a la versión 2.11.0

### DIFF
--- a/modules/stic_AWF_Forms/core/ServerActionFlowExecutor.php
+++ b/modules/stic_AWF_Forms/core/ServerActionFlowExecutor.php
@@ -57,10 +57,14 @@ class ServerActionFlowExecutor {
                 $lastActionConfig = $actionConfig;
 
                 // Check that all requisite_actions have been executed successfully
+                // Backward compatibility: if a requisite action hasn't been executed (null),
+                // log a warning but let the action proceed. This preserves the pre-update
+                // behavior where no topological sort was performed server-side.
                 foreach ($actionConfig->requisite_actions as $reqActionId) {
                     $reqResult = $this->context->getActionResultById($reqActionId);
                     if ($reqResult === null) {
-                        throw new \RuntimeException("Action '{$actionConfig->name}' (id: {$actionConfig->id}) requires action with id '{$reqActionId}' but it was not executed. Possible topological sort issue.");
+                        $GLOBALS['log']->warn('Line '.__LINE__.': '.__METHOD__.': '."Advanced Web Forms: Action '{$actionConfig->name}' (id: {$actionConfig->id}) requires action with id '{$reqActionId}' but it was not executed. Continuing anyway for backward compatibility.");
+                        continue;
                     }
                     if ($reqResult->isError()) {
                         $GLOBALS['log']->warning('Line '.__LINE__.': '.__METHOD__.': '."Advanced Web Forms: Action '{$actionConfig->name}' skipped because requisite action '{$reqActionId}' failed.");


### PR DESCRIPTION
- Closes #1356 

## Descripción
Tal y como se describe en #1356, algunos formularios previos a la release 2.11.0, con más de una acción configurada, producían error al ejecutarse los flujos al recibir una respuesta.
El error es debido a que el servidor lanzaba una excepción si detectaba que las acciones definidas en el Wizard como requisitos no se habían ejecutado. Anteriormente, esta verificación no se realizaba, y con la release 2.11.0, se modificó la ordenación de acciones.

## Solución implementada
Se ha suavizado la validación PHP en `ServerActionFlowExecutor.php:` en lugar de lanzar una excepción cuando una acción requisito no se ha ejecutado, se loguea un warning y se permite que la acción continúe.

## Pruebas
A parte de la validación de código:
1. Tener un formulario web avanzado creado antes de la [release 2.11.0](https://github.com/SinergiaTIC/SinergiaCRM/releases/tag/2.11.0)
2. Asegurarse de que tenga acciones con dependencias entre ellas (p.ej., SaveRecordAction y SendEmailToDataBlockAction).
3. Enviar el formulario desde el frontend.
4. Observar que no se produce ningún error en la respuesta ni en el registro de ejecución.