### PR TITLE
Hotfix - Plantillas PDF - Cabeceras repetidas con Facturas

### DIFF
--- a/custom/modules/AOS_PDF_Templates/SticGeneratePdfFunctions.php
+++ b/custom/modules/AOS_PDF_Templates/SticGeneratePdfFunctions.php
@@ -38,7 +38,7 @@
 function populate_group_lines($text, $lineItemsGroups, $lineItems, $element = 'table')
 {
     // STIC-Custom 20260813 ART - Repeated Headers in PDF Templates with Invoices
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/1381
     // $firstValue = '';
     // $firstNum = 0;
 

--- a/custom/modules/AOS_PDF_Templates/SticGeneratePdfFunctions.php
+++ b/custom/modules/AOS_PDF_Templates/SticGeneratePdfFunctions.php
@@ -37,87 +37,229 @@
  */
 function populate_group_lines($text, $lineItemsGroups, $lineItems, $element = 'table')
 {
-    $firstValue = '';
-    $firstNum = 0;
+    // STIC-Custom 20260813 ART - Repeated Headers in PDF Templates with Invoices
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // $firstValue = '';
+    // $firstNum = 0;
 
-    $lastValue = '';
-    $lastNum = 0;
+    // $lastValue = '';
+    // $lastNum = 0;
 
+    // $startElement = '<' . $element;
+    // $endElement = '</' . $element . '>';
+
+    // $groups = BeanFactory::newBean('AOS_Line_Item_Groups');
+    // foreach ($groups->field_defs as $name => $arr) {
+    //     if (!((isset($arr['dbType']) && strtolower($arr['dbType']) == 'id') || $arr['type'] == 'id' || $arr['type'] == 'link')) {
+    //         $curNum = strpos($text, '$aos_line_item_groups_' . $name);
+    //         if ($curNum) {
+    //             if ($curNum < $firstNum || $firstNum == 0) {
+    //                 $firstValue = '$aos_line_item_groups_' . $name;
+    //                 $firstNum = $curNum;
+    //             }
+    //             if ($curNum > $lastNum) {
+    //                 $lastValue = '$aos_line_item_groups_' . $name;
+    //                 $lastNum = $curNum;
+    //             }
+    //         }
+    //     }
+    // }
+    // if ($firstValue !== '' && $lastValue !== '') {
+    //     // Converting Text
+    //     $parts = explode($firstValue, $text);
+    //     $text = $parts[0];
+    //     $parts = explode($lastValue, $parts[1]);
+    //     if ($lastValue == $firstValue) {
+    //         $groupPart = $firstValue . $parts[0];
+    //     } else {
+    //         $groupPart = $firstValue . $parts[0] . $lastValue;
+    //     }
+
+    //     if (count($lineItemsGroups) != 0) {
+    //         // Read line start <tr> value
+    //         $tcount = strrpos($text, $startElement);
+    //         $lsValue = substr($text, $tcount);
+    //         $tcount = strpos($lsValue, ">") + 1;
+    //         $lsValue = substr($lsValue, 0, $tcount);
+
+    //         // Read line end values
+    //         $tcount = strpos($parts[1], $endElement) + strlen($endElement);
+    //         $leValue = substr($parts[1], 0, $tcount);
+
+    //         // Converting Line Items
+    //         $obb = array();
+
+    //         $tdTemp = explode($lsValue, $text);
+
+    //         $groupPart = $lsValue . $tdTemp[count($tdTemp) - 1] . $groupPart . $leValue;
+
+    //         $text = $tdTemp[0];
+
+    //         foreach ($lineItemsGroups as $group_id => $lineItemsArray) {
+    //             $groupPartTemp = populate_product_lines($groupPart, $lineItemsArray);
+    //             $groupPartTemp = populate_service_lines($groupPartTemp, $lineItemsArray);
+
+    //             $obb['AOS_Line_Item_Groups'] = $group_id;
+    //             $text .= templateParser::parse_template($groupPartTemp, $obb);
+    //             $text .= '<br />';
+    //         }
+    //         $tcount = strpos($parts[1], $endElement) + strlen($endElement);
+    //         $parts[1] = substr($parts[1], $tcount);
+    //     } else {
+    //         $tcount = strrpos($text, $startElement);
+    //         $text = substr($text, 0, $tcount);
+
+    //         $tcount = strpos($parts[1], $endElement) + strlen($endElement);
+    //         $parts[1] = substr($parts[1], $tcount);
+    //     }
+
+    //     $text .= $parts[1];
+    // } else {
+    //     $text = populate_product_lines($text, $lineItems);
+    //     $text = populate_service_lines($text, $lineItems);
+    // }
+
+    // return $text;
     $startElement = '<' . $element;
     $endElement = '</' . $element . '>';
 
     $groups = BeanFactory::newBean('AOS_Line_Item_Groups');
+    $groupVarNames = array();
     foreach ($groups->field_defs as $name => $arr) {
         if (!((isset($arr['dbType']) && strtolower($arr['dbType']) == 'id') || $arr['type'] == 'id' || $arr['type'] == 'link')) {
-            $curNum = strpos($text, '$aos_line_item_groups_' . $name);
-            if ($curNum) {
-                if ($curNum < $firstNum || $firstNum == 0) {
-                    $firstValue = '$aos_line_item_groups_' . $name;
-                    $firstNum = $curNum;
-                }
-                if ($curNum > $lastNum) {
-                    $lastValue = '$aos_line_item_groups_' . $name;
-                    $lastNum = $curNum;
-                }
-            }
+            $groupVarNames[] = '$aos_line_item_groups_' . $name;
         }
     }
-    if ($firstValue !== '' && $lastValue !== '') {
-        // Converting Text
-        $parts = explode($firstValue, $text);
-        $text = $parts[0];
-        $parts = explode($lastValue, $parts[1]);
-        if ($lastValue == $firstValue) {
-            $groupPart = $firstValue . $parts[0];
-        } else {
-            $groupPart = $firstValue . $parts[0] . $lastValue;
+
+    if (empty($groupVarNames)) {
+        $text = populate_product_lines($text, $lineItems);
+        $text = populate_service_lines($text, $lineItems);
+        return $text;
+    }
+
+    // Check if any group variable exists in the text
+    $hasGroupVars = false;
+    foreach ($groupVarNames as $var) {
+        if (strpos($text, $var) !== false) {
+            $hasGroupVars = true;
+            break;
+        }
+    }
+
+    if (!$hasGroupVars) {
+        $text = populate_product_lines($text, $lineItems);
+        $text = populate_service_lines($text, $lineItems);
+        return $text;
+    }
+
+    // Find all table blocks and process each one that contains group variables
+    $aosVarPattern = '/\$aos_[a-z_]+/i';
+    $processedText = '';
+    $remainingText = $text;
+
+    while (($tableStartPos = strpos($remainingText, $startElement)) !== false) {
+        // Find the end of this table
+        $tableEndPos = strpos($remainingText, $endElement, $tableStartPos);
+        if ($tableEndPos === false) {
+            break;
+        }
+        $tableEndPos += strlen($endElement);
+
+        // Extract text before this table
+        $beforeTable = substr($remainingText, 0, $tableStartPos);
+        $tableBlock = substr($remainingText, $tableStartPos, $tableEndPos - $tableStartPos);
+
+        // Check if this table contains group variables
+        $tableHasGroupVars = false;
+        foreach ($groupVarNames as $var) {
+            if (strpos($tableBlock, $var) !== false) {
+                $tableHasGroupVars = true;
+                break;
+            }
         }
 
-        if (count($lineItemsGroups) != 0) {
-            // Read line start <tr> value
-            $tcount = strrpos($text, $startElement);
-            $lsValue = substr($text, $tcount);
-            $tcount = strpos($lsValue, ">") + 1;
-            $lsValue = substr($lsValue, 0, $tcount);
+        if ($tableHasGroupVars && (is_countable($lineItemsGroups) ? count($lineItemsGroups) : 0) != 0) {
+            // Extract all <tr>...</tr> blocks from this table
+            $trStartTag = '<tr';
+            $trEndTag = '</tr>';
+            $rows = array();
+            $searchPos = 0;
 
-            // Read line end values
-            $tcount = strpos($parts[1], $endElement) + strlen($endElement);
-            $leValue = substr($parts[1], 0, $tcount);
+            while (($rowStart = strpos($tableBlock, $trStartTag, $searchPos)) !== false) {
+                $rowEnd = strpos($tableBlock, $trEndTag, $rowStart);
+                if ($rowEnd === false) {
+                    break;
+                }
+                $rowEnd += strlen($trEndTag);
+                $rows[] = substr($tableBlock, $rowStart, $rowEnd - $rowStart);
+                $searchPos = $rowEnd;
+            }
 
-            // Converting Line Items
+            // Separate header rows (no $aos_* variables) from content rows
+            $headerRows = array();
+            $contentRows = array();
+
+            foreach ($rows as $row) {
+                if (!preg_match($aosVarPattern, $row)) {
+                    $headerRows[] = $row;
+                } else {
+                    $contentRows[] = $row;
+                }
+            }
+
+            // Extract the opening <table...> tag once
+            $tableOpenTag = '';
+            if (preg_match('/(<table[^>]*>)/i', $tableBlock, $matches)) {
+                $tableOpenTag = $matches[1];
+            }
+
+            // Build the table header (rendered once, no $aos_* variables)
+            $tableHeaderHtml = '';
+            if (!empty($headerRows) && $tableOpenTag !== '') {
+                $tableHeaderHtml = $tableOpenTag . '<tbody>' . implode('', $headerRows) . '</tbody></table>';
+            }
+
+            // Build the table for group iteration (content rows with $aos_* variables only)
+            $tableForIteration = '';
+            if (!empty($contentRows)) {
+                if ($tableOpenTag !== '') {
+                    $tableForIteration = $tableOpenTag . '<tbody>' . implode('', $contentRows) . '</tbody></table>';
+                } else {
+                    $tableForIteration = implode('', $contentRows);
+                }
+            }
+
+            // Append text before table
+            $processedText .= $beforeTable;
+
+            // Render table header once
+            if (!empty($tableHeaderHtml)) {
+                $processedText .= templateParser::parse_template($tableHeaderHtml, array());
+            }
+
+            // Iterate through groups
             $obb = array();
-
-            $tdTemp = explode($lsValue, $text);
-
-            $groupPart = $lsValue . $tdTemp[count($tdTemp) - 1] . $groupPart . $leValue;
-
-            $text = $tdTemp[0];
-
             foreach ($lineItemsGroups as $group_id => $lineItemsArray) {
-                $groupPartTemp = populate_product_lines($groupPart, $lineItemsArray);
+                $groupPartTemp = populate_product_lines($tableForIteration, $lineItemsArray);
                 $groupPartTemp = populate_service_lines($groupPartTemp, $lineItemsArray);
 
                 $obb['AOS_Line_Item_Groups'] = $group_id;
-                $text .= templateParser::parse_template($groupPartTemp, $obb);
-                $text .= '<br />';
+                $processedText .= templateParser::parse_template($groupPartTemp, $obb);
+                $processedText .= '<br />';
             }
-            $tcount = strpos($parts[1], $endElement) + strlen($endElement);
-            $parts[1] = substr($parts[1], $tcount);
         } else {
-            $tcount = strrpos($text, $startElement);
-            $text = substr($text, 0, $tcount);
-
-            $tcount = strpos($parts[1], $endElement) + strlen($endElement);
-            $parts[1] = substr($parts[1], $tcount);
+            // Table without group variables - keep as is
+            $processedText .= $beforeTable . $tableBlock;
         }
 
-        $text .= $parts[1];
-    } else {
-        $text = populate_product_lines($text, $lineItems);
-        $text = populate_service_lines($text, $lineItems);
+        $remainingText = substr($remainingText, $tableEndPos);
     }
 
-    return $text;
+    // Append any remaining text after the last table
+    $processedText .= $remainingText;
+
+    return $processedText;
+    // END STIC-Custom
 }
 
 /**

--- a/modules/AOS_PDF_Templates/formLetterPdf.php
+++ b/modules/AOS_PDF_Templates/formLetterPdf.php
@@ -265,7 +265,7 @@ $pdf->outputPDF($file_name, 'D');
 function populate_group_lines($text, $lineItemsGroups, $lineItems, $element = 'table')
 {
     // STIC-Custom 20260813 ART - Repeated Headers in PDF Templates with Invoices
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/1381
     // $firstValue = '';
     // $firstNum = 0;
 

--- a/modules/AOS_PDF_Templates/formLetterPdf.php
+++ b/modules/AOS_PDF_Templates/formLetterPdf.php
@@ -264,90 +264,232 @@ $pdf->outputPDF($file_name, 'D');
 // https://github.com/SinergiaTIC/SinergiaCRM/pull/76
 function populate_group_lines($text, $lineItemsGroups, $lineItems, $element = 'table')
 {
-    $firstValue = '';
-    $firstNum = 0;
+    // STIC-Custom 20260813 ART - Repeated Headers in PDF Templates with Invoices
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // $firstValue = '';
+    // $firstNum = 0;
 
-    $lastValue = '';
-    $lastNum = 0;
+    // $lastValue = '';
+    // $lastNum = 0;
 
+    // $startElement = '<' . $element;
+    // $endElement = '</' . $element . '>';
+
+
+    // $groups = BeanFactory::newBean('AOS_Line_Item_Groups');
+    // foreach ($groups->field_defs as $name => $arr) {
+    //     if (!((isset($arr['dbType']) && strtolower($arr['dbType']) == 'id') || $arr['type'] == 'id' || $arr['type'] == 'link')) {
+    //         $curNum = strpos($text, '$aos_line_item_groups_' . $name);
+    //         if ($curNum) {
+    //             if ($curNum < $firstNum || $firstNum == 0) {
+    //                 $firstValue = '$aos_line_item_groups_' . $name;
+    //                 $firstNum = $curNum;
+    //             }
+    //             if ($curNum > $lastNum) {
+    //                 $lastValue = '$aos_line_item_groups_' . $name;
+    //                 $lastNum = $curNum;
+    //             }
+    //         }
+    //     }
+    // }
+    // if ($firstValue !== '' && $lastValue !== '') {
+    //     //Converting Text
+    //     $parts = explode($firstValue, $text);
+    //     $text = $parts[0];
+    //     $parts = explode($lastValue, $parts[1]);
+    //     if ($lastValue == $firstValue) {
+    //         $groupPart = $firstValue . $parts[0];
+    //     } else {
+    //         $groupPart = $firstValue . $parts[0] . $lastValue;
+    //     }
+
+    //     if (count($lineItemsGroups) != 0) {
+    //         //Read line start <tr> value
+    //         $tcount = strrpos($text, $startElement);
+    //         $lsValue = substr($text, $tcount);
+    //         $tcount = strpos($lsValue, ">") + 1;
+    //         $lsValue = substr($lsValue, 0, $tcount);
+
+
+    //         //Read line end values
+    //         $tcount = strpos($parts[1], $endElement) + strlen($endElement);
+    //         $leValue = substr($parts[1], 0, $tcount);
+
+    //         //Converting Line Items
+    //         $obb = array();
+
+    //         $tdTemp = explode($lsValue, $text);
+
+    //         $groupPart = $lsValue . $tdTemp[count($tdTemp) - 1] . $groupPart . $leValue;
+
+    //         $text = $tdTemp[0];
+
+    //         foreach ($lineItemsGroups as $group_id => $lineItemsArray) {
+    //             $groupPartTemp = populate_product_lines($groupPart, $lineItemsArray);
+    //             $groupPartTemp = populate_service_lines($groupPartTemp, $lineItemsArray);
+
+    //             $obb['AOS_Line_Item_Groups'] = $group_id;
+    //             $text .= templateParser::parse_template($groupPartTemp, $obb);
+    //             $text .= '<br />';
+    //         }
+    //         $tcount = strpos($parts[1], $endElement) + strlen($endElement);
+    //         $parts[1] = substr($parts[1], $tcount);
+    //     } else {
+    //         $tcount = strrpos($text, $startElement);
+    //         $text = substr($text, 0, $tcount);
+
+    //         $tcount = strpos($parts[1], $endElement) + strlen($endElement);
+    //         $parts[1] = substr($parts[1], $tcount);
+    //     }
+
+    //     $text .= $parts[1];
+    // } else {
+    //     $text = populate_product_lines($text, $lineItems);
+    //     $text = populate_service_lines($text, $lineItems);
+    // }
+
+
+    // return $text;
     $startElement = '<' . $element;
     $endElement = '</' . $element . '>';
 
-
     $groups = BeanFactory::newBean('AOS_Line_Item_Groups');
+    $groupVarNames = array();
     foreach ($groups->field_defs as $name => $arr) {
         if (!((isset($arr['dbType']) && strtolower($arr['dbType']) == 'id') || $arr['type'] == 'id' || $arr['type'] == 'link')) {
-            $curNum = strpos($text, '$aos_line_item_groups_' . $name);
-            if ($curNum) {
-                if ($curNum < $firstNum || $firstNum == 0) {
-                    $firstValue = '$aos_line_item_groups_' . $name;
-                    $firstNum = $curNum;
-                }
-                if ($curNum > $lastNum) {
-                    $lastValue = '$aos_line_item_groups_' . $name;
-                    $lastNum = $curNum;
-                }
-            }
+            $groupVarNames[] = '$aos_line_item_groups_' . $name;
         }
     }
-    if ($firstValue !== '' && $lastValue !== '') {
-        //Converting Text
-        $parts = explode($firstValue, $text);
-        $text = $parts[0];
-        $parts = explode($lastValue, $parts[1]);
-        if ($lastValue == $firstValue) {
-            $groupPart = $firstValue . $parts[0];
-        } else {
-            $groupPart = $firstValue . $parts[0] . $lastValue;
+
+    if (empty($groupVarNames)) {
+        $text = populate_product_lines($text, $lineItems);
+        $text = populate_service_lines($text, $lineItems);
+        return $text;
+    }
+
+    // Check if any group variable exists in the text
+    $hasGroupVars = false;
+    foreach ($groupVarNames as $var) {
+        if (strpos($text, $var) !== false) {
+            $hasGroupVars = true;
+            break;
+        }
+    }
+
+    if (!$hasGroupVars) {
+        $text = populate_product_lines($text, $lineItems);
+        $text = populate_service_lines($text, $lineItems);
+        return $text;
+    }
+
+    // Find all table blocks and process each one that contains group variables
+    $aosVarPattern = '/\$aos_[a-z_]+/i';
+    $processedText = '';
+    $remainingText = $text;
+
+    while (($tableStartPos = strpos($remainingText, $startElement)) !== false) {
+        // Find the end of this table
+        $tableEndPos = strpos($remainingText, $endElement, $tableStartPos);
+        if ($tableEndPos === false) {
+            break;
+        }
+        $tableEndPos += strlen($endElement);
+
+        // Extract text before this table
+        $beforeTable = substr($remainingText, 0, $tableStartPos);
+        $tableBlock = substr($remainingText, $tableStartPos, $tableEndPos - $tableStartPos);
+
+        // Check if this table contains group variables
+        $tableHasGroupVars = false;
+        foreach ($groupVarNames as $var) {
+            if (strpos($tableBlock, $var) !== false) {
+                $tableHasGroupVars = true;
+                break;
+            }
         }
 
-        if (count($lineItemsGroups) != 0) {
-            //Read line start <tr> value
-            $tcount = strrpos($text, $startElement);
-            $lsValue = substr($text, $tcount);
-            $tcount = strpos($lsValue, ">") + 1;
-            $lsValue = substr($lsValue, 0, $tcount);
+        if ($tableHasGroupVars && (is_countable($lineItemsGroups) ? count($lineItemsGroups) : 0) != 0) {
+            // Extract all <tr>...</tr> blocks from this table
+            $trStartTag = '<tr';
+            $trEndTag = '</tr>';
+            $rows = array();
+            $searchPos = 0;
 
+            while (($rowStart = strpos($tableBlock, $trStartTag, $searchPos)) !== false) {
+                $rowEnd = strpos($tableBlock, $trEndTag, $rowStart);
+                if ($rowEnd === false) {
+                    break;
+                }
+                $rowEnd += strlen($trEndTag);
+                $rows[] = substr($tableBlock, $rowStart, $rowEnd - $rowStart);
+                $searchPos = $rowEnd;
+            }
 
-            //Read line end values
-            $tcount = strpos($parts[1], $endElement) + strlen($endElement);
-            $leValue = substr($parts[1], 0, $tcount);
+            // Separate header rows (no $aos_* variables) from content rows
+            $headerRows = array();
+            $contentRows = array();
 
-            //Converting Line Items
+            foreach ($rows as $row) {
+                if (!preg_match($aosVarPattern, $row)) {
+                    $headerRows[] = $row;
+                } else {
+                    $contentRows[] = $row;
+                }
+            }
+
+            // Extract the opening <table...> tag once
+            $tableOpenTag = '';
+            if (preg_match('/(<table[^>]*>)/i', $tableBlock, $matches)) {
+                $tableOpenTag = $matches[1];
+            }
+
+            // Build the table header (rendered once, no $aos_* variables)
+            $tableHeaderHtml = '';
+            if (!empty($headerRows) && $tableOpenTag !== '') {
+                $tableHeaderHtml = $tableOpenTag . '<tbody>' . implode('', $headerRows) . '</tbody></table>';
+            }
+
+            // Build the table for group iteration (content rows with $aos_* variables only)
+            $tableForIteration = '';
+            if (!empty($contentRows)) {
+                if ($tableOpenTag !== '') {
+                    $tableForIteration = $tableOpenTag . '<tbody>' . implode('', $contentRows) . '</tbody></table>';
+                } else {
+                    $tableForIteration = implode('', $contentRows);
+                }
+            }
+
+            // Append text before table
+            $processedText .= $beforeTable;
+
+            // Render table header once
+            if (!empty($tableHeaderHtml)) {
+                $processedText .= templateParser::parse_template($tableHeaderHtml, array());
+            }
+
+            // Iterate through groups
             $obb = array();
-
-            $tdTemp = explode($lsValue, $text);
-
-            $groupPart = $lsValue . $tdTemp[count($tdTemp) - 1] . $groupPart . $leValue;
-
-            $text = $tdTemp[0];
-
             foreach ($lineItemsGroups as $group_id => $lineItemsArray) {
-                $groupPartTemp = populate_product_lines($groupPart, $lineItemsArray);
+                $groupPartTemp = populate_product_lines($tableForIteration, $lineItemsArray);
                 $groupPartTemp = populate_service_lines($groupPartTemp, $lineItemsArray);
 
                 $obb['AOS_Line_Item_Groups'] = $group_id;
-                $text .= templateParser::parse_template($groupPartTemp, $obb);
-                $text .= '<br />';
+                $processedText .= templateParser::parse_template($groupPartTemp, $obb);
+                $processedText .= '<br />';
             }
-            $tcount = strpos($parts[1], $endElement) + strlen($endElement);
-            $parts[1] = substr($parts[1], $tcount);
         } else {
-            $tcount = strrpos($text, $startElement);
-            $text = substr($text, 0, $tcount);
-
-            $tcount = strpos($parts[1], $endElement) + strlen($endElement);
-            $parts[1] = substr($parts[1], $tcount);
+            // Table without group variables - keep as is
+            $processedText .= $beforeTable . $tableBlock;
         }
 
-        $text .= $parts[1];
-    } else {
-        $text = populate_product_lines($text, $lineItems);
-        $text = populate_service_lines($text, $lineItems);
+        $remainingText = substr($remainingText, $tableEndPos);
     }
 
+    // Append any remaining text after the last table
+    $processedText .= $remainingText;
 
-    return $text;
+    return $processedText;
+    // END STIC-Custom
 }
 
 function populate_product_lines($text, $lineItems, $element = 'tr')

--- a/modules/AOS_PDF_Templates/generatePdf.php
+++ b/modules/AOS_PDF_Templates/generatePdf.php
@@ -180,90 +180,232 @@ if ($task === 'pdf' || $task === 'emailpdf') {
 
 function populate_group_lines($text, $lineItemsGroups, $lineItems, $element = 'table')
 {
-    $firstValue = '';
-    $firstNum = 0;
+    // STIC-Custom 20260813 ART - Repeated Headers in PDF Templates with Invoices
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // $firstValue = '';
+    // $firstNum = 0;
 
-    $lastValue = '';
-    $lastNum = 0;
+    // $lastValue = '';
+    // $lastNum = 0;
 
+    // $startElement = '<' . $element;
+    // $endElement = '</' . $element . '>';
+
+
+    // $groups = BeanFactory::newBean('AOS_Line_Item_Groups');
+    // foreach ($groups->field_defs as $name => $arr) {
+    //     if (!((isset($arr['dbType']) && strtolower($arr['dbType']) == 'id') || $arr['type'] == 'id' || $arr['type'] == 'link')) {
+    //         $curNum = strpos((string) $text, '$aos_line_item_groups_' . $name);
+    //         if ($curNum) {
+    //             if ($curNum < $firstNum || $firstNum == 0) {
+    //                 $firstValue = '$aos_line_item_groups_' . $name;
+    //                 $firstNum = $curNum;
+    //             }
+    //             if ($curNum > $lastNum) {
+    //                 $lastValue = '$aos_line_item_groups_' . $name;
+    //                 $lastNum = $curNum;
+    //             }
+    //         }
+    //     }
+    // }
+    // if ($firstValue !== '' && $lastValue !== '') {
+    //     //Converting Text
+    //     $parts = explode($firstValue, $text);
+    //     $text = $parts[0];
+    //     $parts = explode($lastValue, $parts[1]);
+    //     if ($lastValue === $firstValue) {
+    //         $groupPart = $firstValue . $parts[0];
+    //     } else {
+    //         $groupPart = $firstValue . $parts[0] . $lastValue;
+    //     }
+
+    //     if ((is_countable($lineItemsGroups) ? count($lineItemsGroups) : 0) != 0) {
+    //         //Read line start <tr> value
+    //         $tcount = strrpos($text, $startElement);
+    //         $lsValue = substr($text, $tcount);
+    //         $tcount = strpos($lsValue, ">") + 1;
+    //         $lsValue = substr($lsValue, 0, $tcount);
+
+
+    //         //Read line end values
+    //         $tcount = strpos($parts[1], $endElement) + strlen($endElement);
+    //         $leValue = substr($parts[1], 0, $tcount);
+
+    //         //Converting Line Items
+    //         $obb = array();
+
+    //         $tdTemp = explode($lsValue, $text);
+
+    //         $groupPart = $lsValue . $tdTemp[(is_countable($tdTemp) ? count($tdTemp) : 0) - 1] . $groupPart . $leValue;
+
+    //         $text = $tdTemp[0];
+
+    //         foreach ($lineItemsGroups as $group_id => $lineItemsArray) {
+    //             $groupPartTemp = populate_product_lines($groupPart, $lineItemsArray);
+    //             $groupPartTemp = populate_service_lines($groupPartTemp, $lineItemsArray);
+
+    //             $obb['AOS_Line_Item_Groups'] = $group_id;
+    //             $text .= templateParser::parse_template($groupPartTemp, $obb);
+    //             $text .= '<br />';
+    //         }
+    //         $tcount = strpos($parts[1], $endElement) + strlen($endElement);
+    //         $parts[1] = substr($parts[1], $tcount);
+    //     } else {
+    //         $tcount = strrpos($text, $startElement);
+    //         $text = substr($text, 0, $tcount);
+
+    //         $tcount = strpos($parts[1], $endElement) + strlen($endElement);
+    //         $parts[1] = substr($parts[1], $tcount);
+    //     }
+
+    //     $text .= $parts[1];
+    // } else {
+    //     $text = populate_product_lines($text, $lineItems);
+    //     $text = populate_service_lines($text, $lineItems);
+    // }
+
+
+    // return $text;
     $startElement = '<' . $element;
     $endElement = '</' . $element . '>';
 
-
     $groups = BeanFactory::newBean('AOS_Line_Item_Groups');
+    $groupVarNames = array();
     foreach ($groups->field_defs as $name => $arr) {
         if (!((isset($arr['dbType']) && strtolower($arr['dbType']) == 'id') || $arr['type'] == 'id' || $arr['type'] == 'link')) {
-            $curNum = strpos((string) $text, '$aos_line_item_groups_' . $name);
-            if ($curNum) {
-                if ($curNum < $firstNum || $firstNum == 0) {
-                    $firstValue = '$aos_line_item_groups_' . $name;
-                    $firstNum = $curNum;
-                }
-                if ($curNum > $lastNum) {
-                    $lastValue = '$aos_line_item_groups_' . $name;
-                    $lastNum = $curNum;
-                }
-            }
+            $groupVarNames[] = '$aos_line_item_groups_' . $name;
         }
     }
-    if ($firstValue !== '' && $lastValue !== '') {
-        //Converting Text
-        $parts = explode($firstValue, $text);
-        $text = $parts[0];
-        $parts = explode($lastValue, $parts[1]);
-        if ($lastValue === $firstValue) {
-            $groupPart = $firstValue . $parts[0];
-        } else {
-            $groupPart = $firstValue . $parts[0] . $lastValue;
+
+    if (empty($groupVarNames)) {
+        $text = populate_product_lines($text, $lineItems);
+        $text = populate_service_lines($text, $lineItems);
+        return $text;
+    }
+
+    // Check if any group variable exists in the text
+    $hasGroupVars = false;
+    foreach ($groupVarNames as $var) {
+        if (strpos((string) $text, $var) !== false) {
+            $hasGroupVars = true;
+            break;
+        }
+    }
+
+    if (!$hasGroupVars) {
+        $text = populate_product_lines($text, $lineItems);
+        $text = populate_service_lines($text, $lineItems);
+        return $text;
+    }
+
+    // Find all table blocks and process each one that contains group variables
+    $aosVarPattern = '/\$aos_[a-z_]+/i';
+    $processedText = '';
+    $remainingText = $text;
+
+    while (($tableStartPos = strpos($remainingText, $startElement)) !== false) {
+        // Find the end of this table
+        $tableEndPos = strpos($remainingText, $endElement, $tableStartPos);
+        if ($tableEndPos === false) {
+            break;
+        }
+        $tableEndPos += strlen($endElement);
+
+        // Extract text before this table
+        $beforeTable = substr($remainingText, 0, $tableStartPos);
+        $tableBlock = substr($remainingText, $tableStartPos, $tableEndPos - $tableStartPos);
+
+        // Check if this table contains group variables
+        $tableHasGroupVars = false;
+        foreach ($groupVarNames as $var) {
+            if (strpos($tableBlock, $var) !== false) {
+                $tableHasGroupVars = true;
+                break;
+            }
         }
 
-        if ((is_countable($lineItemsGroups) ? count($lineItemsGroups) : 0) != 0) {
-            //Read line start <tr> value
-            $tcount = strrpos($text, $startElement);
-            $lsValue = substr($text, $tcount);
-            $tcount = strpos($lsValue, ">") + 1;
-            $lsValue = substr($lsValue, 0, $tcount);
+        if ($tableHasGroupVars && (is_countable($lineItemsGroups) ? count($lineItemsGroups) : 0) != 0) {
+            // Extract all <tr>...</tr> blocks from this table
+            $trStartTag = '<tr';
+            $trEndTag = '</tr>';
+            $rows = array();
+            $searchPos = 0;
 
+            while (($rowStart = strpos($tableBlock, $trStartTag, $searchPos)) !== false) {
+                $rowEnd = strpos($tableBlock, $trEndTag, $rowStart);
+                if ($rowEnd === false) {
+                    break;
+                }
+                $rowEnd += strlen($trEndTag);
+                $rows[] = substr($tableBlock, $rowStart, $rowEnd - $rowStart);
+                $searchPos = $rowEnd;
+            }
 
-            //Read line end values
-            $tcount = strpos($parts[1], $endElement) + strlen($endElement);
-            $leValue = substr($parts[1], 0, $tcount);
+            // Separate header rows (no $aos_* variables) from content rows
+            $headerRows = array();
+            $contentRows = array();
 
-            //Converting Line Items
+            foreach ($rows as $row) {
+                if (!preg_match($aosVarPattern, $row)) {
+                    $headerRows[] = $row;
+                } else {
+                    $contentRows[] = $row;
+                }
+            }
+
+            // Extract the opening <table...> tag once
+            $tableOpenTag = '';
+            if (preg_match('/(<table[^>]*>)/i', $tableBlock, $matches)) {
+                $tableOpenTag = $matches[1];
+            }
+
+            // Build the table header (rendered once, no $aos_* variables)
+            $tableHeaderHtml = '';
+            if (!empty($headerRows) && $tableOpenTag !== '') {
+                $tableHeaderHtml = $tableOpenTag . '<tbody>' . implode('', $headerRows) . '</tbody></table>';
+            }
+
+            // Build the table for group iteration (content rows with $aos_* variables only)
+            $tableForIteration = '';
+            if (!empty($contentRows)) {
+                if ($tableOpenTag !== '') {
+                    $tableForIteration = $tableOpenTag . '<tbody>' . implode('', $contentRows) . '</tbody></table>';
+                } else {
+                    $tableForIteration = implode('', $contentRows);
+                }
+            }
+
+            // Append text before table
+            $processedText .= $beforeTable;
+
+            // Render table header once
+            if (!empty($tableHeaderHtml)) {
+                $processedText .= templateParser::parse_template($tableHeaderHtml, array());
+            }
+
+            // Iterate through groups
             $obb = array();
-
-            $tdTemp = explode($lsValue, $text);
-
-            $groupPart = $lsValue . $tdTemp[(is_countable($tdTemp) ? count($tdTemp) : 0) - 1] . $groupPart . $leValue;
-
-            $text = $tdTemp[0];
-
             foreach ($lineItemsGroups as $group_id => $lineItemsArray) {
-                $groupPartTemp = populate_product_lines($groupPart, $lineItemsArray);
+                $groupPartTemp = populate_product_lines($tableForIteration, $lineItemsArray);
                 $groupPartTemp = populate_service_lines($groupPartTemp, $lineItemsArray);
 
                 $obb['AOS_Line_Item_Groups'] = $group_id;
-                $text .= templateParser::parse_template($groupPartTemp, $obb);
-                $text .= '<br />';
+                $processedText .= templateParser::parse_template($groupPartTemp, $obb);
+                $processedText .= '<br />';
             }
-            $tcount = strpos($parts[1], $endElement) + strlen($endElement);
-            $parts[1] = substr($parts[1], $tcount);
         } else {
-            $tcount = strrpos($text, $startElement);
-            $text = substr($text, 0, $tcount);
-
-            $tcount = strpos($parts[1], $endElement) + strlen($endElement);
-            $parts[1] = substr($parts[1], $tcount);
+            // Table without group variables - keep as is
+            $processedText .= $beforeTable . $tableBlock;
         }
 
-        $text .= $parts[1];
-    } else {
-        $text = populate_product_lines($text, $lineItems);
-        $text = populate_service_lines($text, $lineItems);
+        $remainingText = substr($remainingText, $tableEndPos);
     }
 
+    // Append any remaining text after the last table
+    $processedText .= $remainingText;
 
-    return $text;
+    return $processedText;
+    // END STIC-Custom
 }
 
 function populate_product_lines($text, $lineItems, $element = 'tr')

--- a/modules/AOS_PDF_Templates/generatePdf.php
+++ b/modules/AOS_PDF_Templates/generatePdf.php
@@ -181,7 +181,7 @@ if ($task === 'pdf' || $task === 'emailpdf') {
 function populate_group_lines($text, $lineItemsGroups, $lineItems, $element = 'table')
 {
     // STIC-Custom 20260813 ART - Repeated Headers in PDF Templates with Invoices
-    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+    // https://github.com/SinergiaTIC/SinergiaCRM/pull/1381
     // $firstValue = '';
     // $firstNum = 0;
 

--- a/modules/AOS_PDF_Templates/views/view.edit.php
+++ b/modules/AOS_PDF_Templates/views/view.edit.php
@@ -65,7 +65,7 @@ class AOS_PDF_TemplatesViewEdit extends ViewEdit
 
             //Getting Fields
             // STIC-Custom 20260813 ART - Fix "Undefined array key" warning when a module is not in the beanList
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1381
             // if (!$beanList[$moduleName]) {
             if (!isset($beanList[$moduleName])) {
             // END STIC-Custom
@@ -179,7 +179,7 @@ class AOS_PDF_TemplatesViewEdit extends ViewEdit
                 foreach ($product_quote->field_defs as $line_name => $line_arr) {
                     if (!((isset($line_arr['dbType']) && strtolower($line_arr['dbType']) == 'id') || $line_arr['type'] == 'id' || $line_arr['type'] == 'link')) {
                         // STIC-Custom 20260813 ART - Fix "Undefined array key 'vname'" warning when a field definition is not correct
-                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1381
                         // if ((!isset($line_arr['reportable']) || $line_arr['reportable']) && $line_arr['vname']  != 'LBL_NAME') {
                         if ((!isset($line_arr['reportable']) || $line_arr['reportable']) && isset($line_arr['vname']) && $line_arr['vname'] != 'LBL_NAME') {
                         // END STIC-Custom

--- a/modules/AOS_PDF_Templates/views/view.edit.php
+++ b/modules/AOS_PDF_Templates/views/view.edit.php
@@ -64,7 +64,11 @@ class AOS_PDF_TemplatesViewEdit extends ViewEdit
             $mod_options_array = array();
 
             //Getting Fields
-            if (!$beanList[$moduleName]) {
+            // STIC-Custom 20260813 ART - Fix "Undefined array key" warning when a module is not in the beanList
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // if (!$beanList[$moduleName]) {
+            if (!isset($beanList[$moduleName])) {
+            // END STIC-Custom
                 continue;
             }
             $module = new $beanList[$moduleName]();
@@ -174,7 +178,11 @@ class AOS_PDF_TemplatesViewEdit extends ViewEdit
                 $product_quote = BeanFactory::newBean('AOS_Products');
                 foreach ($product_quote->field_defs as $line_name => $line_arr) {
                     if (!((isset($line_arr['dbType']) && strtolower($line_arr['dbType']) == 'id') || $line_arr['type'] == 'id' || $line_arr['type'] == 'link')) {
-                        if ((!isset($line_arr['reportable']) || $line_arr['reportable']) && $line_arr['vname']  != 'LBL_NAME') {
+                        // STIC-Custom 20260813 ART - Fix "Undefined array key 'vname'" warning when a field definition is not correct
+                        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                        // if ((!isset($line_arr['reportable']) || $line_arr['reportable']) && $line_arr['vname']  != 'LBL_NAME') {
+                        if ((!isset($line_arr['reportable']) || $line_arr['reportable']) && isset($line_arr['vname']) && $line_arr['vname'] != 'LBL_NAME') {
+                        // END STIC-Custom
                             $options_array['$'.$product_quote->table_name.'_'.$line_name] = translate($line_arr['vname'], $product_quote->module_dir);
                         }
                     }


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/578

## Description
Se detecta que en la generación de plantillas PDF del módulo de facturas (y presupuestos), la cabecera de la tabla se repite por cada línea de la factura cuando hay variables de grupo de artículos (`$aos_line_item_groups_*`), y solo debería aparecer una única vez.

### Causa
La función `populate_group_lines` (triplicada en 3 ficheros) iteraba por cada grupo de artículos re-renderizando la tabla entera, incluyendo las filas de cabecera. La lógica original basada en `explode` sobre el primer y último valor de grupo no distinguía entre filas de cabecera (texto fijo) y filas de contenido (con variables `$aos_*`).

### Cambios realizados

**Refactorización de `populate_group_lines` en 3 ficheros:**

Cambio idéntico aplicado a:
- `modules/AOS_PDF_Templates/generatePdf.php`
- `modules/AOS_PDF_Templates/formLetterPdf.php`
- `custom/modules/AOS_PDF_Templates/SticGeneratePdfFunctions.php`

La nueva lógica:
1. Escanea el template en busca de bloques `<table>...</table>`
2. Dentro de cada tabla que contenga variables de grupo, extrae todas las filas `<tr>...</tr>`
3. **Separa filas de cabecera** (sin variables `$aos_*`) de **filas de contenido** (con variables `$aos_*`)
4. Renderiza la cabecera **una sola vez** y el contenido **por cada grupo**
5. Las tablas sin variables de grupo se mantienen intactas
6. Se eliminó la variable `$rowPositions` (no utilizada) y se extrajo `$tableOpenTag` una sola vez
7. Se añadió `is_countable()` en `formLetterPdf.php` para homogeneizar con `generatePdf.php`

**Fixes adicionales de warnings en `modules/AOS_PDF_Templates/views/view.edit.php`:**
- Línea 67: `!$beanList[$moduleName]` → `!isset($beanList[$moduleName])` — evita warning si un módulo del dropdown de tipos de plantilla no existe en `$beanList`
- Línea 177: añadido `isset($line_arr['vname'])` — evita warning si un campo de `AOS_Products` no tiene clave `vname`

## Motivation and Context
Al generar un PDF de factura o presupuesto con varios grupos de productos/servicios, la cabecera de la tabla (nombres de columna) aparecía repetida por cada grupo, produciendo documentos visualmente incorrectos que no se pueden enviar al cliente.

El fix asegura que la cabecera de cada tabla se renderice una sola vez, independientemente del número de grupos.

## How To Test This

### Caso 1: Una tabla, varios grupos (escenario principal)
1. Crear una plantilla PDF de Facturas con una tabla que incluya variables de grupo (`$aos_line_item_groups_name`) y de productos (`$aos_products_quotes_name`, `$aos_products_quotes_product_total_price`).
2. Crear una factura con varios grupos de artículos (ej. Grupo A con 2 productos, Grupo B con 1 producto).
3. Generar el PDF desde la vista de detalle (`generatePdf.php`).
4. Verificar que la cabecera de la tabla aparece **una sola vez** al inicio y las filas de productos se listan agrupadas debajo.

### Caso 2: Dos tablas diferentes con grupos (texto entre tablas)
1. Crear una plantilla PDF con dos tablas separadas por texto, cada una con variables de grupo.
2. Generar el PDF.
3. Verificar que **cada tabla conserva su propia cabecera**, renderizada una vez por tabla.

### Caso 3: Tabla sin variables de grupo (otro módulo, ej. Contactos)
1. Crear una plantilla PDF de Contactos con una tabla que incluya variables del módulo (`$contacts_name`, `$contacts_phone_work`).
2. Generar el PDF.
3. Verificar que la tabla se renderiza correctamente sin cambios de comportamiento (sin grupos, sin cabeceras repetidas).

### Caso 4: Generación masiva desde vista de lista (`formLetterPdf.php`)
1. Repetir el Caso 1 pero generando el PDF desde la vista de lista usando "Seleccionar todo" → "PDF".
2. Verificar mismo resultado: cabecera una sola vez.

### Caso 5: PDF firmado electrónicamente (`SticGeneratePdfFunctions.php`)
1. Repetir el Caso 1 pero con el flujo de firma electrónica de SinergiaCRM.
2. Verificar mismo resultado.

### Caso 6: Vista de edición de plantillas sin warnings (`view.edit.php`)
1. Acceder a la vista de edición de cualquier plantilla PDF.
2. Verificar que no aparecen warnings de `Undefined array key`.
