### PR TITLE
Hotfix - Candidaturas - Cambiar el usuario asignado

### DIFF
--- a/modules/stic_Job_Applications/Utils.js
+++ b/modules/stic_Job_Applications/Utils.js
@@ -83,6 +83,56 @@ switch (viewType()) {
     
     setAutofill(["name"]);
 
+    // On new records, prefill assigned user from the selected offer so UI and saved value match
+    if (typeof STIC !== "undefined" && STIC.record && !STIC.record.id) {
+      const offerIdField = "stic_job_applications_stic_job_offersstic_job_offers_ida";
+      const assignedUserIdField = "assigned_user_id";
+      const assignedUserNameField = "assigned_user_name";
+      let assignedUserManuallyChanged = false;
+
+      function getOfferAssignedUser(offerId, callbackFunction) {
+        $.ajax({
+          url: "index.php?module=stic_Job_Applications&action=getOfferAssignedUser",
+          type: "post",
+          dataType: "json",
+          data: { offerId: offerId },
+          success: function (result) {
+            if (result && result.code == "OK" && result.data) {
+              callbackFunction(result.data);
+            }
+          },
+        });
+      }
+
+      function prefillAssignedUserFromOffer() {
+        const offerId = $("#" + offerIdField).val();
+        if (!offerId) {
+          return;
+        }
+        getOfferAssignedUser(offerId, function (data) {
+          if (
+            data &&
+            data.assigned_user_id &&
+            !assignedUserManuallyChanged &&
+            $("#" + offerIdField).val() === offerId
+          ) {
+            $("#" + assignedUserIdField).val(data.assigned_user_id);
+            $("#" + assignedUserNameField).val(data.assigned_user_name);
+          }
+        });
+      }
+
+      // Any change to the assigned user field is considered a manual change
+      YAHOO.util.Event.addListener(assignedUserIdField, "change", function () {
+        assignedUserManuallyChanged = true;
+      });
+
+      YAHOO.util.Event.addListener(offerIdField, "change", prefillAssignedUserFromOffer);
+
+      // If the offer is already set (e.g. new record created from an offer subpanel), prefill on load
+      prefillAssignedUserFromOffer();
+    }
+
     break;
   case "detail":
     break;

--- a/modules/stic_Job_Applications/controller.php
+++ b/modules/stic_Job_Applications/controller.php
@@ -28,7 +28,7 @@ class stic_Job_ApplicationsController extends SugarController
      * STIC#959
      */
     public function action_createMassJobApplications() {
-        global $db, $current_user;
+        global $db;
         $offerId = $_REQUEST['offerId'] ?? '';
         $offerName = $_REQUEST['offerName'] ?? '';
         $contactsIds = array();
@@ -63,6 +63,9 @@ class stic_Job_ApplicationsController extends SugarController
             $contactsIds = explode(',', $_REQUEST['uid']);
         }
         if (is_array($contactsIds) && !empty($contactsIds) && $offerId && $offerName) {
+            // Get the assigned user of the offer to inherit it in the created job applications
+            $offerBean = BeanFactory::getBean('stic_Job_Offers', $offerId);
+            $offerAssignedUserId = !empty($offerBean) && !empty($offerBean->id) ? $offerBean->assigned_user_id : '';
             // Create a job application for each selected contact
             foreach($contactsIds as $contactId) {
                 $jobApplicationBean = BeanFactory::newBean('stic_Job_Applications');
@@ -70,10 +73,32 @@ class stic_Job_ApplicationsController extends SugarController
                 $jobApplicationBean->status = 'expected_presentation';
                 $jobApplicationBean->stic_job_applications_contactscontacts_ida = $contactId;
                 $jobApplicationBean->stic_job_applications_stic_job_offersstic_job_offers_ida = $offerId;
-                $jobApplicationBean->assigned_user_id = $current_user->id;
+                $jobApplicationBean->assigned_user_id = $offerAssignedUserId;
                 $jobApplicationBean->save();
             }
             SugarApplication::redirect('index.php?module=stic_Job_Applications&action=index&query=true&searchFormTab=advanced_search&status_advanced=expected_presentation&range_start_date_advanced='.date('Y-m-d').'&stic_job_applications_stic_job_offers_name_advanced='.$offerName);
         } 
+    }
+
+    /**
+     * Action that returns the assigned user of a job offer.
+     * It is used from the edit view to prefill the assigned user of a new job application
+     * with the assigned user of the related offer.
+     *
+     * @return void
+     */
+    public function action_getOfferAssignedUser() {
+        $offerId = $_POST['offerId'] ?? '';
+        $response['code'] = 'No data';
+        if (!empty($offerId)) {
+            $offerBean = BeanFactory::getBean('stic_Job_Offers', $offerId);
+            if (!empty($offerBean) && !empty($offerBean->id)) {
+                $response['code'] = 'OK';
+                $response['data']['assigned_user_id'] = $offerBean->assigned_user_id ?? '';
+                $response['data']['assigned_user_name'] = $offerBean->assigned_user_name ?? '';
+            }
+        }
+        echo json_encode($response);
+        exit;
     }
 }

