### PR TITLE
Hotfix - Administración - "Exportar personalizaciones" de Estudio

### DIFF
--- a/ModuleInstall/ModuleInstaller.php
+++ b/ModuleInstall/ModuleInstaller.php
@@ -214,6 +214,19 @@ class ModuleInstaller
             require_once("modules/Administration/upgrade_custom_relationships.php");
             upgrade_custom_relationships($this->installed_modules);
             $this->rebuild_all(true);
+
+            // STIC-Custom 20260819 ART - Export Customizations from Studio 
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // Clear language cache for all modules so custom field labels appear immediately after customization-only packages
+            global $sugar_config;
+            require_once('include/SugarObjects/LanguageManager.php');
+            if (!empty($sugar_config['languages']) && is_array($sugar_config['languages'])) {
+                foreach ($sugar_config['languages'] as $language => $value) {
+                    LanguageManager::clearLanguageCache('', $language);
+                }
+            }
+            // END STIC-Custom
+
             require_once('modules/Administration/QuickRepairAndRebuild.php');
             $rac = new RepairAndClear();
             $rac->repairAndClearAll($selectedActions, $this->installed_modules, true, false);
@@ -1336,6 +1349,64 @@ class ModuleInstaller
                     $fieldObject->populateFromRow($field);
                     $mod->custom_fields->use_existing_labels =  true;
                     $mod->custom_fields->addFieldObject($fieldObject);
