### PR TITLE
Hotfix - Formularios Web Avanzados - Mostrar registros en selección de registros de módulos protegidos

### DIFF
--- a/modules/stic_AWF_Forms/ui/WizardView/js/wizard.js
+++ b/modules/stic_AWF_Forms/ui/WizardView/js/wizard.js
@@ -1231,7 +1231,11 @@ class WizardStep2 {
           }
         };
         if (this.optionValuesRelated != ''){
-          listName = `${utils.getModuleInformation(this.relatedModule)?.text} (${this.optionValuesRelated.split('|').length})`;
+          let relatedModuleText = utils.getModuleInformation(this.relatedModule)?.text;
+          if(!relatedModuleText && this.selectedFieldInfo?.module) {
+            relatedModuleText = SUGAR.language.languages.app_list_strings.moduleList[this.selectedFieldInfo.module] ?? this.selectedFieldInfo.module;
+          }
+          listName = `${relatedModuleText} (${this.optionValuesRelated.split('|').length})`;
         }
         if (listName == '' && this.field && this.field.value_options.length > 0) {
           listName = this.field.value_options.filter(v => v.is_visible).map(v => v.text).join(', ');
@@ -1241,7 +1245,8 @@ class WizardStep2 {
 
       get relatedModule() {
         if (this.field && this.field.type == 'relate') {
-          return this.formConfig.getRelationshipModule(this.dataBlock.id, this.selectedFieldInfo?.options);
+          return this.formConfig.getRelationshipModule(this.dataBlock.id, this.selectedFieldInfo?.options)
+                 || this.selectedFieldInfo?.module || '';
         }
         return '';
       },


### PR DESCRIPTION
- Closes #1368 
---

## Descripción
Tal y como se explica en #1368, al editar un Formulario Web Avanzado y mostrar el popup de selección de registros de un módulo que no sea permitido usar para crear registros mediante un Formulario Web Avanzado (por ejemplo `Users`), el popup aparecía vacío y con un mensaje de error.

Esto era debido a que la información del módulo destino del campo `relate` se obtenía mediante la función `getRelationshipModule`, la cual usa el listado filtrado de módulos.

## Solución aplicada
Si al buscar el módulo destino, no obtenemos información mediante la función `getRelationshipModule`, se obtiene el nombre del módulo mediante la información del campo `relate`, que informa del módulo destino.
Por otro lado, para poder mostrar el nombre del listado de elementos para los casos de campos de formulario con desplegable y valores posibles, se usa el nombre del módulo definido en las cadenas de `SUGAR.language.languages.app_list_strings.moduleList`

## Pruebas
1. Crear o editar un Formulario Web Avanzado
2. En el paso 2, añadir un Bloque de Datos vinculado a cualquier módulo (p. ej. Personas).
3. Añadir un campo de Servidor y seleccionar el campo "Asignado a".
4. En el selector del valor, pulsar el botón para abrir el popup de selección.
> Verificar que aparece el popup con los Usuarios registrados en el CRM
5. Seleccionar un registro y guardar el campo de servidor
6. Editar el campo de servidor "Asignado a"
7. Convertirlo en "campo de formulario"
8. Presionar en "Seleccionar registros" para abrir el popup
> Verificar que aparece el popup con los usuarios registrados en el CRM y es posible seleccionar más de uno
9. Seleccionar más de uno 
> Verificar que el nombre de la lista asociada es el nombre del módulo con el número de registros seleccionados entre paréntesis `Usuarios (2)`
