### PR TITLE
Fix signature placeholder not replaced when inside table in PDF template

### DIFF
--- a/modules/stic_Signatures/Utils.php
+++ b/modules/stic_Signatures/Utils.php
@@ -291,9 +291,11 @@ class stic_SignaturesUtils
      * and returns the resulting HTML header, content, and footer.
      *
      * @param string $signerId The ID of the signer.
+     * @param string|null $signatureImgSrc Optional signature image src URL. When provided, the signature
+     * placeholder is replaced before HTML cleaning so it survives the tag-stripping process.
      * @return array An associative array containing the parsed 'header', 'converted' (content), and 'footer'.
      */
-    public static function getParsedTemplate($signerId)
+    public static function getParsedTemplate($signerId, $signatureImgSrc = null)
     {
         require_once 'SticInclude/Utils.php';
         // Use common functions for PDF generation
@@ -372,6 +374,22 @@ class stic_SignaturesUtils
             "'",
             'chr(%1)',
         ];
+
+        if ($signatureImgSrc !== null) {
+            $encodedPlaceholder = '&lt;img class=&quot;signature&quot; src=&quot;themes/SuiteP/images/SignaturePlaceholder.png&quot; alt=&quot;&quot; width=&quot;200&quot; /&gt;';
+            $encodedSignatureImg = '&lt;img class=&quot;signature&quot; src=&quot;' . $signatureImgSrc . '&quot; width=&quot;200&quot; /&gt;';
+
+            $templateBean->pdfheader = str_replace($encodedPlaceholder, $encodedSignatureImg, (string) $templateBean->pdfheader);
+            $templateBean->pdffooter = str_replace($encodedPlaceholder, $encodedSignatureImg, (string) $templateBean->pdffooter);
+            $templateBean->description = str_replace($encodedPlaceholder, $encodedSignatureImg, (string) $templateBean->description);
+
+            $plainPlaceholder = '<img class="signature" src="themes/SuiteP/images/SignaturePlaceholder.png" alt="" width="200" />';
+            $plainSignatureImg = '<img class="signature" src="' . $signatureImgSrc . '" width="200" />';
+
+            $templateBean->pdfheader = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->pdfheader);
+            $templateBean->pdffooter = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->pdffooter);
+            $templateBean->description = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->description);
+        }
 
         // Clean the template content (header, footer, description)
         $header = preg_replace($search, $replace, $templateBean->pdfheader);

--- a/modules/stic_Signatures/Utils.php
+++ b/modules/stic_Signatures/Utils.php
@@ -293,9 +293,13 @@ class stic_SignaturesUtils
      * @param string $signerId The ID of the signer.
      * @param string|null $signatureImgSrc Optional signature image src URL. When provided, the signature
      * placeholder is replaced before HTML cleaning so it survives the tag-stripping process.
+     * @param string|null $appendHtml Optional HTML appended to the template description before HTML cleaning
+     * (e.g. the audit page). Appending it here (instead of modifying the template bean in the caller) makes
+     * the result independent of BeanFactory's in-memory bean cache, which can evict and re-fetch the
+     * template bean from the database, silently losing in-memory modifications.
      * @return array An associative array containing the parsed 'header', 'converted' (content), and 'footer'.
      */
-    public static function getParsedTemplate($signerId, $signatureImgSrc = null)
+    public static function getParsedTemplate($signerId, $signatureImgSrc = null, $appendHtml = null)
     {
         require_once 'SticInclude/Utils.php';
         // Use common functions for PDF generation
@@ -389,6 +393,13 @@ class stic_SignaturesUtils
             $templateBean->pdfheader = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->pdfheader);
             $templateBean->pdffooter = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->pdffooter);
             $templateBean->description = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->description);
+        }
+
+        // Append custom HTML (e.g. audit page) to the description, entity-encoded so it
+        // survives the tag-stripping regex below and is decoded back into real HTML tags
+        // by the entity-decoding patterns.
+        if ($appendHtml !== null) {
+            $templateBean->description .= htmlspecialchars($appendHtml);
         }
 
         // Clean the template content (header, footer, description)

