### PR TITLE
Fix: SMTP SendAsDenied error in signature email sending

### DIFF
--- a/modules/stic_Signers/Utils.php
+++ b/modules/stic_Signers/Utils.php
@@ -83,12 +83,14 @@ class stic_SignersUtils
         $mail = new SugarPHPMailer();
         $mail->setMailerForSystem();
 
-        // Set From and FromName using current user or system defaults
-        $fromEmail = $current_user->email1 ?: $defaults['email'];
-        $mail->From = $fromEmail;
+        // Use system default email for From header (SMTP compatibility)
+        $mail->From = $defaults['email'];
+        $mail->FromName = $defaults['name'];
 
-        $fromName = $current_user->name ?: $defaults['name'];
-        $mail->FromName = $fromName;
+        // Add current user as Reply-To so recipients can respond directly
+        if (!empty($current_user->email1)) {
+            $mail->AddReplyTo($current_user->email1, $current_user->name);
+        }
 
         // Add recipient
         if (empty($destAddress)) {
@@ -206,12 +208,14 @@ class stic_SignersUtils
         $mail = new SugarPHPMailer();
         $mail->setMailerForSystem();
 
-        // Set From and FromName
-        $fromEmail = $current_user->email1 ?: $defaults['email'];
-        $mail->From = $fromEmail;
+        // Use system default email for From header (SMTP compatibility)
+        $mail->From = $defaults['email'];
+        $mail->FromName = $defaults['name'];
 
-        $fromName = $current_user->name ?: $defaults['name'];
-        $mail->FromName = $fromName;
+        // Add current user as Reply-To so recipients can respond directly
+        if (!empty($current_user->email1)) {
+            $mail->AddReplyTo($current_user->email1, $current_user->name);
+        }
 
         // Add recipient
         if (empty($destAddress)) {


### PR DESCRIPTION
## 🐛 Problem

When sending a signature request link to a signer, an SMTP `SendAsDeniedException` error occurs when the user initiating the send has an email defined, but the system's main email account cannot send emails on their behalf. This affects all SMTP providers except SinergiaTIC's.

**Error:**
```
SMTP Error: data not accepted.SMTP server error: DATA END command failed 
Detail: 5.2.252 SendAsDenied; c___m@XXXXX.org not allowed to send as e______s@XXXXX.org
SMTP code: 554
```

**Root Cause:**
The code was setting the email's `From` header to the current user's email address, but sending via the system's SMTP account. Most SMTP providers (Gmail, MS 365, etc.) reject this because the authenticated account doesn't match the `From` address.

## ✅ Solution

Changed both email-sending methods to:
- Use the **system default email** for the `From` header (ensures SMTP compatibility)
- Add the **current user's email as `Reply-To`** (allows recipients to respond directly to the user)

## 📝 Changes

**File:** `modules/stic_Signers/Utils.php`

- `sendToSign()` method - Fixed From/Reply-To headers
- `sendOtpEmailToSigner()` method - Applied same fix

## 🧪 Testing

- [ ] Test with Gmail SMTP
- [ ] Test with Microsoft 365 SMTP
- [ ] Verify Reply-To header functionality
- [ ] Ensure no regression with SinergiaTIC SMTP

Fixes #1349