### PR TITLE
Enhancement - General - Amplia los formatos de imágenes permitidos para registar

### DIFF
--- a/config.php
+++ b/config.php
@@ -72,6 +72,7 @@ $sugar_config = array(
         2 => 'png',
         3 => 'jpeg',
         4 => 'jpg',
+        5 => 'webp',
     ),
     'anti_malware_scanners' => array(
         'SuiteCRM\\Utility\\AntiMalware\\Providers\\ClamTCP' => array(
@@ -536,6 +537,7 @@ $sugar_config = array(
         3 => 'jpeg',
         4 => 'svg',
         5 => 'bmp',
+        6 => 'webp',
     ),
     'vcal_time' => '2',
     'verify_client_ip' => true,

--- a/config.php
+++ b/config.php
@@ -72,7 +72,10 @@ $sugar_config = array(
         2 => 'png',
         3 => 'jpeg',
         4 => 'jpg',
+        // STIC-Custom SPPM - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
+		// https://github.com/SinergiaTIC/SinergiaCRM/pull/1390
         5 => 'webp',
+        // END STIC-Custom
     ),
     'anti_malware_scanners' => array(
         'SuiteCRM\\Utility\\AntiMalware\\Providers\\ClamTCP' => array(
@@ -537,7 +540,10 @@ $sugar_config = array(
         3 => 'jpeg',
         4 => 'svg',
         5 => 'bmp',
+        // STIC-Custom SPPM - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
+		// https://github.com/SinergiaTIC/SinergiaCRM/pull/1390
         6 => 'webp',
+        // END STIC-Custom
     ),
     'vcal_time' => '2',
     'verify_client_ip' => true,

--- a/include/utils.php
+++ b/include/utils.php
@@ -5473,6 +5473,16 @@ function verify_image_file($path, $jpeg = false)
             if (file_put_contents($path, $image)) {
                 return true;
             }
+        // STIC-Custom OC - 20260818 - Allow GIF image uploads (re-encode with GD)
+        } elseif ($filetype == 'image/gif') {
+            // else if the filetype is gif, create gif
+            ob_start();
+            imagegif($img);
+            $image = ob_get_clean();
+            if (file_put_contents($path, $image)) {
+                return true;
+            }
+        // END STIC-Custom OC
         } else {
             return false;
         }

--- a/include/utils.php
+++ b/include/utils.php
@@ -223,7 +223,10 @@ function make_sugar_config(&$sugar_config)
         ) : $upload_badext,
         'valid_image_ext' => [
             'gif',
+			// STIC-Custom SPPM - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
+			// https://github.com/SinergiaTIC/SinergiaCRM/pull/1390
             'webp',
+			// END STIC-Custom
             'png',
             'jpg',
             'jpeg',
@@ -233,7 +236,10 @@ function make_sugar_config(&$sugar_config)
         'upload_maxsize' => empty($upload_maxsize) ? 30000000 : $upload_maxsize,
         'allowed_preview' => [
             'gif',
+			// STIC-Custom SPPM - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
+			// https://github.com/SinergiaTIC/SinergiaCRM/pull/1390
             'webp',
+			// END STIC-Custom
             'png',
             'jpeg',
             'jpg'
@@ -497,7 +503,10 @@ function get_sugar_config_defaults(): array
         ],
         'valid_image_ext' => [
             'gif',
+			// STIC-Custom SPPM - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
+			// https://github.com/SinergiaTIC/SinergiaCRM/pull/1390
             'webp',
+			// END STIC-Custom
             'png',
             'jpg',
             'jpeg',
@@ -506,7 +515,10 @@ function get_sugar_config_defaults(): array
         ],
         'allowed_preview' => [
             'gif',
+			// STIC-Custom SPPM - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
+			// https://github.com/SinergiaTIC/SinergiaCRM/pull/1390
             'webp',
+			// END STIC-Custom
             'png',
             'jpeg',
             'jpg'
@@ -6080,7 +6092,10 @@ function has_valid_image_extension($fieldName, $name)
 
     $validExtensions = [
         'gif',
+		// STIC-Custom SPPM - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
+		// https://github.com/SinergiaTIC/SinergiaCRM/pull/1390
         'webp',
+		// END STIC-Custom
         'png',
         'jpg',
         'jpeg',
@@ -6109,7 +6124,10 @@ function has_valid_image_mime_type(string $mimeType): bool
 
     $validExtensions = [
         'gif',
+		// STIC-Custom SPPM - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
+		// https://github.com/SinergiaTIC/SinergiaCRM/pull/1390
         'webp',
+		// END STIC-Custom
         'png',
         'jpg',
         'jpeg',

--- a/include/utils.php
+++ b/include/utils.php
@@ -5477,7 +5477,8 @@ function verify_image_file($path, $jpeg = false)
             if (file_put_contents($path, $image)) {
                 return true;
             }
-        // STIC-Custom OC - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
+        // STIC-Custom SPPM - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
+		// https://github.com/SinergiaTIC/SinergiaCRM/pull/1390
         } elseif ($filetype == 'image/gif') {
             // else if the filetype is gif, create gif
             ob_start();
@@ -5494,7 +5495,7 @@ function verify_image_file($path, $jpeg = false)
             if (file_put_contents($path, $image)) {
                 return true;
             }
-        // END STIC-Custom OC
+        // END STIC-Custom
         } else {
             return false;
         }
@@ -5516,6 +5517,11 @@ function verify_image_file($path, $jpeg = false)
 function verify_uploaded_image($path, $jpeg_only = false)
 {
     global $sugar_config;
+	// STIC-Custom SPPM - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
+	// https://github.com/SinergiaTIC/SinergiaCRM/pull/1390
+	// $supportedExtensions = $sugar_config['image_ext'] ?? ['image/jpeg', 'image/png', 'image/gif', 'tmp' => 'tmp'];
+	// END STIC-Custom
+	
     $supportedExtensions = $sugar_config['image_ext'] ?? ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'tmp' => 'tmp'];
 
     if (!$jpeg_only) {

--- a/include/utils.php
+++ b/include/utils.php
@@ -5532,9 +5532,8 @@ function verify_uploaded_image($path, $jpeg_only = false)
 	// STIC-Custom SPPM - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
 	// https://github.com/SinergiaTIC/SinergiaCRM/pull/1390
 	// $supportedExtensions = $sugar_config['image_ext'] ?? ['image/jpeg', 'image/png', 'image/gif', 'tmp' => 'tmp'];
+	$supportedExtensions = $sugar_config['image_ext'] ?? ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'tmp' => 'tmp'];
 	// END STIC-Custom
-	
-    $supportedExtensions = $sugar_config['image_ext'] ?? ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'tmp' => 'tmp'];
 
     if (!$jpeg_only) {
         $supportedExtensions['png'] = 'image/png';

--- a/include/utils.php
+++ b/include/utils.php
@@ -223,6 +223,7 @@ function make_sugar_config(&$sugar_config)
         ) : $upload_badext,
         'valid_image_ext' => [
             'gif',
+            'webp',
             'png',
             'jpg',
             'jpeg',
@@ -232,6 +233,7 @@ function make_sugar_config(&$sugar_config)
         'upload_maxsize' => empty($upload_maxsize) ? 30000000 : $upload_maxsize,
         'allowed_preview' => [
             'gif',
+            'webp',
             'png',
             'jpeg',
             'jpg'
@@ -495,6 +497,7 @@ function get_sugar_config_defaults(): array
         ],
         'valid_image_ext' => [
             'gif',
+            'webp',
             'png',
             'jpg',
             'jpeg',
@@ -503,6 +506,7 @@ function get_sugar_config_defaults(): array
         ],
         'allowed_preview' => [
             'gif',
+            'webp',
             'png',
             'jpeg',
             'jpg'
@@ -5473,11 +5477,19 @@ function verify_image_file($path, $jpeg = false)
             if (file_put_contents($path, $image)) {
                 return true;
             }
-        // STIC-Custom OC - 20260818 - Allow GIF image uploads (re-encode with GD)
+        // STIC-Custom OC - 20260818 - Allow GIF and WEBP image uploads (re-encode with GD)
         } elseif ($filetype == 'image/gif') {
             // else if the filetype is gif, create gif
             ob_start();
             imagegif($img);
+            $image = ob_get_clean();
+            if (file_put_contents($path, $image)) {
+                return true;
+            }
+        } elseif ($filetype == 'image/webp') {
+            // else if the filetype is webp, create webp
+            ob_start();
+            imagewebp($img);
             $image = ob_get_clean();
             if (file_put_contents($path, $image)) {
                 return true;
@@ -5504,7 +5516,7 @@ function verify_image_file($path, $jpeg = false)
 function verify_uploaded_image($path, $jpeg_only = false)
 {
     global $sugar_config;
-    $supportedExtensions = $sugar_config['image_ext'] ?? ['image/jpeg', 'image/png', 'image/gif' , 'tmp' => 'tmp'];
+    $supportedExtensions = $sugar_config['image_ext'] ?? ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'tmp' => 'tmp'];
 
     if (!$jpeg_only) {
         $supportedExtensions['png'] = 'image/png';
@@ -6062,6 +6074,7 @@ function has_valid_image_extension($fieldName, $name)
 
     $validExtensions = [
         'gif',
+        'webp',
         'png',
         'jpg',
         'jpeg',
@@ -6090,6 +6103,7 @@ function has_valid_image_mime_type(string $mimeType): bool
 
     $validExtensions = [
         'gif',
+        'webp',
         'png',
         'jpg',
         'jpeg',


### PR DESCRIPTION
## Descripción
Permitir la subida de imágenes GIF y WEBP en el CRM. El validador de imágenes en `include/utils.php` (`verify_image_file()`) solo volvía a codificar JPEG y PNG con GD, por lo que los archivos GIF y WEBP válidos se rechazaban con el error de seguridad "Image Malware found, unable to save file". Este cambio añade ramas GIF y WEBP que vuelven a codificar la imagen con `imagegif()` / `imagewebp()` tras el chequeo de contenido hostil mediante regex, siguiendo el mismo patrón que las ramas JPEG/PNG.

Para WEBP, además del re-encode, se ha añadido soporte en el resto de puntos de validación (a diferencia de GIF, que ya estaba incluido):

- `config.php`: `valid_image_ext` y `allowed_preview` incluyen ahora `webp`.
- `verify_uploaded_image()`: el array por defecto de `image_ext` incluye ahora `image/webp`.
- Valores por defecto de `make_sugar_config()`, `get_sugar_config_defaults()`, `has_valid_image_extension()` y `has_valid_image_mime_type()` incluyen ahora `webp`.

## Motivación y contexto

Al subir una imagen `.gif` o `.webp`, el CRM mostraba el error de seguridad `Image Malware found, unable to save file` aunque el formato de imagen fuera válido. Los usuarios no podían usar estos formatos, muy habituales en logos e imágenes de recursos, y debían convertirlas manualmente a JPG o PNG antes de subirlas.

Este cambio permite subir imágenes GIF y WEBP sin errores, manteniendo intactos todos los controles de seguridad existentes.

## Cómo probarlo

El módulo `stic_r3s` (Recursos 3r Sector) dispone de dos campos de tipo imagen: `logo` (Logotipo) e `resource_image` (Imagen de recurso), que utilizan el validador `verify_uploaded_image()` / `verify_image_file()` modificado en este PR.

1. Verificar la sintaxis: `php -l include/utils.php` y `php -l config.php`.
2. Limpiar la caché de la instancia de prueba: `rm -rf cache/*`.
3. Crear o editar un registro en el módulo `stic_r3s` (Recursos 3r Sector).
4. En el campo **Logotipo** (campo `logo`), subir una imagen `.gif` válida.
5. En el campo **Imagen de recurso** (campo `resource_image`), subir una imagen `.webp` válida.
6. Guardar el registro y confirmar que ambas subidas se realizan correctamente y que las imágenes se almacenan/muestran en el detalle del registro.
7. Confirmar que los GIF animados se vuelven a codificar correctamente (la animación puede perderse; solo se conserva el primer frame si GD no está configurado para animaciones).
8. Prueba de regresión: subir un `.png` y un `.jpg` en los mismos campos y confirmar que siguen subiendo correctamente.
9. Prueba de seguridad: intentar subir un archivo con contenido hostil (p. ej. un payload PHP/HTML disfrazado de imagen) y confirmar que sigue siendo rechazado por el chequeo de contenido mediante regex.