--- a/modules/stic_Job_Applications/stic_Job_Applications.php
+++ b/modules/stic_Job_Applications/stic_Job_Applications.php
@@ -81,6 +81,7 @@ class stic_Job_Applications extends Basic
 
         // If it is a new record, the assigned user of the offer is indicated in the job application
         if (!empty($offerBean) &&
+            empty($this->fetched_row['id']) &&
             $this->assigned_user_id != $offerBean->assigned_user_id) {
             $this->assigned_user_id = $offerBean->assigned_user_id;
         }

--- a/modules/stic_Job_Applications/stic_Job_Applications.php
+++ b/modules/stic_Job_Applications/stic_Job_Applications.php
@@ -79,14 +79,6 @@ class stic_Job_Applications extends Basic
             $this->name = $contact_name .' - '.$offer_name;
         }
 
-        // If it is a new record, inherit the assigned user from the related offer, unless the user has manually changed it
-        global $current_user;
-        if (empty($this->fetched_row['id']) && !empty($offerBean) && !empty($offerBean->id)) {
-            if ($this->assigned_user_id === $current_user->id) {
-                $this->assigned_user_id = $offerBean->assigned_user_id;
-            }
-        }
-
         parent::save($check_notify);
 
         if (isset($this->status) && $this->status == 'accepted') {

--- a/modules/stic_Job_Applications/stic_Job_Applications.php
+++ b/modules/stic_Job_Applications/stic_Job_Applications.php
@@ -79,11 +79,12 @@ class stic_Job_Applications extends Basic
             $this->name = $contact_name .' - '.$offer_name;
         }
 
-        // If it is a new record, the assigned user of the offer is indicated in the job application
-        if (!empty($offerBean) &&
-            empty($this->fetched_row['id']) &&
-            $this->assigned_user_id != $offerBean->assigned_user_id) {
-            $this->assigned_user_id = $offerBean->assigned_user_id;
+        // If it is a new record, inherit the assigned user from the related offer, unless the user has manually changed it
+        global $current_user;
+        if (empty($this->fetched_row['id']) && !empty($offerBean) && !empty($offerBean->id)) {
+            if ($this->assigned_user_id === $current_user->id) {
+                $this->assigned_user_id = $offerBean->assigned_user_id;
+            }
         }
 
         parent::save($check_notify);


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/1176

## Description
Tras el https://github.com/SinergiaTIC/SinergiaCRM/pull/916, se ha producido una incidencia con lo siguiente:
El CRM no deja cambiar el usuario asignado a una Candidatura. Como aportación, cito una frase del apartado Crear candidatura del artículo de Voluntariado de la wiki, que habla de un comportamiento que probablemente esté interfiriendo en esto: "Al guardar la candidatura, el CRM almacena el usuario asignado de la oferta de trabajo en la candidatura (...)"

Aunque se introdujo en el PR de Voluntariado, en el de Portal Laboral se hizo que cuando se añadiera la oferta a la candidatura, este recogiera el usuario asignado de la oferta. Este comportamiento debe darse únicamente en registros nuevos y de forma visible: al seleccionar la oferta, el campo «Asignado a» muestra directamente el usuario de la oferta, de modo que lo que el usuario ve es exactamente lo que se guarda. Si el usuario modifica manualmente el usuario asignado, se respeta dicho cambio.

## Motivation and Context
Al ser una candidatura nueva, debe de recoger el usuario asignado de la oferta (siempre y cuando no se haya cambiado el usuario asignado), pero aún así, si se cambia, debería de respetar dicho cambio. Además, el comportamiento debe ser consistente con la interfaz: lo que se muestra en el campo «Asignado a» debe ser lo que se guarda.

Para conseguirlo, se ha trasladado la herencia del usuario asignado de la oferta y se ha eliminado la modificación que se hacía en el método `save()` tras el guardado (que no estaba validada por el usuario):

**modules/stic_Job_Applications/Utils.js**
- En registros nuevos, al seleccionar o cambiar la oferta (o si esta viene precargada, por ejemplo desde el subpanel de la oferta), se rellena de forma visible el campo «Asignado a» con el usuario asignado de la oferta.
- Si el usuario modifica manualmente «Asignado a», se respeta el cambio y no se vuelve a rellenar.

**modules/stic_Job_Applications/controller.php**
- Nueva acción `action_getOfferAssignedUser` que devuelve el usuario asignado de la oferta para el rellenado desde la vista de edición.
- La creación masiva de candidaturas (`action_createMassJobApplications`) ahora hereda explícitamente el usuario asignado de la oferta.

**modules/stic_Job_Applications/stic_Job_Applications.php**
- Eliminada la sobreescritura del usuario asignado en `save()`, ya que impedía cambiar el usuario asignado y producía modificaciones no visibles tras el guardado.


Adicionalmente se corrige la creación masiva de candidaturas desde la vista de lista, donde no se estaba asignando por defecto el usuario de la oferta.


## How To Test This
### Permitir cambiar el usuario asignado
1. Ir a Candidaturas
2. Crear un registro con una oferta relacionada
3. Comprobar que el campo «Asignado a» muestra directamente el usuario de la oferta y que se guarda dicho usuario
4. Cambiar el usuario asignado y comprobar que el cambio se respeta al guardar
5. Modificar el usuario asignado desde la vista de detalle o desde la de edición y comprobar que ya deja cambiarlo.
### Creación masiva
1. Ir a la vista de lista de Personas
2. Seleccionar varias personas
3. En acciones masivas, escoger Generar Candidaturas
4. Comprobar que las candidaturas generadas tienen el usuario de la oferta y no el operante
