### PR TITLE
Hotfix - Firmas - Error al incluir imagen de firma si está dentro de una tabla.

### DIFF
--- a/modules/stic_Signatures/SignaturePortal/SignaturePortalUtils.php
+++ b/modules/stic_Signatures/SignaturePortal/SignaturePortalUtils.php
@@ -116,6 +116,16 @@ class stic_SignaturePortalUtils
         require_once 'modules/stic_Signatures/Utils.php';
         $parsedText = stic_SignaturesUtils::getParsedTemplate($this->signerId);
         $html = "{$parsedText['header']}{$parsedText['converted']}{$parsedText['footer']}";
+        // The signature marker was normalized to a plain-text token inside
+        // stic_SignaturesUtils::getParsedTemplate() so it survives the HTML
+        // cleaning pipeline. In the portal preview (before signing) we replace
+        // that token with the placeholder image so the signer sees where the
+        // signature will be placed.
+        $html = str_replace(
+            stic_SignaturesUtils::SIGNATURE_TOKEN,
+            '<img class="signature" src="themes/SuiteP/images/SignaturePlaceholder.png" alt="" width="200" />',
+            (string) $html
+        );
         if (!empty($html)) {
             return $html;
         } else {

--- a/modules/stic_Signatures/Utils.php
+++ b/modules/stic_Signatures/Utils.php
@@ -291,9 +291,11 @@ class stic_SignaturesUtils
      * and returns the resulting HTML header, content, and footer.
      *
      * @param string $signerId The ID of the signer.
+     * @param string|null $signatureImgSrc Optional signature image src URL. When provided, the signature
+     * placeholder is replaced before HTML cleaning so it survives the tag-stripping process.
      * @return array An associative array containing the parsed 'header', 'converted' (content), and 'footer'.
      */
-    public static function getParsedTemplate($signerId)
+    public static function getParsedTemplate($signerId, $signatureImgSrc = null)
     {
         require_once 'SticInclude/Utils.php';
         // Use common functions for PDF generation
@@ -372,6 +374,22 @@ class stic_SignaturesUtils
             "'",
             'chr(%1)',
         ];
+
+        if ($signatureImgSrc !== null) {
+            $encodedPlaceholder = '&lt;img class=&quot;signature&quot; src=&quot;themes/SuiteP/images/SignaturePlaceholder.png&quot; alt=&quot;&quot; width=&quot;200&quot; /&gt;';
+            $encodedSignatureImg = '&lt;img class=&quot;signature&quot; src=&quot;' . $signatureImgSrc . '&quot; width=&quot;200&quot; /&gt;';
+
+            $templateBean->pdfheader = str_replace($encodedPlaceholder, $encodedSignatureImg, (string) $templateBean->pdfheader);
+            $templateBean->pdffooter = str_replace($encodedPlaceholder, $encodedSignatureImg, (string) $templateBean->pdffooter);
+            $templateBean->description = str_replace($encodedPlaceholder, $encodedSignatureImg, (string) $templateBean->description);
+
+            $plainPlaceholder = '<img class="signature" src="themes/SuiteP/images/SignaturePlaceholder.png" alt="" width="200" />';
+            $plainSignatureImg = '<img class="signature" src="' . $signatureImgSrc . '" width="200" />';
+
+            $templateBean->pdfheader = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->pdfheader);
+            $templateBean->pdffooter = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->pdffooter);
+            $templateBean->description = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->description);
+        }
 
         // Clean the template content (header, footer, description)
         $header = preg_replace($search, $replace, $templateBean->pdfheader);

--- a/modules/stic_Signatures/Utils.php
+++ b/modules/stic_Signatures/Utils.php
@@ -293,9 +293,13 @@ class stic_SignaturesUtils
      * @param string $signerId The ID of the signer.
      * @param string|null $signatureImgSrc Optional signature image src URL. When provided, the signature
      * placeholder is replaced before HTML cleaning so it survives the tag-stripping process.
+     * @param string|null $appendHtml Optional HTML appended to the template description before HTML cleaning
+     * (e.g. the audit page). Appending it here (instead of modifying the template bean in the caller) makes
+     * the result independent of BeanFactory's in-memory bean cache, which can evict and re-fetch the
+     * template bean from the database, silently losing in-memory modifications.
      * @return array An associative array containing the parsed 'header', 'converted' (content), and 'footer'.
      */
