### PR TITLE
Hotfix - Correos - Corregir duplicado y codificación del remitente por defecto en el campo "De"

### DIFF
--- a/modules/Emails/EmailsControllerActionGetFromFields.php
+++ b/modules/Emails/EmailsControllerActionGetFromFields.php
@@ -202,16 +202,33 @@ class EmailsControllerActionGetFromFields
             $signature = $userOutboundAccount->signature ?? '';
             $isPersonal = $type === 'user';
             $isGroup = $type === 'group';
+            // STIC-Custom 20260803 PCS - Avoid adding the system default outbound account twice:
+            // it may already have been added by the collector through addSystemEmailAddress /
+            // fillDataAddressWithSystemMailerSettings (same id as the system mailer settings).
+            // STIC#
+            $existingIds = array_column($dataAddresses, 'id');
+            if (in_array($id, $existingIds, true) && $type === 'system') {
+                continue;
+            }
+            // END STIC-Custom
             $entry = [
                 'type' => 'OutboundEmailAccount',
                 'id' => $id,
                 'name' => $name,
                 'attributes' => [
-                    'from' => $fromAddress,
-                    'name' => $fromName,
+                    // STIC-Custom 20260803 PCS - Avoid encoding errors.
+                    // STIC#
+                    // 'from' => $fromAddress,
+                    // 'name' => $fromName,
+                    // 'oe' => '',
+                    // 'reply_to' => $replyToAddress,
+                    // 'reply_to_name' => $replyToName
+                    'from' => mb_convert_encoding($fromAddress, 'UTF-8', 'ISO-8859-1'),
+                    'name' => mb_convert_encoding($fromName, 'UTF-8', 'ISO-8859-1'),
                     'oe' => '',
-                    'reply_to' => $replyToAddress,
-                    'reply_to_name' => $replyToName
+                    'reply_to' => mb_convert_encoding($replyToAddress, 'UTF-8', 'ISO-8859-1'),
+                    'reply_to_name' => mb_convert_encoding($replyToName, 'UTF-8', 'ISO-8859-1')
+                    // END STIC-Custom
                 ],
                 'prepend' => false,
                 'isPersonalEmailAccount' => $isPersonal,

--- a/modules/Emails/EmailsControllerActionGetFromFields.php
+++ b/modules/Emails/EmailsControllerActionGetFromFields.php
@@ -205,7 +205,7 @@ class EmailsControllerActionGetFromFields
             // STIC-Custom 20260803 PCS - Avoid adding the system default outbound account twice:
             // it may already have been added by the collector through addSystemEmailAddress /
             // fillDataAddressWithSystemMailerSettings (same id as the system mailer settings).
-            // STIC#
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1366
             $existingIds = array_column($dataAddresses, 'id');
             if (in_array($id, $existingIds, true) && $type === 'system') {
                 continue;
@@ -217,7 +217,7 @@ class EmailsControllerActionGetFromFields
                 'name' => $name,
                 'attributes' => [
                     // STIC-Custom 20260803 PCS - Avoid encoding errors.
-                    // STIC#
+                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/1366
                     // 'from' => $fromAddress,
                     // 'name' => $fromName,
                     // 'oe' => '',

--- a/modules/Emails/EmailsDataAddressCollector.php
+++ b/modules/Emails/EmailsDataAddressCollector.php
@@ -672,6 +672,14 @@ class EmailsDataAddressCollector
         $this->setOe(new OutboundEmail());
         if ($this->getOe()->isAllowUserAccessToSystemDefaultOutbound()) {
             $system = $this->getOe()->getSystemMailerSettings();
+            // STIC-Custom 20260803 PCS - Avoid adding the system default outbound account twice when
+            // it has already been added by addOutboundEmailAccounts (same id in the outbound_email table).
+            // STIC#
+            $existingIds = array_column($dataAddresses, 'id');
+            if (in_array($system->id, $existingIds, true)) {
+                return $dataAddresses;
+            }
+            // END STIC-Custom
             $dataAddresses[] = $this->getFillDataAddressArray(
                 $system->id,
                 $system->name,
@@ -694,6 +702,14 @@ class EmailsDataAddressCollector
         $this->setOe(new OutboundEmail());
         if ($this->getOe()->isAllowUserAccessToSystemDefaultOutbound()) {
             $system = $this->getOe()->getSystemMailerSettings();
+            // STIC-Custom 20260803 PCS - Avoid adding the system default outbound account twice when
+            // it has already been added by addOutboundEmailAccounts (same id in the outbound_email table).
+            // STIC#
+            $existingIds = array_column($dataAddresses, 'id');
+            if (in_array($system->id, $existingIds, true)) {
+                return;
+            }
+            // END STIC-Custom
             $dataAddresses[] = $this->getFillDataAddressArray(
                 $system->id,
                 $system->name,

--- a/modules/Emails/EmailsDataAddressCollector.php
+++ b/modules/Emails/EmailsDataAddressCollector.php
@@ -674,7 +674,7 @@ class EmailsDataAddressCollector
             $system = $this->getOe()->getSystemMailerSettings();
             // STIC-Custom 20260803 PCS - Avoid adding the system default outbound account twice when
             // it has already been added by addOutboundEmailAccounts (same id in the outbound_email table).
-            // STIC#
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1366
             $existingIds = array_column($dataAddresses, 'id');
             if (in_array($system->id, $existingIds, true)) {
                 return $dataAddresses;
@@ -704,7 +704,7 @@ class EmailsDataAddressCollector
             $system = $this->getOe()->getSystemMailerSettings();
             // STIC-Custom 20260803 PCS - Avoid adding the system default outbound account twice when
             // it has already been added by addOutboundEmailAccounts (same id in the outbound_email table).
-            // STIC#
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1366
             $existingIds = array_column($dataAddresses, 'id');
             if (in_array($system->id, $existingIds, true)) {
                 return;


### PR DESCRIPTION
- Closes #1364
## Descripción

Al enviar un email directamente desde cualquier módulo (p.ej. Personas), en el campo "De" el remitente por defecto aparece duplicado (dos entradas para la misma cuenta), y una de ellas muestra los caracteres especiales mal codificados (acentos/ñ distorsionados).
Se reproduce de forma general en las instancias donde la cuenta de salida por defecto del sistema está visible para el usuario (preferencia de administración `notify_allow_default_outbound`).

El mismo remitente se añade dos veces por dos vías distintas en `action_getFromFields`:

- El collector lo agrega como cuenta system (`addSystemEmailAddress / fillDataAddressWithSystemMailerSettings`).
- `addOutboundEmailAccounts() `lo vuelve a añadir porque getUserOutboundAccounts() también devuelve la cuenta con type='system'.

 Además, la entrada creada por `addOutboundEmailAccounts()` construía los campos from/name/reply_to/reply_to_name en crudo, sin la normalización de codificación `mb_convert_encoding(...,'UTF-8','ISO-8859-1') `que sí aplica `EmailsDataAddress::getDataArrayAttributes()`. Ese desajuste provocaba que los caracteres especiales salieran mal en una de las entradas.

## Solución

- Deduplicación por id (evita que el mismo remitente aparezca dos veces):

En `addOutboundEmailAccounts()`: se omite añadir una cuenta si su id ya existe en las direcciones recogidas.
En `fillDataAddressWithSystemMailerSettings() y addSystemEmailAddress(): `solo se añade la cuenta sistema si su id todavía no está.

- Codificación consistente (arregla los caracteres mal):

En addOutboundEmailAccounts(): se aplica mb_convert_encoding(..., 'UTF-8', 'ISO-8859-1') a from, name, reply_to y reply_to_name, igual que hace EmailsDataAddress::getDataArrayAttributes() para el resto de entradas, de modo que todas renderizan igual.


## Pruebas
1. Enviar un email desde cualquier módulo y comprobar que el remitente por defecto no aparece duplicado.
2. Verificar que los acentos/ñ se muestran correctamente en todas las cuentas del campo "De".
