### PR TITLE
Hotfix - General - Añadir opciones "Hoy", "Ayer" y "Mañana" en filtros de búsqueda por rango de fechas

### DIFF
--- a/include/SearchForm/SearchForm2.php
+++ b/include/SearchForm/SearchForm2.php
@@ -1450,7 +1450,7 @@ class SearchForm
                                 $where .= "$db_field <= $field_value";
                                 break;
                             // STIC Custom 20260825 PCS - Add today, yesterday and tomorrow to date range search options
-                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/1395
                             case 'today':
                             case 'yesterday':
                             case 'tomorrow':

--- a/include/SearchForm/SearchForm2.php
+++ b/include/SearchForm/SearchForm2.php
@@ -1449,6 +1449,12 @@ class SearchForm
                                 $field_value = $db->quoteType($type, $field_value);
                                 $where .= "$db_field <= $field_value";
                                 break;
+                            // STIC Custom 20260825 PCS - Add today, yesterday and tomorrow to date range search options
+                            // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+                            case 'today':
+                            case 'yesterday':
+                            case 'tomorrow':
+                            // END STIC Custom
                             case 'next_7_days':
                             case 'last_7_days':
                             case 'last_month':

--- a/include/language/ca_ES.lang.php
+++ b/include/language/ca_ES.lang.php
@@ -1099,6 +1099,12 @@ $app_list_strings = array(
         'not_equal' => 'Diferent de',
         'greater_than' => 'Després de',
         'less_than' => 'Abans de',
+        // STIC Custom 20260825 PCS - Add today, yesterday and tomorrow to date range search options
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        'today' => 'Avui',
+        'yesterday' => 'Ahir',
+        'tomorrow' => 'Demà',
+        // END STIC Custom
         'last_7_days' => 'Els darrers 7 dies',
         'next_7_days' => 'Els propers 7 dies',
         'last_30_days' => 'Els darrers 30 dies',

--- a/include/language/ca_ES.lang.php
+++ b/include/language/ca_ES.lang.php
@@ -1100,7 +1100,7 @@ $app_list_strings = array(
         'greater_than' => 'Després de',
         'less_than' => 'Abans de',
         // STIC Custom 20260825 PCS - Add today, yesterday and tomorrow to date range search options
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1395
         'today' => 'Avui',
         'yesterday' => 'Ahir',
         'tomorrow' => 'Demà',

--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -1051,7 +1051,7 @@ $app_list_strings = array(
         'greater_than' => 'After',
         'less_than' => 'Before',
         // STIC Custom 20260825 PCS - Add today, yesterday and tomorrow to date range search options
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1395
         'today' => 'Today',
         'yesterday' => 'Yesterday',
         'tomorrow' => 'Tomorrow',

--- a/include/language/en_us.lang.php
+++ b/include/language/en_us.lang.php
@@ -1050,6 +1050,12 @@ $app_list_strings = array(
         'not_equal' => 'Not On',
         'greater_than' => 'After',
         'less_than' => 'Before',
+        // STIC Custom 20260825 PCS - Add today, yesterday and tomorrow to date range search options
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        'today' => 'Today',
+        'yesterday' => 'Yesterday',
+        'tomorrow' => 'Tomorrow',
+        // END STIC Custom
         'last_7_days' => 'Last 7 Days',
         'next_7_days' => 'Next 7 Days',
         'last_30_days' => 'Last 30 Days',

--- a/include/language/es_ES.lang.php
+++ b/include/language/es_ES.lang.php
@@ -1118,7 +1118,7 @@ $app_list_strings = array(
         'greater_than' => 'Después de',
         'less_than' => 'Antes de',
         // STIC Custom 20260825 PCS - Add today, yesterday and tomorrow to date range search options
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1395
         'today' => 'Hoy',
         'yesterday' => 'Ayer',
         'tomorrow' => 'Mañana',

--- a/include/language/es_ES.lang.php
+++ b/include/language/es_ES.lang.php
@@ -1117,6 +1117,12 @@ $app_list_strings = array(
         'not_equal' => 'Distinto de',
         'greater_than' => 'Después de',
         'less_than' => 'Antes de',
+        // STIC Custom 20260825 PCS - Add today, yesterday and tomorrow to date range search options
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        'today' => 'Hoy',
+        'yesterday' => 'Ayer',
+        'tomorrow' => 'Mañana',
+        // END STIC Custom
         'last_7_days' => 'Últimos 7 días',
         'next_7_days' => 'Próximos 7 días',
         'last_30_days' => 'Últimos 30 días',

--- a/include/language/eu_ES.lang.php
+++ b/include/language/eu_ES.lang.php
@@ -1118,7 +1118,7 @@ $app_list_strings = array(
         'greater_than' => 'Después de',
         'less_than' => 'Antes de',
         // STIC Custom 20260825 PCS - Add today, yesterday and tomorrow to date range search options
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1395
         'today' => 'Hoy',
         'yesterday' => 'Ayer',
         'tomorrow' => 'Mañana',

--- a/include/language/eu_ES.lang.php
+++ b/include/language/eu_ES.lang.php
@@ -1117,6 +1117,12 @@ $app_list_strings = array(
         'not_equal' => 'Distinto de',
         'greater_than' => 'Después de',
         'less_than' => 'Antes de',
+        // STIC Custom 20260825 PCS - Add today, yesterday and tomorrow to date range search options
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        'today' => 'Hoy',
+        'yesterday' => 'Ayer',
+        'tomorrow' => 'Mañana',
+        // END STIC Custom
         'last_7_days' => 'Últimos 7 días',
         'next_7_days' => 'Próximos 7 días',
         'last_30_days' => 'Últimos 30 días',

--- a/include/language/gl_ES.lang.php
+++ b/include/language/gl_ES.lang.php
@@ -1118,7 +1118,7 @@ $app_list_strings = array(
         'greater_than' => 'Despois de',
         'less_than' => 'Antes de',
         // STIC Custom 20260825 PCS - Add today, yesterday and tomorrow to date range search options
-        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/1395
         'today' => 'Hoxe',
         'yesterday' => 'Onte',
         'tomorrow' => 'Mañá',

--- a/include/language/gl_ES.lang.php
+++ b/include/language/gl_ES.lang.php
@@ -1117,6 +1117,12 @@ $app_list_strings = array(
         'not_equal' => 'Distinto de',
         'greater_than' => 'Despois de',
         'less_than' => 'Antes de',
+        // STIC Custom 20260825 PCS - Add today, yesterday and tomorrow to date range search options
+        // https://github.com/SinergiaTIC/SinergiaCRM/pull/
+        'today' => 'Hoxe',
+        'yesterday' => 'Onte',
+        'tomorrow' => 'Mañá',
+        // END STIC Custom
         'last_7_days' => 'Últimos 7 días',
         'next_7_days' => 'Próximos 7 días',
         'last_30_days' => 'Últimos 30 días',


### PR DESCRIPTION
- Closes #1394 

## Descripción

Los filtros de búsqueda por rango de fechas en las vistas de lista no incluyen las opciones **Hoy, Ayer** ni **Mañana**. Estas opciones sí aparecen en los filtros de Dashlets, generando una inconsistencia y obligando al usuario a seleccionar manualmente la fecha con el calendario.

## Solución
Se añaden las opciones today, yesterday y tomorrow al dropdown date_range_search_dom en `custom/Extension/application/Ext/Language/*.stic_date_range_dom.php` y se habilitan en el motor de búsqueda `include/SearchForm/SearchForm2.php`

## Cómo probar
1. Ir a cualquier módulo con búsqueda por rango habilitada en campos fecha (ej. Personas → fecha de nacimiento)
2. Abrir la búsqueda avanzada
3. Verificar que en el dropdown del campo fecha aparecen las opciones Hoy, Ayer, Mañana
4. Seleccionar una y comprobar que filtra correctamente