--- a/modules/stic_Signatures/sticGenerateSignedPdf.php
+++ b/modules/stic_Signatures/sticGenerateSignedPdf.php
@@ -307,48 +307,32 @@ class sticGenerateSignedPdf
         }
         // END STIC-Custom 20240125
 
-        // Apply cleaning to header and footer
-        $header = preg_replace($search, $replace, (string) $templateBean->pdfheader);
-        $footer = preg_replace($search, $replace, (string) $templateBean->pdffooter);
-
-        // Final template parsing using the utility function, which handles advanced placeholders
-        $parsedText = stic_SignaturesUtils::getParsedTemplate($signerBean->id);
-        $converted = $parsedText['converted'];
-        $header = $parsedText['header'];
-        $footer = $parsedText['footer'];
-
-        // Replace the signature src with the actual signature image/acceptance image.
-        $stringToreplace = 'src="themes/SuiteP/images/SignaturePlaceholder.png"';
-
-        // Set time in user format and UTC for use later in audit/acceptance
+        // Determine the signature image URL based on signed mode
+        $signatureImgSrc = null;
         $userTime = (new DateTime())->format('Y-m-d H:i:s (\U\T\C P)');
-
-        $replaceWith = '';
-        // Prepare the replacement HTML based on the signed mode
         switch ($signedMode) {
             case 'handwritten':
-                // Use the drawn signature image URL from the signer bean
-                $replaceWith = 'src="' . $signerBean->signature_image . '";';
+                $signatureImgSrc = $signerBean->signature_image;
                 break;
             case 'button':
-                // Generate an acceptance image with signer details and timestamp
                 $textArray = [
-                    'Document accepted by:',
+                    $mod_strings['LBL_PORTAL_DOCUMENT_ACCEPTED_BY'],
                     $signerBean->parent_name,
                     $signerBean->email_address,
                     $userTime,
                 ];
-
-                $acceptImage = stic_SignaturesUtils::generateAcceptImage($textArray);
-                $replaceWith = 'src="' . $acceptImage . '";';
-                break;
-            default:
-                // Default case, no replacement
+                $signatureImgSrc = stic_SignaturesUtils::generateAcceptImage($textArray);
                 break;
         }
 
-        // Perform the replacement in the $text
-        $converted = str_replace($stringToreplace, $replaceWith, (string) $converted);
+        // Final template parsing with signature replacement handled inside getParsedTemplate.
+        // The signature image is passed so it is replaced BEFORE HTML cleaning, ensuring
+        // it survives the tag-stripping regex regardless of whether the template uses
+        // tables, plain HTML, or HTML-encoded placeholders.
+        $parsedText = stic_SignaturesUtils::getParsedTemplate($signerBean->id, $signatureImgSrc);
+        $converted = $parsedText['converted'];
+        $header = $parsedText['header'];
+        $footer = $parsedText['footer'];
 
         // Replace newlines with HTML line breaks for PDF generation
         $printable = str_replace("\n", "<br />", (string) $converted);

--- a/modules/stic_Signatures/sticGenerateSignedPdf.php
+++ b/modules/stic_Signatures/sticGenerateSignedPdf.php
@@ -143,51 +143,18 @@ class sticGenerateSignedPdf
             LoggerManager::getLogger()->warn('PDFException: ' . $e->getMessage());
         }
 
-        // Array for template parsing
-        $object_arr = [$sourceBean->module_dir => $sourceBean->id];
-
-        // Add related Accounts ID if the source is Contacts for backward compatibility
-        if ($sourceBean->module_dir === 'Contacts' && isset($sourceBean->account_id)) {
-            $object_arr['Accounts'] = $sourceBean->account_id;
-        }
-
-        // Replace the signature placeholder with the actual signature image/acceptance image.
-        // The placeholder string is HTML-encoded.
-        $stringToreplace = '&lt;img class=&quot;signature&quot; src=&quot;themes/SuiteP/images/SignaturePlaceholder.png&quot; alt=&quot;&quot; width=&quot;200&quot; /&gt;';
-
-        // Set time in user format and UTC for use later in audit/acceptance
+        // Set time in user format for use in the audit page and the acceptance image
         $userTime = (new DateTime())->format('Y-m-d H:i:s (\U\T\C P)');
