### PR TITLE
Hotfix - Firmas - Corregir error en envío SMTP

### DIFF
--- a/modules/stic_Signers/Utils.php
+++ b/modules/stic_Signers/Utils.php
@@ -83,12 +83,14 @@ class stic_SignersUtils
         $mail = new SugarPHPMailer();
         $mail->setMailerForSystem();
 
-        // Set From and FromName using current user or system defaults
-        $fromEmail = $current_user->email1 ?: $defaults['email'];
-        $mail->From = $fromEmail;
+        // Use system default email for From header (SMTP compatibility)
+        $mail->From = $defaults['email'];
+        $mail->FromName = $defaults['name'];
 
-        $fromName = $current_user->name ?: $defaults['name'];
-        $mail->FromName = $fromName;
+        // Add current user as Reply-To so recipients can respond directly
+        if (!empty($current_user->email1)) {
+            $mail->AddReplyTo($current_user->email1, $current_user->name);
+        }
 
         // Add recipient
         if (empty($destAddress)) {
@@ -206,12 +208,14 @@ class stic_SignersUtils
         $mail = new SugarPHPMailer();
         $mail->setMailerForSystem();
 
-        // Set From and FromName
-        $fromEmail = $current_user->email1 ?: $defaults['email'];
-        $mail->From = $fromEmail;
+        // Use system default email for From header (SMTP compatibility)
+        $mail->From = $defaults['email'];
+        $mail->FromName = $defaults['name'];
 
-        $fromName = $current_user->name ?: $defaults['name'];
-        $mail->FromName = $fromName;
+        // Add current user as Reply-To so recipients can respond directly
+        if (!empty($current_user->email1)) {
+            $mail->AddReplyTo($current_user->email1, $current_user->name);
+        }
 
         // Add recipient
         if (empty($destAddress)) {

--- a/modules/stic_Signers/Utils.php
+++ b/modules/stic_Signers/Utils.php
@@ -83,14 +83,6 @@ class stic_SignersUtils
         $mail = new SugarPHPMailer();
         $mail->setMailerForSystem();
 
-        // Use system default email for From header (SMTP compatibility)
-        $mail->From = $defaults['email'];
-        $mail->FromName = $defaults['name'];
-
-        // Add current user as Reply-To so recipients can respond directly
-        if (!empty($current_user->email1)) {
-            $mail->AddReplyTo($current_user->email1, $current_user->name);
-        }
 
         // Add recipient
         if (empty($destAddress)) {
@@ -208,14 +200,7 @@ class stic_SignersUtils
         $mail = new SugarPHPMailer();
         $mail->setMailerForSystem();
 
-        // Use system default email for From header (SMTP compatibility)
-        $mail->From = $defaults['email'];
-        $mail->FromName = $defaults['name'];
 
-        // Add current user as Reply-To so recipients can respond directly
-        if (!empty($current_user->email1)) {
-            $mail->AddReplyTo($current_user->email1, $current_user->name);
-        }
 
         // Add recipient
         if (empty($destAddress)) {


### PR DESCRIPTION
## 🐛 Problema

Al enviar un enlace de solicitud de firma a un firmante, se produce un error SMTP `SendAsDeniedException` cuando el usuario que realiza el envío tiene un email definido, pero la cuenta principal del CRM no puede enviar emails en su nombre. Esto afecta a todos los proveedores SMTP excepto el de SinergiaTIC.

**Error:**
```
SMTP Error: data not accepted.SMTP server error: DATA END command failed 
Detail: 5.2.252 SendAsDenied; c___m@XXXXX.org not allowed to send as e______s@XXXXX.org
SMTP code: 554
```

**Causa raíz:**
El código establecía el header `From` del email con la dirección del usuario actual, pero enviaba a través de la cuenta SMTP del sistema. La mayoría de proveedores SMTP (Gmail, MS 365, etc.) rechazan esto porque la cuenta autenticada no coincide con la dirección `From`.

## ✅ Solución

Se han modificado ambos métodos de envío de email para usar el **email predeterminado del sistema** en el header `From`, lo que garantiza la  compatibilidad SMTP. 

Esto impide que se puedan utilizar como From la dirección de email del usuario, lo que evita el problema detectado, aunque impide que se pueda _customizar_ el envío de estos correos de notificación _ordinarios_. Sin embargo el envío de notificaciones de firma, mediante campañas si permiten especificar qué cuenta de correo debe usarse para el envío.


## 📝 Cambios

**Archivo:** `modules/stic_Signers/Utils.php`

- Método `sendToSign()` - Ahora siempre se usa la cuenta SMTP del sistema.
- Método `sendOtpEmailToSigner()` - Aplicada la misma corrección

## 🧪 Pruebas

- [ ] Probar con SMTP de Gmail
- [ ] Probar con SMTP de Microsoft 365
- [ ] Verificar funcionalidad del header Reply-To
- [ ] Asegurar que no hay regresión con SMTP de SinergiaTIC

Cierra #1349


Nota alternativa:
- Otra solución pasaría por utilizar la cuenta de correo saliente configurada en el usuario que realiza el envío. Pero esto último se debería considerar si es opcional/configurable en el proceso de firma o en el momento de solicitar la firma por correo.  Hay que tener en cuenta que cuando se realiza la solicitud de firma a través del subpanel de Notificaciones en el proceso de firma sí que se puede escoger la cuenta de correo saliente y los demás detalles.