-    public static function getParsedTemplate($signerId, $signatureImgSrc = null)
+    public static function getParsedTemplate($signerId, $signatureImgSrc = null, $appendHtml = null)
     {
         require_once 'SticInclude/Utils.php';
         // Use common functions for PDF generation
@@ -389,6 +393,13 @@ class stic_SignaturesUtils
             $templateBean->pdfheader = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->pdfheader);
             $templateBean->pdffooter = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->pdffooter);
             $templateBean->description = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->description);
+        }
+
+        // Append custom HTML (e.g. audit page) to the description, entity-encoded so it
+        // survives the tag-stripping regex below and is decoded back into real HTML tags
+        // by the entity-decoding patterns.
+        if ($appendHtml !== null) {
+            $templateBean->description .= htmlspecialchars($appendHtml);
         }
 
         // Clean the template content (header, footer, description)

--- a/modules/stic_Signatures/Utils.php
+++ b/modules/stic_Signatures/Utils.php
@@ -29,6 +29,14 @@
 class stic_SignaturesUtils
 {
     /**
+     * Plain-text token used as a safe placeholder for the signature marker.
+     * It replaces the raw <img> marker before the HTML cleaning pipeline so that
+     * it survives the tag-stripping regexes, and is later replaced by the real
+     * signature image after the template is parsed.
+     */
+    const SIGNATURE_TOKEN = '@@SIGNATURE_IMAGE@@';
+
+    /**
      * Retrieves the relationships and fields for a given SuiteCRM module.
      * This function fetches a module's own reportable fields and also
      * identifies and lists reportable fields from related modules.
@@ -291,15 +299,9 @@ class stic_SignaturesUtils
      * and returns the resulting HTML header, content, and footer.
      *
      * @param string $signerId The ID of the signer.
-     * @param string|null $signatureImgSrc Optional signature image src URL. When provided, the signature
-     * placeholder is replaced before HTML cleaning so it survives the tag-stripping process.
-     * @param string|null $appendHtml Optional HTML appended to the template description before HTML cleaning
-     * (e.g. the audit page). Appending it here (instead of modifying the template bean in the caller) makes
-     * the result independent of BeanFactory's in-memory bean cache, which can evict and re-fetch the
-     * template bean from the database, silently losing in-memory modifications.
      * @return array An associative array containing the parsed 'header', 'converted' (content), and 'footer'.
      */
-    public static function getParsedTemplate($signerId, $signatureImgSrc = null, $appendHtml = null)
+    public static function getParsedTemplate($signerId)
     {
         require_once 'SticInclude/Utils.php';
         // Use common functions for PDF generation
@@ -379,28 +381,18 @@ class stic_SignaturesUtils
             'chr(%1)',
         ];
 
-        if ($signatureImgSrc !== null) {
-            $encodedPlaceholder = '&lt;img class=&quot;signature&quot; src=&quot;themes/SuiteP/images/SignaturePlaceholder.png&quot; alt=&quot;&quot; width=&quot;200&quot; /&gt;';
-            $encodedSignatureImg = '&lt;img class=&quot;signature&quot; src=&quot;' . $signatureImgSrc . '&quot; width=&quot;200&quot; /&gt;';
-
-            $templateBean->pdfheader = str_replace($encodedPlaceholder, $encodedSignatureImg, (string) $templateBean->pdfheader);
-            $templateBean->pdffooter = str_replace($encodedPlaceholder, $encodedSignatureImg, (string) $templateBean->pdffooter);
-            $templateBean->description = str_replace($encodedPlaceholder, $encodedSignatureImg, (string) $templateBean->description);
-
-            $plainPlaceholder = '<img class="signature" src="themes/SuiteP/images/SignaturePlaceholder.png" alt="" width="200" />';
-            $plainSignatureImg = '<img class="signature" src="' . $signatureImgSrc . '" width="200" />';
-
-            $templateBean->pdfheader = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->pdfheader);
-            $templateBean->pdffooter = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->pdffooter);
-            $templateBean->description = str_replace($plainPlaceholder, htmlspecialchars($plainSignatureImg), (string) $templateBean->description);
-        }
-
-        // Append custom HTML (e.g. audit page) to the description, entity-encoded so it
-        // survives the tag-stripping regex below and is decoded back into real HTML tags
-        // by the entity-decoding patterns.
-        if ($appendHtml !== null) {
-            $templateBean->description .= htmlspecialchars($appendHtml);
-        }
+        // Normalize every possible representation of the signature marker to a
+        // plain-text token BEFORE the HTML cleaning pipeline. This way the marker
+        // survives the tag-stripping regexes even when it is placed inside a table,
+        // and can be replaced by the real signature image after the template is parsed.
+        $signatureToken = self::SIGNATURE_TOKEN;
+        $signatureMarkers = [
+            '&lt;img class=&quot;signature&quot; src=&quot;themes/SuiteP/images/SignaturePlaceholder.png&quot; alt=&quot;&quot; width=&quot;200&quot; /&gt;',
+            '<img class="signature" src="themes/SuiteP/images/SignaturePlaceholder.png" alt="" width="200" />',
+        ];
+        $templateBean->pdfheader = str_replace($signatureMarkers, $signatureToken, (string) $templateBean->pdfheader);
+        $templateBean->pdffooter = str_replace($signatureMarkers, $signatureToken, (string) $templateBean->pdffooter);
+        $templateBean->description = str_replace($signatureMarkers, $signatureToken, (string) $templateBean->description);
 
         // Clean the template content (header, footer, description)
         $header = preg_replace($search, $replace, $templateBean->pdfheader);