-        $utcTime = (new DateTime('UTC'))->format('Y-m-d H:i:s P');
 
-        $replaceWith = '';
-        // Prepare the replacement HTML based on the signed mode
-        switch ($signedMode) {
-            case 'handwritten':
-                // Use the drawn signature image URL from the signer bean
-                $replaceWith = htmlspecialchars('<img class="signature" src="' . $signerBean->signature_image . '" width="200"></div>');
-                break;
-            case 'button':
-                // Generate an acceptance image with signer details and timestamp
-                $textArray = [
-                    $mod_strings['LBL_PORTAL_DOCUMENT_ACCEPTED_BY'],
-                    $signerBean->parent_name,
-                    $signerBean->email_address,
-                    $userTime,
-                    // $utcTime // UTC time is commented out but available
-                ];
+        // Build the audit page HTML if enabled. It is intentionally NOT appended here to the
+        // template bean description: BeanFactory's in-memory bean cache is limited (oldest beans
+        // are evicted), so the template bean can be re-fetched from the database inside
+        // getParsedTemplate, silently losing any in-memory modifications made here. The audit
+        // HTML is passed as a parameter instead, so it is appended inside getParsedTemplate
+        // after the template bean is loaded, independent of the cache state.
+        $auditHtml = null;
 
-                $acceptImage = stic_SignaturesUtils::generateAcceptImage($textArray);
-                $replaceWith = htmlspecialchars('<img class="signature" src="' . $acceptImage . '" width="200"></div>');
-                break;
-            default:
-                // Default case, no replacement
-                break;
-        }
-
-        // Perform the replacement in the template description
-        $templateBean->description = str_replace($stringToreplace, $replaceWith, (string) $templateBean->description);
-
-        // If 'pdf_audit_page' is enabled, append an audit page to the PDF content
+        // If 'pdf_audit_page' is enabled, build the audit page HTML to append to the PDF content
         if (!empty($signatureBean->pdf_audit_page) && $signatureBean->pdf_audit_page && $signedMode != 'unsigned') {
 
             // Get logs related to the signer
@@ -216,100 +183,13 @@ class sticGenerateSignedPdf
 
             $sugar_smarty->assign('SIGNER_LOG', $signerLog);
 
-            // Construct the audit HTML content
+            // Construct the audit HTML content (page break followed by the audit data)
             $auditHtml = '<p style="page-break-before: always;">&nbsp;</p>';
             $auditHtml .= $sugar_smarty->fetch('modules/stic_Signatures/AuditPageTemplate.tpl');
-
-            // Append the audit page HTML (encoded) to the template description
-            $templateBean->description .= htmlspecialchars($auditHtml);
         }
