### PR TITLE
Hotfix - Competencias - Visualizar paneles custom

### DIFF
--- a/modules/stic_Skills/Utils.js
+++ b/modules/stic_Skills/Utils.js
@@ -105,7 +105,8 @@ switch (viewType()) {
 // Function to show the tabs depending of the type
 function showTabs(typeSelected) {
 
-  var panelLanguages = $("div.panel-content");
+  // Select the language panel by its data-id, avoiding affecting other panels (including those created from Studio)
+  var panelLanguages = $(".panelContainer[data-id='LBL_PANEL_LANGUAGE']").closest(".panel");
 
   // Ocultar el panel de lenguaje por defecto
   panelLanguage(panelLanguages, "hide");
@@ -137,8 +138,8 @@ function showTabsEdit() {
       });
     }
   } else {
-    $("#type").on("change", function () {
-      showTabsEdit();
+    $("#type").off("change.sticTabs").on("change.sticTabs", function () {
+      showTabs($("#type").val());
     });
   }
 }
@@ -158,7 +159,7 @@ function getRequiredStatus(fieldId) {
 function panelLanguage(panelLanguages, view) {
   // Showing the tab Task and put the fields required if is in the EditView
   if (view === "show") {
-    panelLanguages.show();
+    panelLanguages.removeClass("hidden");
     if (
       viewType() === "edit" ||
       viewType() === "quickcreate" ||
@@ -185,7 +186,7 @@ function panelLanguage(panelLanguages, view) {
     }
     // Hiding the tab Task and put the fields unrequired if is in the EditView
   } else if (view === "hide") {
-    panelLanguages.hide();
+    panelLanguages.addClass("hidden");
     if (
       viewType() === "edit" ||
       viewType() === "quickcreate" ||


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/1372

## Description
Se ha detectado que las vistas personalizadas sobre el módulo de Competencias (`stic_Skills`) no funcionan correctamente al añadir paneles nuevos desde Estudio.

En `modules/stic_Skills/Utils.js`, la función `showTabs()` usaba el selector `$("div.panel-content")` (línea 108), que seleccionaba **todos** los paneles del tab en lugar de solo el panel de Idioma. Al ejecutar `.show()` o `.hide()` sobre esta selección, se ocultaban o mostraban todos los paneles a la vez, incluidos los creados desde Estudio mediante vistas personalizadas.

Además, los métodos `.show()` y `.hide()` de jQuery usan estilos inline (`display: none`), que entran en conflicto con el sistema de clases CSS usado por las vistas personalizadas para controlar la visibilidad de paneles.

## Motivation and Context
Al crear paneles personalizados desde Estudio y configurar su visibilidad mediante vistas personalizadas, el comportamiento del panel de Idioma interfería: al seleccionar "Idiomas" como tipo de competencia se mostraban todos los paneles (incluidos los personalizados), y al seleccionar cualquier otro tipo se ocultaban todos. Esto impedía usar vistas personalizadas sobre Competencias para cualquier panel distinto del de Idioma.

Los cambios aseguran que la lógica de mostrar/ocultar el panel de Idioma sea independiente y no afecte a otros paneles, respetando así la configuración de las vistas personalizadas.

## How To Test This
1. Ir a Estudio → Competencias → Diseño de Edición.
2. Crear un panel nuevo (ej. "Panel Personalizado") y añadir algún campo.
3. Ir a Vistas Personalizadas y crear una nueva para Competencias de vista de Edición:
3.1. Condiciones: Tipo → No Igual a → Otras
3.2. Acciones: Panel → "Panel Personalizado" → Visible → No
5. Crear una nueva Competencia con Tipo = "Otras".
6. Verificar que el "Panel Personalizado" se muestra correctamente y que el panel de Idioma no se muestra.
7. Cambiar el Tipo a "Idiomas".
8. Verificar que el panel de Idioma se muestra y que el "Panel Personalizado" se oculta.