--- a/modules/stic_Signatures/sticGenerateSignedPdf.php
+++ b/modules/stic_Signatures/sticGenerateSignedPdf.php
@@ -307,48 +307,32 @@ class sticGenerateSignedPdf
         }
         // END STIC-Custom 20240125
 
-        // Apply cleaning to header and footer
-        $header = preg_replace($search, $replace, (string) $templateBean->pdfheader);
-        $footer = preg_replace($search, $replace, (string) $templateBean->pdffooter);
-
-        // Final template parsing using the utility function, which handles advanced placeholders
-        $parsedText = stic_SignaturesUtils::getParsedTemplate($signerBean->id);
-        $converted = $parsedText['converted'];
-        $header = $parsedText['header'];
-        $footer = $parsedText['footer'];
-
-        // Replace the signature src with the actual signature image/acceptance image.
-        $stringToreplace = 'src="themes/SuiteP/images/SignaturePlaceholder.png"';
-
-        // Set time in user format and UTC for use later in audit/acceptance
+        // Determine the signature image URL based on signed mode
+        $signatureImgSrc = null;
         $userTime = (new DateTime())->format('Y-m-d H:i:s (\U\T\C P)');
-
-        $replaceWith = '';
-        // Prepare the replacement HTML based on the signed mode
         switch ($signedMode) {
             case 'handwritten':
-                // Use the drawn signature image URL from the signer bean
-                $replaceWith = 'src="' . $signerBean->signature_image . '";';
+                $signatureImgSrc = $signerBean->signature_image;
                 break;
             case 'button':
-                // Generate an acceptance image with signer details and timestamp
                 $textArray = [
-                    'Document accepted by:',
+                    $mod_strings['LBL_PORTAL_DOCUMENT_ACCEPTED_BY'],
                     $signerBean->parent_name,
                     $signerBean->email_address,
                     $userTime,
                 ];
-
-                $acceptImage = stic_SignaturesUtils::generateAcceptImage($textArray);
-                $replaceWith = 'src="' . $acceptImage . '";';
-                break;
-            default:
-                // Default case, no replacement
+                $signatureImgSrc = stic_SignaturesUtils::generateAcceptImage($textArray);
                 break;
         }
 
