### PR TITLE
Hotfix - Emulación de usuarios - Dashlets de Inicio

### DIFF
--- a/custom/modules/Users/SticImpersonate/LogicHooksCode.php
+++ b/custom/modules/Users/SticImpersonate/LogicHooksCode.php
@@ -42,6 +42,11 @@ class ImpersonateLogicHooks
             return;
         }
 
+        // Avoid injecting UI in AJAX/body-only responses (dashlets, inline edits, searches, calendar, popups)
+        if (!empty($_REQUEST['to_pdf']) || !empty($_REQUEST['sugar_body_only'])) {
+            return;
+        }
+
         require_once('custom/modules/Users/SticImpersonate/Impersonate.php');
         $impersonate = new Impersonate();
         


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/1375
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/1080

## Description
Al emular a otro usuario, los dashlets de la página de inicio dejan de funcionar correctamente: el diálogo "Añadir Dashlet" se queda cargando indefinidamente y al editar un dashlet existente aparece un popup de error.
Además, si se accedía a Estudio producía un error.

## Motivation and Context
La emulación de usuarios es una funcionalidad crítica para administradores que necesitan diagnosticar o replicar incidencias. 
La causa es que el hook `after_ui_frame` de la emulación (`custom/modules/Users/SticImpersonate/LogicHooksCode.php`) inyecta HTML (`<script>` y `<link>`) en **todas** las respuestas del servidor, incluyendo las respuestas AJAX de los dashlets. Estas peticiones AJAX esperan texto plano (un GUID) o JSON (`result = {...}`), y el HTML inyectado corrompe la respuesta provocando que el JavaScript falle al evaluarla.

Se añade una comprobación al inicio del método `after_ui_frame` para que no inyecte HTML en respuestas AJAX, usando los parámetros `to_pdf` y `sugar_body_only` que SuiteCRM ya utiliza para identificar peticiones de respuesta parcial:

```
if (!empty($_REQUEST['to_pdf']) || !empty($_REQUEST['sugar_body_only'])) {
    return;
}
```

Este es el mismo patrón que ya usan otros hooks del sistema como SecurityGroups/AssignGroups.php e include/utils.php.

Sin esta solución, al emular a un usuario la página de inicio queda inutilizable (no se pueden añadir ni editar dashlets), lo que impide a los administradores trabajar correctamente en el contexto emulado. Al igual que si se accede a Estudio, no dejaba emular al usuario navegando por dicho módulo.

## How To Test This
1. Iniciar sesión como usuario administrador
2. Ir a cualquier otro usuario y usar la función de emulación
3. Ir a la página de Inicio (Home)
4. Hacer clic en "Añadir Dashlet" y comprobar que se abre el diálogo con el listado de dashlets disponibles
5. Hacer clic en el icono de editar de un dashlet existente y comprobar que se abre la ventana de configuración
6. Acceder a Estudio y comprobar que se puede navegar por los diferentes módulos, editando/añadiendo campos, vistas, etc., sin que llegue a aparecer ningún error.
7. Repetir sin emulación para confirmar que todas las operaciones funcionan igual.