### PR TITLE
Hotfix - Importación - Evitar warnings al importar CSV en módulos con campos HTML

### DIFF
--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2548,7 +2548,11 @@ class SugarBean
                     $this->$key = trim($this->$key);
                 }
 
-                if (isset($def['type']) && ($def['type'] == 'html' || $def['type'] == 'longhtml')) {
+                // STIC-Custom 20260901 JCH - Avoid using property "key" if it is not set for html/longhtml fields
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/XXXX
+                // if (isset($def['type']) && ($def['type'] == 'html' || $def['type'] == 'longhtml')) {
+                if (isset($def['type']) && ($def['type'] == 'html' || $def['type'] == 'longhtml') && property_exists($this, $key)) {
+                // END STIC-Custom (JCH 20260901)
                     $this->$key = purify_html($this->$key, ['HTML.ForbiddenElements' => ['iframe' => true]]);
                 // STIC-Custom 20210326 jchg: Avoid cleaning html in email templates body to preserve content pasted from external sources
                 // STIC#607

--- a/data/SugarBean.php
+++ b/data/SugarBean.php
@@ -2549,7 +2549,7 @@ class SugarBean
                 }
 
                 // STIC-Custom 20260901 JCH - Avoid using property "key" if it is not set for html/longhtml fields
-                // https://github.com/SinergiaTIC/SinergiaCRM/pull/XXXX
+                // https://github.com/SinergiaTIC/SinergiaCRM/pull/1399
                 // if (isset($def['type']) && ($def['type'] == 'html' || $def['type'] == 'longhtml')) {
                 if (isset($def['type']) && ($def['type'] == 'html' || $def['type'] == 'longhtml') && property_exists($this, $key)) {
                 // END STIC-Custom (JCH 20260901)


### PR DESCRIPTION
- Closes #1398

## Descripción
Tal y como se describe en #1398, al importar un fichero CSV en un módulo con campos de tipo HTML se mostraban warnings por cada campo HTML, independientemente de si tenía valor o estaba vacío.

Los campos HTML tienen `source: 'non-db'` en sus vardefs, por lo que no son propiedades declaradas en la clase SugarBean. En `data/SugarBean.php`, método `cleanBean()`, se accedía a `$this->$key` para los campos `html`/`longhtml` sin verificar antes si la propiedad existía, generando el warning al acceder a una propiedad indefinida.

Se añade el guard `property_exists($this, $key)` siguiendo el mismo patrón ya aplicado a los campos `name`/`varchar` en la misma función (PR #470).

## Pruebas
1. Crear un campo HTML en un módulo.
2. Exportar un registro que incluya el campo HTML.
3. Importar el fichero CSV exportado.
4. Verificar que no se muestran warnings y que el registro se crea correctamente.