### PR TITLE
Hotfix - Formularios Web Avanzados - Migración de configuración de relaciones

### DIFF
--- a/modules/stic_AWF_Forms/js/stic_AwfClasses.js
+++ b/modules/stic_AWF_Forms/js/stic_AwfClasses.js
@@ -1266,6 +1266,11 @@ class stic_AwfConfiguration {
     this._ensureDefaultDataBlocks();
     this._ensureDefaultFlows();
     this._ensureDefaultLayout();
+
+    // 5. Backward compatibility: migrate relationships stored in the pre-2.11.0
+    // format (relate fields with value_type = 'dataBlock') into the new
+    // data_blocks[].relationships array.
+    this._migrateLegacyRelationships();
   }
   static fromJSON(jsonString){
     const config = new stic_AwfConfiguration(JSON.parse(jsonString));
@@ -1344,6 +1349,75 @@ class stic_AwfConfiguration {
   }
   _ensureDefaultLayout() {
     // No default Layout!!
+  }
+
+  /**
+   * Backward compatibility migration.
+   * Before SinergiaCRM 2.11.0, block-to-block relationships were stored implicitly
+   * by adding a relate field with value_type = 'dataBlock' to the origin data block.
+   * From 2.11.0 onwards, relationships are stored explicitly in
+   * data_blocks[].relationships and are used by getAllDataBlockRelationships() and
+   * regenerateAutomaticActions().
+   *
+   * This method detects the old-style relate fields and recreates the relationship
+   * entries in the new format, so pre-2.11.0 forms keep working when edited.
+   */
+  _migrateLegacyRelationships() {
+    if (!this.data_blocks || this.data_blocks.length === 0) {
+      return;
+    }
+
+    this.data_blocks.forEach(block => {
+      if (!block.module || !block.fields) {
+        return;
+      }
+
+      const moduleInfo = block.getModuleInformation();
+      if (!moduleInfo || !moduleInfo.fields) {
+        return;
+      }
+
+      block.fields.forEach(field => {
+        // Only old-style relationship fields point to another data block
+        if (field.type !== 'relate' || field.value_type !== 'dataBlock' || !field.value) {
+          return;
+        }
+
+        const relatedBlockId = field.value;
+        const relatedBlock = this.data_blocks.find(b => b.id === relatedBlockId);
+        if (!relatedBlock) {
+          return;
+        }
+
+        // Resolve the relationship name from the module metadata
+        const fieldInfo = moduleInfo.fields[field.name];
+        const relName = fieldInfo?.options;
+        if (!relName) {
+          return;
+        }
+
+        // Skip if the relationship has already been migrated in either direction
+        const alreadyExists =
+          block.relationships.some(
+            r => r.name === relName && r.related_datablock_id === relatedBlockId
+          ) ||
+          relatedBlock.relationships.some(
+            r => r.name === relName && r.related_datablock_id === block.id
+          );
+        if (alreadyExists) {
+          return;
+        }
+
+        // Ensure the field has a readable text value
+        if (!field.value_text) {
+          field.value_text = relatedBlock.text;
+        }
+
+        // Use the existing relationship creation logic to add entries on both sides,
+        // set initiator_id / role and create/update the relate field consistently.
+        this.addDataBlockRelationship(block.id, relName, relatedBlockId, '');
+      });
+    });
   }
 
  /**


### PR DESCRIPTION
- Closes #1359

## Problema
En la versión 2.11.0 se introdujo el almacenamiento explícito de las relaciones entre bloques de datos en el array `data_blocks[].relationships`. Los formularios creados antes de esta versión guardaban las relaciones de forma implícita añadiendo un campo `relate` con `value_type = "dataBlock"` al bloque de origen.

Al abrir uno de estos formularios antiguos en el asistente y guardarlo:
- En el paso *Estructura y campos* del asistente, no aparecían las relaciones.
- `regenerateAutomaticActions()` reconstruía el flujo únicamente con acciones `SaveRecordAction`, perdiendo la inyección de FK para relaciones 1-N y las acciones `RelateRecordsAction` para relaciones N-M.

## Causa raíz
- `getAllDataBlockRelationships()` solo marca como usadas las relaciones que existen en `data_blocks[].relationships`.
- `regenerateAutomaticActions()` genera las acciones automáticas a partir de ese array.
- No existía ninguna migración que convirtiera los campos `relate` antiguos (`value_type = "dataBlock"`) en entradas del nuevo formato.

## Solución aplicada
Se añade el método `_migrateLegacyRelationships()` al constructor de `stic_AwfConfiguration` en `modules/stic_AWF_Forms/js/stic_AwfClasses.js`:

- Detecta campos `relate` con `value_type = "dataBlock"` cuyo valor sea el ID de otro bloque de datos existente.
- Resuelve el nombre de la relación a partir de los metadatos del módulo (`moduleInfo.fields[field.name].options`).
- Reconstruye las relaciones en el nuevo formato usando `addDataBlockRelationship()`, que se encarga de generar correctamente los campos `initiator_id`, `role` y el campo relate en ambos bloques.
- Evita duplicados comprobando si la relación ya existe en cualquiera de los dos sentidos.
- Rellena `field.value_text` si falta.

La migración se ejecuta automáticamente al cargar cualquier formulario.

## Pasos para probar
1. Localizar un formulario web avanzado guardado antes de la 2.11.0 que tenga relaciones entre bloques de datos.
2. Enviar una respuesta y verificar que se crean las relaciones
3. Abrir el formulario en el asistente (Editar).
4. Ir al paso Estructura y campos (paso 2). Comprobar que la lista de relaciones NO está vacía y es correcta.
5. Guardar el formulario (o entrar en el paso 3 de acciones y guardar).
6. Enviar una respuesta del formulario.
7. Verificar que se crean los registros y se establecen las relaciones.

## Notas para las pruebas
Para obtener un formulario con una versión anterior a la 2.11.0 se puede hacer una de las siguientes opciones:
- Hacer checkout a la release 2.10.1 (`git checkout tags/2.10.1`) y crear el formulario.
- Crear un formulario (no importa la versión) y en el campo `configuration` de la tabla `stic_awf_forms` de su registro copiar el json de la configuración de un formulario definido en una versión anterior, como por ejemplo el adjunto a este PR
[config_form_previo_2.11.0.json](https://github.com/user-attachments/files/30513311/config_form_previo_2.11.0.json)