-        // Perform the replacement in the $text
-        $converted = str_replace($stringToreplace, $replaceWith, (string) $converted);
+        // Final template parsing with signature replacement handled inside getParsedTemplate.
+        // The signature image is passed so it is replaced BEFORE HTML cleaning, ensuring
+        // it survives the tag-stripping regex regardless of whether the template uses
+        // tables, plain HTML, or HTML-encoded placeholders.
+        $parsedText = stic_SignaturesUtils::getParsedTemplate($signerBean->id, $signatureImgSrc);
+        $converted = $parsedText['converted'];
+        $header = $parsedText['header'];
+        $footer = $parsedText['footer'];
 
         // Replace newlines with HTML line breaks for PDF generation
         $printable = str_replace("\n", "<br />", (string) $converted);

--- a/modules/stic_Signatures/sticGenerateSignedPdf.php
+++ b/modules/stic_Signatures/sticGenerateSignedPdf.php
@@ -143,51 +143,18 @@ class sticGenerateSignedPdf
             LoggerManager::getLogger()->warn('PDFException: ' . $e->getMessage());
         }
 
-        // Array for template parsing
-        $object_arr = [$sourceBean->module_dir => $sourceBean->id];
-
-        // Add related Accounts ID if the source is Contacts for backward compatibility
-        if ($sourceBean->module_dir === 'Contacts' && isset($sourceBean->account_id)) {
-            $object_arr['Accounts'] = $sourceBean->account_id;
-        }
-
-        // Replace the signature placeholder with the actual signature image/acceptance image.
-        // The placeholder string is HTML-encoded.
-        $stringToreplace = '&lt;img class=&quot;signature&quot; src=&quot;themes/SuiteP/images/SignaturePlaceholder.png&quot; alt=&quot;&quot; width=&quot;200&quot; /&gt;';
-
-        // Set time in user format and UTC for use later in audit/acceptance
+        // Set time in user format for use in the audit page and the acceptance image
         $userTime = (new DateTime())->format('Y-m-d H:i:s (\U\T\C P)');
-        $utcTime = (new DateTime('UTC'))->format('Y-m-d H:i:s P');
 
-        $replaceWith = '';
-        // Prepare the replacement HTML based on the signed mode
-        switch ($signedMode) {
-            case 'handwritten':
-                // Use the drawn signature image URL from the signer bean
-                $replaceWith = htmlspecialchars('<img class="signature" src="' . $signerBean->signature_image . '" width="200"></div>');
-                break;
-            case 'button':
-                // Generate an acceptance image with signer details and timestamp
-                $textArray = [
-                    $mod_strings['LBL_PORTAL_DOCUMENT_ACCEPTED_BY'],
-                    $signerBean->parent_name,
-                    $signerBean->email_address,
-                    $userTime,
-                    // $utcTime // UTC time is commented out but available
-                ];
+        // Build the audit page HTML if enabled. It is intentionally NOT appended here to the
+        // template bean description: BeanFactory's in-memory bean cache is limited (oldest beans
+        // are evicted), so the template bean can be re-fetched from the database inside
+        // getParsedTemplate, silently losing any in-memory modifications made here. The audit
+        // HTML is passed as a parameter instead, so it is appended inside getParsedTemplate
+        // after the template bean is loaded, independent of the cache state.
+        $auditHtml = null;
 
-                $acceptImage = stic_SignaturesUtils::generateAcceptImage($textArray);
-                $replaceWith = htmlspecialchars('<img class="signature" src="' . $acceptImage . '" width="200"></div>');
-                break;
-            default:
-                // Default case, no replacement
-                break;
-        }
-
-        // Perform the replacement in the template description
-        $templateBean->description = str_replace($stringToreplace, $replaceWith, (string) $templateBean->description);
-
-        // If 'pdf_audit_page' is enabled, append an audit page to the PDF content
+        // If 'pdf_audit_page' is enabled, build the audit page HTML to append to the PDF content
         if (!empty($signatureBean->pdf_audit_page) && $signatureBean->pdf_audit_page && $signedMode != 'unsigned') {
 
             // Get logs related to the signer
@@ -216,100 +183,13 @@ class sticGenerateSignedPdf
 
             $sugar_smarty->assign('SIGNER_LOG', $signerLog);
 
-            // Construct the audit HTML content
+            // Construct the audit HTML content (page break followed by the audit data)
             $auditHtml = '<p style="page-break-before: always;">&nbsp;</p>';
             $auditHtml .= $sugar_smarty->fetch('modules/stic_Signatures/AuditPageTemplate.tpl');
-
-            // Append the audit page HTML (encoded) to the template description
-            $templateBean->description .= htmlspecialchars($auditHtml);
         }
