### PR TITLE
Hotfix - Mensajes - Estado de WhatsApp Web muestra "Enviado" en lugar de "Redirigido"

### DIFF
--- a/modules/stic_Messages/Helpers/WhatsAppWebHelper.php
+++ b/modules/stic_Messages/Helpers/WhatsAppWebHelper.php
@@ -68,7 +68,7 @@ class WhatsAppWebHelper extends stic_MessagesHelper {
             'lockSender' => true,
             'fixedStatus' => 'redirected',
             'canRetry' => false,
-            'allowedStatus' => ['sent', 'redirected'],
+            'allowedStatus' => ['redirected'],
         ];
     }
 


### PR DESCRIPTION
- Closes #1383 

## Descripción

Corrige el doble cambio de estado observado en la vista de edición de `stic_Messages` al seleccionar WhatsApp Web como tipo de mensaje.

Anteriormente, al elegir `type = whatsapp_web` el campo Estado quedaba no editable pero mostraba visualmente **"Enviado" (sent)**. El estado solo pasaba a **"Redirigido" (redirected)** en el momento del guardado.

Dado que los mensajes de WhatsApp Web nunca se envían realmente a través del CRM (se redirigen a wa.me), `sent` no es un estado final válido para este canal y no debería presentarse como opción.


## Cambios

- `modules/stic_Messages/Helpers/WhatsAppWebHelper.php`: `allowedStatus` pasa de `['sent', 'redirected']` a `['redirected']`.

## Instrucciones de prueba

1. Ir a una Mensjes.
2. Seleccionar `WhatsApp Web` como tipo.
3. Verificar que el campo Estado está bloqueado y muestra **"Redirigido"** (no "Enviado").
4. Guardar y confirmar que el registro se crea con `status = redirected`.
5. Repetir con `SMS`, `WhatsApp (Twilio)` y `Área privada` para confirmar que no hay errores.
