### PR TITLE
Hotfix - General - Exportar utilizando un filtro con comillas y seleccionar todos los registros

### DIFF
--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -112,7 +112,12 @@ class MassUpdate
         unset($_REQUEST['current_query_by_page']);
         unset($_REQUEST[session_name()]);
         unset($_REQUEST['PHPSESSID']);
-        $query = json_encode($_REQUEST);
+        // STIC-Custom 20260813 ART - Export with special characters in the filter and select all
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // $query = json_encode($_REQUEST);
+        // Encode special HTML characters as \uXXXX JSON escapes to prevent breaking the single-quoted HTML attribute
+        $query = json_encode($_REQUEST, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP);
+        // END STIC-Custom
 
         if (!isset($_REQUEST['module'])) {
             LoggerManager::getLogger()->warn('Undefined index: module');

--- a/include/MassUpdate.php
+++ b/include/MassUpdate.php
@@ -113,7 +113,7 @@ class MassUpdate
         unset($_REQUEST[session_name()]);
         unset($_REQUEST['PHPSESSID']);
         // STIC-Custom 20260813 ART - Export with special characters in the filter and select all
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1378
         // $query = json_encode($_REQUEST);
         // Encode special HTML characters as \uXXXX JSON escapes to prevent breaking the single-quoted HTML attribute
         $query = json_encode($_REQUEST, JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP);


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/943

## Description
Se detecta un error al exportar datos usando la opción "Seleccionar todo" cuando el filtro contiene valores con comillas u otros caracteres especiales. El problema se da tanto con el filtro rápido como con el filtro avanzado, en cualquier módulo.

## Motivation and Context
El problema afecta a cualquier exportación masiva que utilice "Seleccionar todo" tras aplicar un filtro con comillas o caracteres especiales. El archivo exportado no respeta el filtro aplicado, mostrando más registros de los esperados (o únicamente la cabecera sin datos), lo que supone una pérdida de funcionalidad y un posible problema de confidencialidad si el usuario espera exportar solo los registros filtrados y obtiene todos.

## How To Test This
1. Crear un registro cuyo nombre contenga comillas (ej. `"Prueba"` u `O'Brien`) en cualquier módulo.
2. Usar el filtro rápido o avanzado para buscar ese registro por el nombre exacto (incluyendo las comillas).
3. Verificar que la vista de lista muestra únicamente el registro filtrado.
4. Pulsar "Seleccionar todo" y a continuación el botón "Exportar".
5. Verificar que el archivo CSV exportado contiene exclusivamente el registro filtrado y no registros adicionales.
6. Repetir la prueba con una combinación como `"O'Brien & Sons"`.
7. Verificar también que las acciones masivas estándar (MassUpdate, eliminación masiva) siguen funcionando correctamente con filtros que contengan estos caracteres.
