### PR TITLE
Hotfix - Firmas - Aplicar Grupos de Seguridad y validación de entrada en el subpanel "Firmantes" (#1379)

### DIFF
--- a/modules/stic_Signatures/stic_Signatures.php
+++ b/modules/stic_Signatures/stic_Signatures.php
@@ -132,10 +132,26 @@ class stic_Signatures extends Basic
      */
     public function getSticSignersForSignature()
     {
+        global $current_user;
+
         $signature_id = $_REQUEST['record'];
         if (empty($signature_id)) {
             return '';
         }
+
+        require_once 'modules/SecurityGroups/SecurityGroup.php';
+        require_once 'modules/ACL/ACLController.php';
+
+        $db = DBManagerFactory::getInstance();
+        $quotedSignatureId = $db->quote($signature_id);
+
+        // STIC custom - Only return the signers the current user is authorized to view (owner or security group).
+        // https://github.com/SinergiaTIC/SinergiaCRM/issues/1379
+        $accessWhere = '';
+        if (ACLController::requireSecurityGroup('stic_Signers', 'list')) {
+            $accessWhere = " AND (stic_signers.assigned_user_id = '" . $db->quote($current_user->id) . "' OR " . SecurityGroup::getGroupWhere('stic_signers', 'stic_Signers', $current_user->id) . ")";
+        }
+        // END STIC custom
 
         // Construct the SQL query
         $query = "
@@ -162,9 +178,10 @@ class stic_Signatures extends Basic
                 JOIN stic_signatures_stic_signers_c rel
                     ON rel.stic_signatures_stic_signersstic_signers_idb = stic_signers.id
                 LEFT JOIN contacts c1 ON c1.id = stic_signers.contact_id_c -- to get on_behalf_of_id
-                WHERE rel.stic_signatures_stic_signersstic_signatures_ida = '{$signature_id}'
+                WHERE rel.stic_signatures_stic_signersstic_signatures_ida = '{$quotedSignatureId}'
                     AND stic_signers.deleted = 0
                     AND rel.deleted = 0
+                    {$accessWhere}
                 ) AS stic_signers
         ";
         return $query;

--- a/modules/stic_Signers/Utils.php
+++ b/modules/stic_Signers/Utils.php
@@ -348,12 +348,26 @@ class stic_SignersUtils
      */
     public static function getSticSignersForContacts()
     {
-        global $app_list_strings;
+        global $current_user;
 
         $contact_id = $_REQUEST['record'];
         if (empty($contact_id)) {
             return '';
         }
+
+        require_once 'modules/SecurityGroups/SecurityGroup.php';
+        require_once 'modules/ACL/ACLController.php';
+
+        $db = DBManagerFactory::getInstance();
+        $quotedContactId = $db->quote($contact_id);
+
+        // STIC custom - Only return the signers the current user is authorized to view (owner or security group).
+        // https://github.com/SinergiaTIC/SinergiaCRM/issues/1379
+        $accessWhere = '';
+        if (ACLController::requireSecurityGroup('stic_Signers', 'list')) {
+            $accessWhere = " AND (stic_signers.assigned_user_id = '" . $db->quote($current_user->id) . "' OR " . SecurityGroup::getGroupWhere('stic_signers', 'stic_Signers', $current_user->id) . ")";
+        }
+        // END STIC custom
 
         // Construct the SQL query
         $query = "
@@ -379,9 +393,10 @@ class stic_SignersUtils
                 FROM stic_signers
                 LEFT JOIN contacts c1 ON c1.id = stic_signers.contact_id_c -- to get on_behalf_of_id
                 WHERE parent_type = 'Contacts'
-                    AND (stic_signers.parent_id = '{$contact_id}' OR stic_signers.contact_id_c = '{$contact_id}')
+                    AND (stic_signers.parent_id = '{$quotedContactId}' OR stic_signers.contact_id_c = '{$quotedContactId}')
                     AND stic_signers.status in ('pending','signed')
                     AND stic_signers.deleted = 0
+                    {$accessWhere}
                 ) AS stic_signers
         ";
         return $query;
@@ -395,10 +410,26 @@ class stic_SignersUtils
      */
     public static function getSticSignersForUsers()
     {
+        global $current_user;
+
         $user_id = $_REQUEST['record'];
         if (empty($user_id)) {
             return '';
         }
+
+        require_once 'modules/SecurityGroups/SecurityGroup.php';
+        require_once 'modules/ACL/ACLController.php';
+
+        $db = DBManagerFactory::getInstance();
+        $quotedUserId = $db->quote($user_id);
+
+        // STIC custom - Only return the signers the current user is authorized to view (owner or security group).
+        // https://github.com/SinergiaTIC/SinergiaCRM/issues/1379
+        $accessWhere = '';
+        if (ACLController::requireSecurityGroup('stic_Signers', 'list')) {
+            $accessWhere = " AND (stic_signers.assigned_user_id = '" . $db->quote($current_user->id) . "' OR " . SecurityGroup::getGroupWhere('stic_signers', 'stic_Signers', $current_user->id) . ")";
+        }
+        // END STIC custom
 
         // Construct the SQL query
         $query = "
@@ -422,9 +453,10 @@ class stic_SignersUtils
                     stic_signers.record_id
                 FROM stic_signers
                 WHERE parent_type = 'Users'
-                    AND parent_id = '{$user_id}'
+                    AND parent_id = '{$quotedUserId}'
                     AND status in ('pending','signed')
                     AND deleted = 0
+                    {$accessWhere}
                 ) AS stic_signers
         ";
 


### PR DESCRIPTION
### Descripción
El subpanel "Firmantes" de la ficha de un registro de `stic_Signatures` mostraba todos los registros de `stic_Signers` asociados a la firma, sin tener en cuenta los Grupos de Seguridad, los roles ni el usuario propietario. Un usuario sin permisos podía ver datos (nombre, email, teléfono, estado, fecha de firma) de firmantes de otros grupos.

Se ha detectado el mismo problema en los subpaneles de firmantes de `Contacts` y `Users`, también basados en funciones que devuelven SQL en crudo.

**Causa raíz:**
Los subpaneles usan una fuente de datos por función (`get_subpanel_data => 'function:...'`). `SugarBean::get_union_related_list()` (`data/SugarBean.php:861-890`) ejecuta la consulta SQL devuelta tal cual, **sin pasar por** `buildAccessWhere()` (`data/SugarBean.php:3654-3696`), donde se inyecta normalmente el filtro de Grupos de Seguridad. Las consultas solo filtraban por el registro padre y `deleted = 0`.

### Cambios realizados

**`modules/stic_Signatures/stic_Signatures.php`** - `getSticSignersForSignature()`:
- Se añadió filtrado por Security Groups mediante `ACLController::requireSecurityGroup()` y `SecurityGroup::getGroupWhere()`, más verificación del usuario propietario (`assigned_user_id`), de forma análoga al patrón existente en `SignaturePopup.php`.
- El subpanel "Firmantes" ahora solo muestra los registros de firmantes a los que el usuario tiene acceso (propietario o grupo de seguridad).
- Se sanea el `$signature_id` (`$_REQUEST['record']`) con `$db->quote()` para evitar inyección SQL.

**`modules/stic_Signers/Utils.php`** - `getSticSignersForContacts()` y `getSticSignersForUsers()`:
- Mismo fix aplicado a los subpaneles de firmantes de Contactos y Usuarios: filtrado por Security Groups + propietario y saneamiento de `$_REQUEST['record']` con `$db->quote()`.

### Issues relacionados
Closes #1379

### Pruebas a realizar

**1. Acceso correcto (debería funcionar):**
- Crear una firma con firmantes asignados al GS del usuario.
- Iniciar sesión como ese usuario y abrir la ficha de la firma.
- Verificar que el subpanel "Firmantes" muestra los firmantes.

**2. Acceso denegado en subpanel (debería filtrar):**
- Crear una segunda firma (o añadir firmantes vinculados a un GS distinto) a la que el usuario NO pertenezca.
- Repetir el paso anterior.
- Verificar que el subpanel NO muestra los firmantes que pertenecen solo a otro GS.

**3. Permisos por asignación (owner):**
- Crear una firma con firmantes sin GS asignados al usuario.
- Verificar que el usuario puede verlos en el subpanel.

**4. Administrador ve todos los registros:**
- Iniciar sesión como administrador.
- Verificar que el subpanel muestra todos los firmantes sin filtro de GS.

**5. Subpaneles de Contactos y Usuarios:**
- Repetir las pruebas 1-4 desde la ficha de un Contacto y de un Usuario, verificando que los subpaneles de firmantes (`stic_signers_contacts`, `stic_signers_users`) aplican el mismo filtro de GS y propietario.

### Cómo se ha probado
- [x] Syntax check: `php -l` pass
- [x] Cache limpiada