-
-        // HTML Cleaning and Replacement preparation
-        $search = [
-            '@<script[^>]*?>.*?</script>@si', // Strip out javascript
-            '@<[\/\!]*?[^<>]*?>@si', // Strip out HTML tags
-            '@([\r\n])[\s]+@', // Strip out white space
-            '@&(quot|#34);@i', // Replace HTML entities
-            '@&(amp|#38);@i',
-            '@&(lt|#60);@i',
-            '@&(gt|#62);@i',
-            '@&(nbsp|#160);@i',
-            '@&(iexcl|#161);@i',
-            '@<address[^>]*?>@si',
-        ];
-
-        $replace = [
-            '',
-            '',
-            '\1',
-            '"',
-            '&',
-            '<',
-            '>',
-            ' ',
-            chr(161),
-            '<br>',
-        ];
-
-        // Apply initial cleaning to the description
-        $text = preg_replace($search, $replace, (string) $templateBean->description);
-
-        // Replace {DATE <format>} placeholders with the current date
-        $text = preg_replace_callback(
-            '/{DATE\s+(.*?)}/',
-            function ($matches) {
-                return date($matches[1]);
-            },
-            $text
-        );
-
-        // STIC-Custom 20240125 JBL - Product line items in pdf
-        // Handle AOS (Advanced OpenSales) specific modules for line items
-        if (str_starts_with($sourceModule, "AOS_")) {
-            $variableName = strtolower($sourceBean->module_dir);
-            $lineItemsGroups = [];
-            $lineItems = [];
-
-            // Query to fetch line items and groups
-            $sql = "SELECT pg.id, pg.product_id, pg.group_id FROM aos_products_quotes pg LEFT JOIN aos_line_item_groups lig ON pg.group_id = lig.id WHERE pg.parent_type = '" . $sourceBean->object_name . "' AND pg->parent_id = '" . $sourceBean->id . "' AND pg->deleted = 0 ORDER BY lig.number ASC, pg.number ASC";
-            $res = $sourceBean->db->query($sql);
-            while ($row = $sourceBean->db->fetchByAssoc($res)) {
-                $lineItemsGroups[$row['group_id']][$row['id']] = $row['product_id'];
-                $lineItems[$row['id']] = $row['product_id'];
-            }
-
-            // Backward compatibility for related beans in AOS modules
-            if (isset($sourceBean->billing_account_id)) {
-                $object_arr['Accounts'] = $sourceBean->billing_account_id;
-            }
-            if (isset($sourceBean->billing_contact_id)) {
-                $object_arr['Contacts'] = $sourceBean->billing_contact_id;
-            }
-            if (isset($sourceBean->assigned_user_id)) {
-                $object_arr['Users'] = $sourceBean->assigned_user_id;
-            }
-            if (isset($sourceBean->currency_id)) {
-                $object_arr['Currencies'] = $sourceBean->currency_id;
-            }
-
-            // Replace specific AOS variables with dynamic ones
-            $text = str_replace("\$aos_quotes", "\$" . $variableName, $text);
-            $text = str_replace("\$aos_invoices", "\$" . $variableName, $text);
-            $text = str_replace("\$total_amt", "\$" . $variableName . "_total_amt", $text);
-            $text = str_replace("\$discount_amount", "\$" . $variableName . "_discount_amount", $text);
-            $text = str_replace("\$subtotal_amount", "\$" . $variableName . "_subtotal_amount", $text);
-            $text = str_replace("\$tax_amount", "\$" . $variableName . "_tax_amount", $text);
-            $text = str_replace("\$shipping_amount", "\$" . $variableName . "_shipping_amount", $text);
-            $text = str_replace("\$total_amount", "\$" . $variableName . "_total_amount", $text);
-
-            // Populate group lines (products/services) in the template
-            $text = populate_group_lines($text, $lineItemsGroups, $lineItems);
-        }
-        // END STIC-Custom 20240125
 
         // Determine the signature image URL based on signed mode
         $signatureImgSrc = null;
-        $userTime = (new DateTime())->format('Y-m-d H:i:s (\U\T\C P)');
         switch ($signedMode) {
             case 'handwritten':
                 $signatureImgSrc = $signerBean->signature_image;
@@ -326,10 +206,12 @@ class sticGenerateSignedPdf
         }
 
         // Final template parsing with signature replacement handled inside getParsedTemplate.
-        // The signature image is passed so it is replaced BEFORE HTML cleaning, ensuring
-        // it survives the tag-stripping regex regardless of whether the template uses
-        // tables, plain HTML, or HTML-encoded placeholders.
-        $parsedText = stic_SignaturesUtils::getParsedTemplate($signerBean->id, $signatureImgSrc);
+        // The signature image and the audit page HTML are passed as parameters so all
+        // replacements and appends happen inside getParsedTemplate, on the template bean
+        // it loads itself, BEFORE HTML cleaning. This ensures they survive the tag-stripping
+        // process regardless of whether the template stores placeholders as plain HTML or
+        // HTML-encoded, and regardless of the state of BeanFactory's in-memory bean cache.
+        $parsedText = stic_SignaturesUtils::getParsedTemplate($signerBean->id, $signatureImgSrc, $auditHtml);
         $converted = $parsedText['converted'];
         $header = $parsedText['header'];
         $footer = $parsedText['footer'];