-
-        // HTML Cleaning and Replacement preparation
-        $search = [
-            '@<script[^>]*?>.*?</script>@si', // Strip out javascript
-            '@<[\/\!]*?[^<>]*?>@si', // Strip out HTML tags
-            '@([\r\n])[\s]+@', // Strip out white space
-            '@&(quot|#34);@i', // Replace HTML entities
-            '@&(amp|#38);@i',
-            '@&(lt|#60);@i',
-            '@&(gt|#62);@i',
-            '@&(nbsp|#160);@i',
-            '@&(iexcl|#161);@i',
-            '@<address[^>]*?>@si',
-        ];
-
-        $replace = [
-            '',
-            '',
-            '\1',
-            '"',
-            '&',
-            '<',
-            '>',
-            ' ',
-            chr(161),
-            '<br>',
-        ];
-
-        // Apply initial cleaning to the description
-        $text = preg_replace($search, $replace, (string) $templateBean->description);
-
-        // Replace {DATE <format>} placeholders with the current date
-        $text = preg_replace_callback(
-            '/{DATE\s+(.*?)}/',
-            function ($matches) {
-                return date($matches[1]);
-            },
-            $text
-        );
-
-        // STIC-Custom 20240125 JBL - Product line items in pdf
-        // Handle AOS (Advanced OpenSales) specific modules for line items
-        if (str_starts_with($sourceModule, "AOS_")) {
-            $variableName = strtolower($sourceBean->module_dir);
-            $lineItemsGroups = [];
-            $lineItems = [];
-
-            // Query to fetch line items and groups
-            $sql = "SELECT pg.id, pg.product_id, pg.group_id FROM aos_products_quotes pg LEFT JOIN aos_line_item_groups lig ON pg.group_id = lig.id WHERE pg.parent_type = '" . $sourceBean->object_name . "' AND pg->parent_id = '" . $sourceBean->id . "' AND pg->deleted = 0 ORDER BY lig.number ASC, pg.number ASC";
-            $res = $sourceBean->db->query($sql);
-            while ($row = $sourceBean->db->fetchByAssoc($res)) {
-                $lineItemsGroups[$row['group_id']][$row['id']] = $row['product_id'];
-                $lineItems[$row['id']] = $row['product_id'];
-            }
-
-            // Backward compatibility for related beans in AOS modules
-            if (isset($sourceBean->billing_account_id)) {
-                $object_arr['Accounts'] = $sourceBean->billing_account_id;
-            }
-            if (isset($sourceBean->billing_contact_id)) {
-                $object_arr['Contacts'] = $sourceBean->billing_contact_id;
-            }
-            if (isset($sourceBean->assigned_user_id)) {
-                $object_arr['Users'] = $sourceBean->assigned_user_id;
-            }
-            if (isset($sourceBean->currency_id)) {
-                $object_arr['Currencies'] = $sourceBean->currency_id;
-            }
-
-            // Replace specific AOS variables with dynamic ones
-            $text = str_replace("\$aos_quotes", "\$" . $variableName, $text);
-            $text = str_replace("\$aos_invoices", "\$" . $variableName, $text);
-            $text = str_replace("\$total_amt", "\$" . $variableName . "_total_amt", $text);
-            $text = str_replace("\$discount_amount", "\$" . $variableName . "_discount_amount", $text);
-            $text = str_replace("\$subtotal_amount", "\$" . $variableName . "_subtotal_amount", $text);
-            $text = str_replace("\$tax_amount", "\$" . $variableName . "_tax_amount", $text);
-            $text = str_replace("\$shipping_amount", "\$" . $variableName . "_shipping_amount", $text);
-            $text = str_replace("\$total_amount", "\$" . $variableName . "_total_amount", $text);
-
-            // Populate group lines (products/services) in the template
-            $text = populate_group_lines($text, $lineItemsGroups, $lineItems);
-        }
-        // END STIC-Custom 20240125
 
         // Determine the signature image URL based on signed mode
         $signatureImgSrc = null;