+
+                    // STIC-Custom 20260819 ART - Export Customizations from Studio 
+                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                    // Ensure fields_meta_data exists after addFieldObject by inserting it if STIC update logic skipped saving
+                    // Check whether the metadata row was actually created
+                    $fmdCheck = BeanFactory::newBean('EditCustomFields');
+                    $fieldId = $field['module'] . $field['name'];
+                    $existingId = $fmdCheck->retrieve($fieldId, true, false);
+                    if (empty($existingId)) {
+                        $GLOBALS['log']->debug("Inserting missing fields_meta_data record for field {$fieldId}");
+
+                        // Allow only valid fields_meta_data columns
+                        $allowedColumns = array(
+                            'id', 'name', 'vname', 'comments', 'help', 'custom_module', 'type', 'len',
+                            'required', 'default_value', 'date_modified', 'deleted', 'audited',
+                            'massupdate', 'duplicate_merge', 'reportable', 'importable',
+                            'ext1', 'ext2', 'ext3', 'ext4', 'inline_edit',
+                        );
+
+                        // Map installer keys to DB column names
+                        $fieldMap = array(
+                            'module' => 'custom_module',
+                            'label' => 'vname',
+                            'require_option' => 'required',
+                            'mass_update' => 'massupdate',
+                            'max_size' => 'len',
+                        );
+
+                        // Build the INSERT payload from the field definition
+                        $columns = array();
+                        $values = array();
+                        foreach ($field as $key => $value) {
+                            $dbCol = isset($fieldMap[$key]) ? $fieldMap[$key] : $key;
+                            if (!in_array($dbCol, $allowedColumns)) {
+                                continue;
+                            }
+                            if ($dbCol === 'date_modified' && (empty($value) || $value === '0000-00-00 00:00:00')) {
+                                $value = gmdate('Y-m-d H:i:s');
+                            }
+                            $columns[] = $dbCol;
+                            $values[] = is_null($value) ? 'NULL' : "'" . $this->db->quote($value) . "'";
+                        }
+
+                        // Ensure required defaults for a new metadata row
+                        if (!in_array('deleted', $columns)) {
+                            $columns[] = 'deleted';
+                            $values[] = "'0'";
+                        }
+                        if (!in_array('date_modified', $columns)) {
+                            $columns[] = 'date_modified';
+                            $values[] = "'" . gmdate('Y-m-d H:i:s') . "'";
+                        }
+
+                        // Insert a fallback row so Studio labels are available immediately
+                        $insertSql = "INSERT INTO fields_meta_data (" . implode(',', $columns) . ") VALUES (" . implode(',', $values) . ")";
+                        $this->db->query($insertSql, true, 'Cannot insert fields_meta_data record');
+                    }
+                    // END STIC-Custom
                 }
             }
             if (!$installed) {

--- a/ModuleInstall/ModuleInstaller.php
+++ b/ModuleInstall/ModuleInstaller.php
@@ -216,7 +216,7 @@ class ModuleInstaller
             $this->rebuild_all(true);
 
             // STIC-Custom 20260819 ART - Export Customizations from Studio 
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1392
             // Clear language cache for all modules so custom field labels appear immediately after customization-only packages
             global $sugar_config;
             require_once('include/SugarObjects/LanguageManager.php');
@@ -1351,7 +1351,7 @@ class ModuleInstaller
                     $mod->custom_fields->addFieldObject($fieldObject);
 
                     // STIC-Custom 20260819 ART - Export Customizations from Studio 
-                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/1392
                     // Ensure fields_meta_data exists after addFieldObject by inserting it if STIC update logic skipped saving
                     // Check whether the metadata row was actually created
                     $fmdCheck = BeanFactory::newBean('EditCustomFields');

--- a/modules/ModuleBuilder/MB/MBPackage.php
+++ b/modules/ModuleBuilder/MB/MBPackage.php
@@ -479,12 +479,20 @@ class MBPackage
             foreach ($custom_module as $va) {
                 if ($va === 'language') {
                     $this->getLanguageManifestForModule($value, $installdefs);
-                    $this->getCustomFieldsManifestForModule($value, $installdefs);
+                    // STIC-Custom 20260819 ART - Export Customizations from Studio 
+                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                    // $this->getCustomFieldsManifestForModule($value, $installdefs);
+                    // END STIC-Custom
                 }//fi
                 if ($va === 'metadata') {
                     $this->getCustomMetadataManifestForModule($value, $installdefs);
                 }//fi
             }//foreach
+            // STIC-Custom 20260819 ART - Export Customizations from Studio 
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // Always include custom fields regardless of language directory presence
+            $this->getCustomFieldsManifestForModule($value, $installdefs);
+            // END STIC-Custom
             $relationshipsMetaFiles = $this->getCustomRelationshipsMetaFilesByModuleName($value, true, true, $modules);
             if ($relationshipsMetaFiles) {
                 foreach ($relationshipsMetaFiles as $file) {

--- a/modules/ModuleBuilder/MB/MBPackage.php
+++ b/modules/ModuleBuilder/MB/MBPackage.php
@@ -480,7 +480,7 @@ class MBPackage
                 if ($va === 'language') {
                     $this->getLanguageManifestForModule($value, $installdefs);
                     // STIC-Custom 20260819 ART - Export Customizations from Studio 
-                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/1392
                     // $this->getCustomFieldsManifestForModule($value, $installdefs);
                     // END STIC-Custom
                 }//fi
@@ -489,7 +489,7 @@ class MBPackage
                 }//fi
             }//foreach
             // STIC-Custom 20260819 ART - Export Customizations from Studio 
-            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1392
             // Always include custom fields regardless of language directory presence
             $this->getCustomFieldsManifestForModule($value, $installdefs);
             // END STIC-Custom


### PR DESCRIPTION
- Closes https://github.com/SinergiaTIC/SinergiaCRM/issues/138

## Description
Al exportar un módulo personalizado e instalarlo vía Cargador de Módulos, los campos personalizados no se instalaban: no se creaba el registro en la tabla `fields_meta_data` y el campo no aparecía en Estudio.

El problema tenía dos causas:
1. **Exportación incompleta** (`modules/ModuleBuilder/MB/MBPackage.php`): la llamada a `getCustomFieldsManifestForModule()` estaba anidada dentro del bloque `if ($va === 'language')`. Cuando el módulo no tenía directorio `custom/modules/<modulo>/language/`, los campos personalizados no se añadían a `$installdefs['custom_fields']` del `manifest.php` generado.
2. **Instalación incompleta** (`ModuleInstall/ModuleInstaller.php`): la personalización STIC de `addFieldObject()` puede no guardar el registro en `fields_meta_data` cuando se toma la ruta de actualización. Se añade una red de seguridad que inserta el registro directamente si sigue faltando tras `addFieldObject()`.

Además, al instalar un paquete de personalizaciones (donde `installed_modules` queda vacío y no se lanza el rebuild de idioma), se limpia el caché de lenguaje de todos los módulos para que las etiquetas de los campos aparezcan inmediatamente sin necesidad de _Reparación manual_.

## Motivation and Context
El botón "Exportar Personalizaciones" no cumplía su cometido: los campos personalizados no estaban en el paquete ni se registraban en la instancia destino. Para completar la instalación era necesario pasar manualmente los registros de `fields_meta_data` entre instancias.
En SinergiaCRM los campos custom y sus propiedades se tratan de forma diferente a la estándar, lo que provocaba este efecto colateral: el campo se desplegaba (fichero `_override_sugarfield_CAMPO_c.php` en `Ext/Vardefs`) pero no se creaba el registro en `fields_meta_data`, por lo que no aparecía en Estudio. Este comportamiento no sucede en SuiteCRM.
Con este cambio, el paquete exportado incluye siempre `$installdefs['custom_fields']` y la instalación garantiza el registro en `fields_meta_data` y la visibilidad inmediata del campo y su etiqueta.

## How To Test This

### 1. Exportar Personalizaciones
**Objetivo:** verificar que el ZIP genera correctamente `$installdefs['custom_fields']`.
Pasos:
1. Ve a Estudio > Asistencias > Campos y añade un campo custom (ej: `test_c`, tipo Texto).
2. Ve a Estudio > botón **"Exportar Personalizaciones"**.
3. Selecciona Asistencias y genera el paquete.
4. Descarga el ZIP y descomprímelo.
5. Abre `manifest.php` y verifica:
5.1. Debe existir `$installdefs['custom_fields']` con los datos del campo `test_c`.
5.2. Debe existir `$installdefs['copy']` con las extensiones (vardefs, logic hooks, idioma).
5.3. No debe depender de que exista el directorio `custom/modules/stic_Attendances/language/`.

### 2. Instalación del Paquete (Instancia Destino)
**Objetivo:** verificar que el paquete instala correctamente el campo, la etiqueta y las vistas.
Pasos (en instancia limpia donde **NO** exista el campo):
1. Ve a Admin > Cargador de Módulos.
2. Carga el ZIP generado en el paso 1.
3. Instala el paquete.
4. Verifica inmediatamente (**SIN** hacer *Repair and Rebuild* manual):
4.1. Campo en `fields_meta_data` -> `SELECT * FROM fields_meta_data WHERE name = 'test_c'`: _Debe devolver **1 fila**_ 
4.2. Campo visible en Estudio -> Estudio > `stic_Attendances` > Campos: _Debe aparecer `test_c`_
4.3. Etiqueta del campo -> En el formulario de edición del campo, el label debe mostrarse correctamente (ni vacío ni "undefined") |
4.4. Fichero `_override_sugarfield_test_c.php` -> `custom/Extension/modules/stic_Attendances/Ext/Vardefs/`: `Debe existir`
4.5. Columna en bbdd -> `SHOW COLUMNS FROM stic_attendances_cstm LIKE 'test_c'`: _Debe existir_
4.6. Vista de edición -> Editar una asistencia -> el campo debe aparecer en el layout

### 3. Vistas/Layouts
**Objetivo:** verificar que las vistas personalizadas también se exportan/instalan.
Pasos:
1. En Estudio, modifica el layout de Vista de Detalle de Asistencias (mueve un campo, añade uno).
2. Exporta personalizaciones.
3. Instala en instancia limpia.
4. Verifica:
4.1. `custom/modules/stic_Attendances/metadata/detailviewdefs.php` existe.
4.2. El layout refleja los cambios al ver una asistencia.

### 4. Desinstalación
**Objetivo:** verificar que el paquete se desinstala limpiamente.
Pasos:
1. Desinstala el paquete desde Cargador de Módulos.
2. Verifica:
2.1. Campo borrado de `fields_meta_data`.
2.2. Columna borrada de `stic_attendances_cstm`.
2.3. Ficheros de extensión borrados de `custom/Extension/...`.
2.4. No quedan residuos en el `manifest.php` del cargador.