### PR DESCRIPTION
## Descripción

Corrige el problema por el cual el marcador de firma en las plantillas PDF no se sustituye por la imagen de firma real cuando el marcador está dentro de una `<table>`, causando también la pérdida de la página de auditoría en los PDF firmados generados.

## Problema

Cuando el marcador de firma está dentro de una tabla en la plantilla PDF, **dos síntomas** aparecen simultáneamente en el PDF firmado:
1. La imagen de firma real no se muestra (el marcador queda como espacio en blanco)
2. La página de auditoría no aparece

**Causa raíz:** El mecanismo antiguo en `sticGenerateSignedPdf` realizaba la sustitución del marcador y el añadido de la auditoría **en memoria** sobre el bean de plantilla, y luego llamaba a `getParsedTemplate()` que **recargaba el bean desde la base de datos** vía `BeanFactory` (caché limitado a 10 beans — los más antiguos se desalojan). Esto hacía que las modificaciones en memoria se perdieran silenciosamente.

Además, el marcador dentro de tablas se almacena con un nivel de codificación diferente (HTML-encoded por CKEditor), y la sustitución antigua solo gestionaba una variante. El atributo `src` generado también contenía un punto y coma final malformado.

**Nota:** Cuando el marcador estaba fuera de la tabla, el reemplazo funcionaba y la auditoría se mostraba correctamente — confirmando que ambos síntomas compartían la misma causa.

## Solución

Todas las modificaciones de la plantilla se realizan dentro de `getParsedTemplate()`, sobre el bean que ella misma carga, **antes de la limpieza HTML** — haciendo el resultado determinista e independiente del estado del caché de BeanFactory:

1. **`Utils.php` — `getParsedTemplate($signerId, $signatureImgSrc = null, $appendHtml = null)`**
   - Imagen de firma: sustituye ambas variantes del marcador (HTML simple y codificado con entidades) antes de la limpieza (codificada con entidades para que sobreviva a la eliminación de etiquetas)
   - Página de auditoría: nuevo parámetro `$appendHtml` — se añade a la descripción después de cargar el bean, codificado con entidades para que sobreviva a la limpieza y sea decodificado de vuelta a HTML real
2. **`sticGenerateSignedPdf.php`**
   - Calcula la URL de la imagen de firma y el HTML de la página de auditoría y pasa ambos a `getParsedTemplate()`
   - Eliminado el bloque muerto de cálculo de `$text` en memoria (su salida siempre era descartada por la llamada a `getParsedTemplate()` — incluso antes de este PR)
   - Eliminada la sustitución en memoria no fiable del marcador codificado
   - Corregido el atributo `src` malformado (`;` sobrante)

## Cambios

| Archivo | Cambio |
|---------|--------|
| `modules/stic_Signatures/Utils.php` | `getParsedTemplate()` acepta `$signatureImgSrc` + `$appendHtml`; sustitución pre-limpieza para ambos formatos de marcador; añadido de auditoría |
| `modules/stic_Signatures/sticGenerateSignedPdf.php` | Pasa URL de firma + HTML de auditoría; eliminadas ~120 líneas de código muerto/no fiable |

## Seguridad

- `getParsedTemplate()` solo se llama desde el módulo de firmas (la previsualización del portal no pasa parámetros extra — comportamiento sin cambios)
- Los nuevos parámetros son opcionales — `SignaturePortalUtils::getHtmlFromSigner()` no se ve afectado
- Sin cambios en el proceso de limpieza HTML ni en la generación general de PDF (`SticGeneratePdf`)

## Verificación (end-to-end con datos reales)

- El PDF contiene todo el contenido de la plantilla (texto + estructura de tabla decodificada del almacenamiento con entidades)
- Todos los marcadores de firma sustituidos (3/3) y renderizados como imágenes visibles (imagen+smask, posición/tamaño correctos)
- Página de auditoría presente en la página 2 con los datos del firmante y el registro de eventos completo
- Desalojo del caché de BeanFactory reproducido y verificado que la nueva solución lo evita (bisección basada en marcadores)

Cierra #1401