-        $userTime = (new DateTime())->format('Y-m-d H:i:s (\U\T\C P)');
         switch ($signedMode) {
             case 'handwritten':
                 $signatureImgSrc = $signerBean->signature_image;
@@ -326,10 +206,12 @@ class sticGenerateSignedPdf
         }
 
         // Final template parsing with signature replacement handled inside getParsedTemplate.
-        // The signature image is passed so it is replaced BEFORE HTML cleaning, ensuring
-        // it survives the tag-stripping regex regardless of whether the template uses
-        // tables, plain HTML, or HTML-encoded placeholders.
-        $parsedText = stic_SignaturesUtils::getParsedTemplate($signerBean->id, $signatureImgSrc);
+        // The signature image and the audit page HTML are passed as parameters so all
+        // replacements and appends happen inside getParsedTemplate, on the template bean
+        // it loads itself, BEFORE HTML cleaning. This ensures they survive the tag-stripping
+        // process regardless of whether the template stores placeholders as plain HTML or
+        // HTML-encoded, and regardless of the state of BeanFactory's in-memory bean cache.
+        $parsedText = stic_SignaturesUtils::getParsedTemplate($signerBean->id, $signatureImgSrc, $auditHtml);
         $converted = $parsedText['converted'];
         $header = $parsedText['header'];
         $footer = $parsedText['footer'];

--- a/modules/stic_Signatures/sticGenerateSignedPdf.php
+++ b/modules/stic_Signatures/sticGenerateSignedPdf.php
@@ -143,18 +143,11 @@ class sticGenerateSignedPdf
             LoggerManager::getLogger()->warn('PDFException: ' . $e->getMessage());
         }
 
-        // Set time in user format for use in the audit page and the acceptance image
+        // Set time in user format and UTC for use later in audit/acceptance
         $userTime = (new DateTime())->format('Y-m-d H:i:s (\U\T\C P)');
+        $utcTime = (new DateTime('UTC'))->format('Y-m-d H:i:s P');
 
-        // Build the audit page HTML if enabled. It is intentionally NOT appended here to the
-        // template bean description: BeanFactory's in-memory bean cache is limited (oldest beans
-        // are evicted), so the template bean can be re-fetched from the database inside
-        // getParsedTemplate, silently losing any in-memory modifications made here. The audit
-        // HTML is passed as a parameter instead, so it is appended inside getParsedTemplate
-        // after the template bean is loaded, independent of the cache state.
-        $auditHtml = null;
-
-        // If 'pdf_audit_page' is enabled, build the audit page HTML to append to the PDF content
+        // If 'pdf_audit_page' is enabled, append an audit page to the PDF content
         if (!empty($signatureBean->pdf_audit_page) && $signatureBean->pdf_audit_page && $signedMode != 'unsigned') {
 
             // Get logs related to the signer
@@ -183,38 +176,54 @@ class sticGenerateSignedPdf
 
             $sugar_smarty->assign('SIGNER_LOG', $signerLog);
 
-            // Construct the audit HTML content (page break followed by the audit data)
+            // Construct the audit HTML content
             $auditHtml = '<p style="page-break-before: always;">&nbsp;</p>';
             $auditHtml .= $sugar_smarty->fetch('modules/stic_Signatures/AuditPageTemplate.tpl');
+
+            // Append the audit page HTML (encoded) to the template description
+            $templateBean->description .= htmlspecialchars($auditHtml);
         }
 
-        // Determine the signature image URL based on signed mode
-        $signatureImgSrc = null;
+        // Determine the signature image HTML based on signed mode. The signature
+        // marker is normalized to a plain-text token inside
+        // stic_SignaturesUtils::getParsedTemplate() (before the HTML cleaning
+        // pipeline), so this replacement is applied AFTER the template is parsed.
+        // Note: no closing </div> is appended, as an unmatched </div> makes TCPDF
+        // drop the rest of the document when the signature is inside a table cell.
+        $replaceWith = '';
         switch ($signedMode) {
             case 'handwritten':
-                $signatureImgSrc = $signerBean->signature_image;
+                // Use the drawn signature image URL from the signer bean
+                $replaceWith = '<img class="signature" src="' . $signerBean->signature_image . '" width="200">';
                 break;
             case 'button':
+                // Generate an acceptance image with signer details and timestamp
                 $textArray = [
                     $mod_strings['LBL_PORTAL_DOCUMENT_ACCEPTED_BY'],
                     $signerBean->parent_name,
                     $signerBean->email_address,
                     $userTime,
                 ];
-                $signatureImgSrc = stic_SignaturesUtils::generateAcceptImage($textArray);
+                $acceptImage = stic_SignaturesUtils::generateAcceptImage($textArray);
+                $replaceWith = '<img class="signature" src="' . $acceptImage . '" width="200">';
+                break;
+            default:
+                // Default case, no replacement
                 break;
         }
 
-        // Final template parsing with signature replacement handled inside getParsedTemplate.
-        // The signature image and the audit page HTML are passed as parameters so all
-        // replacements and appends happen inside getParsedTemplate, on the template bean
-        // it loads itself, BEFORE HTML cleaning. This ensures they survive the tag-stripping
-        // process regardless of whether the template stores placeholders as plain HTML or
-        // HTML-encoded, and regardless of the state of BeanFactory's in-memory bean cache.
-        $parsedText = stic_SignaturesUtils::getParsedTemplate($signerBean->id, $signatureImgSrc, $auditHtml);
+        // Final template parsing using the utility function, which handles
+        // advanced placeholders.
+        $parsedText = stic_SignaturesUtils::getParsedTemplate($signerBean->id);
         $converted = $parsedText['converted'];
         $header = $parsedText['header'];
         $footer = $parsedText['footer'];
+
+        // Replace the plain-text signature token with the actual signature
+        // image/acceptance image. The token survived the HTML cleaning pipeline,
+        // so this replacement works regardless of whether the marker was inside
+        // a table or not.
+        $converted = str_replace(stic_SignaturesUtils::SIGNATURE_TOKEN, $replaceWith, (string) $converted);
 
         // Replace newlines with HTML line breaks for PDF generation
         $printable = str_replace("\n", "<br />", (string) $converted);


### PR DESCRIPTION
## Descripción

Corrige el error por el cual la imagen de firma no se muestra (ni el contenido posterior) cuando el marcador de firma está dentro de una `<table>` en la plantilla PDF de un proceso de firmas.

## Problema

Cuando el marcador de firma se colocaba dentro de una tabla HTML en la plantilla, el PDF firmado presentaba **dos síntomas**:

1. La imagen de firma real no se mostraba (el marcador desaparecía).
2. Todo el contenido posterior al marcador se perdía (la tabla y el texto siguiente no aparecían).

**Causa raíz:** dos problemas encadenados:

- **El marcador de firma se destruía en la limpieza HTML.** La plantilla guarda el marcador como una etiqueta `<img class="signature" ...>`. Antes de generar el PDF, el pipeline de limpieza elimina todas las etiquetas HTML, por lo que el marcador se borraba y la sustitución por la imagen real no encontraba nada que reemplazar (especialmente cuando estaba dentro de una tabla).
- **Un `</div>` huérfano rompía el renderizado con TCPDF.** El HTML de sustitución terminaba con un `</div>` sin su etiqueta de apertura. El motor PDF real (TCPDF) es estricto: al encontrar ese `</div>` suelto dentro de una celda de tabla, descartaba el resto del documento.

**Nota:** cuando el marcador estaba fuera de la tabla, el reemplazo funcionaba y el contenido se mostraba correctamente.

## Solución

La solución combina un **token de texto plano** que sobrevive a la limpieza HTML y la **eliminación del `</div>` huérfano**:

1. **`Utils.php`**
   - Nueva constante `stic_SignaturesUtils::SIGNATURE_TOKEN = '@@SIGNATURE_IMAGE@@'`.
   - En `getParsedTemplate()`, antes de la limpieza HTML, se normalizan todas las representaciones del marcador (HTML simple y codificado con entidades) a ese token de texto plano, que sobrevive a la eliminación de etiquetas y al parseo de la plantilla.
2. **`sticGenerateSignedPdf.php`**
   - Tras parsear la plantilla, sustituye el token `SIGNATURE_TOKEN` por la imagen de firma real (manuscrita o de botón).
   - **Elimina el `</div>` huérfano** del HTML de la firma, que era la causa de que TCPDF truncara el documento cuando la imagen estaba dentro de una tabla.
3. **`SignaturePortalUtils.php`**
   - En la vista previa del portal (`getHtmlFromSigner()`), el token se sustituye por la imagen placeholder (`SignaturePlaceholder.png`) para que el firmante vea dónde irá la firma, en lugar de un texto literal.

## Código eliminado (sin cambios funcionales)

Al hacer la corrección se detectó y eliminó **código muerto** en `sticGenerateSignedPdf.php` que no afectaba al resultado del PDF, para evitar confusiones:

- **`$object_arr` y el bloque de parseo en memoria.** Construían un array de registros y un texto `$text` limpiado/parseado localmente. Pero el PDF final se genera a partir de `getParsedTemplate()`, que recarga su propio bean y hace su propia limpieza/parseo; por tanto, el resultado de ese bloque **siempre se descartaba**.
- **El bloque "HTML Cleaning and Replacement preparation"** (`$search`/`$replace`, `$text = preg_replace(...)`, sustitución de `{DATE}`, etc.). Hacía la limpieza HTML y el procesamiento sobre `$text`, pero como `$text` se descartaba, era trabajo inútil.
- **`$stringToreplace` con la cadena del `src` codificada y su `str_replace`.** Buscaba el marcador por la cadena `src="themes/SuiteP/images/SignaturePlaceholder.png"`, que podía borrarse en la limpieza y no cubría todas las variantes en que se guarda el marcador. Se sustituye por el mecanismo del token.

En resumen: la limpieza HTML **no se ha eliminado** — se centralizó en `getParsedTemplate()` (donde ya se hacía y de donde sale el PDF final), y ahí se añadió el paso de convertir el marcador en token antes de borrar etiquetas.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `modules/stic_Signatures/Utils.php` | Constante `SIGNATURE_TOKEN`; normalización del marcador a token antes de la limpieza |
| `modules/stic_Signatures/sticGenerateSignedPdf.php` | Sustitución del token por la imagen real tras el parseo; eliminado el `</div>` huérfano; eliminado código muerto |
| `modules/stic_Signatures/SignaturePortal/SignaturePortalUtils.php` | Vista previa del portal: token → imagen placeholder |

## Seguridad

- `getParsedTemplate()` solo se llama desde el módulo de firmas.
- `SignaturePortalUtils::getHtmlFromSigner()` no se ve afectado en cuanto a su firma (el token se sustituye en la vista previa).
- Sin cambios en el proceso de limpieza HTML ni en la generación general de PDF (`SticGeneratePdf`).

## Cómo probarlo

1. Crear una plantilla PDF (`AOS_PDF_Templates`) que sea plantilla para documentos firmables.
2. Editar la descripción del PDF e insertar el marcador de firma **fuera de la tabla** (caso que ya funcionaba) y **dentro de una tabla HTML**, con texto después del marcador, por ejemplo:

   ```html
   <p>Firma fuera de la tabla:</p>
   <p><img class="signature" src="themes/SuiteP/images/SignaturePlaceholder.png" alt="" width="200" /> f1</p>

   <table style="height: 33px; width: 254px;">
     <tbody>
       <tr>
         <td>
           <p><img class="signature" src="themes/SuiteP/images/SignaturePlaceholder.png" alt="" width="200" /></p>
           <p>Texto después de la firma</p>
         </td>
       </tr>
     </tbody>
   </table>
   ```

3. Asociar la plantilla a un proceso de firma.
4. Firmar el documento desde el portal de firmas.
5. Descargar el PDF firmado y verificar:
   - La imagen de firma real aparece **tanto fuera como dentro de la tabla** (las dos marcas se sustituyen).
   - El contenido posterior al marcador (tabla y texto siguiente) se conserva.
   - La página de auditoría aparece con los datos del firmante y el registro de eventos.

Cierra #1401