### PR TITLE
Hotfix - Medicación - Creación de registro de log en el día + otras incidencias

### DIFF
--- a/modules/stic_Medication_Log/Utils.php
+++ b/modules/stic_Medication_Log/Utils.php
@@ -27,7 +27,6 @@ class stic_Medication_LogUtils
      * createLogs Creates medication logs according to the parameters provided
      *
      * @param String $date String in Y-m-d format '2019-05-05' Optional, default null (apply current_date)
-     * @param String $prescriptionId Optional, default null
      * @return void
      */
     public static function createLogs($date = null)

--- a/modules/stic_Medication_Log/Utils.php
+++ b/modules/stic_Medication_Log/Utils.php
@@ -49,7 +49,7 @@ class stic_Medication_LogUtils
 
         $sql =
             "select
-                concat(con.first_name, ' ', con.last_name, ' - ', med.name, ' - ', date_format(curdate(), '%d/%m/%Y'), ' - ') as name,
+                concat(ifnull(concat(con.first_name, ' '), ''), con.last_name, ' - ', med.name, ' - ',  date_format('$date', '%d/%m/%Y'), ' - ') as name,
                 con.id as contactId,
                 pre.id as prescriptionId,
                 med.name as medicamento,
@@ -71,7 +71,7 @@ class stic_Medication_LogUtils
                 (
                 select mlpre.stic_medication_log_stic_prescriptionstic_prescription_ida as prescriptionId, concat('^', GROUP_CONCAT(ml.schedule separator '^,^'), '^') as schedule
                 from stic_medication_log_stic_prescription_c mlpre
-                join stic_medication_log ml on ml.id = mlpre.stic_medication_log_stic_prescriptionstic_medication_log_idb and ml.deleted = 0 and ml.intake_date = curdate()
+                join stic_medication_log ml on ml.id = mlpre.stic_medication_log_stic_prescriptionstic_medication_log_idb and ml.deleted = 0 and ml.intake_date = '$date'
                 group by prescriptionId
                 ) existingLog on existingLog.prescriptionId = pre.id
             where
@@ -80,11 +80,11 @@ class stic_Medication_LogUtils
                 and precon.deleted = 0
                 and med.deleted = 0
                 and con.deleted = 0
-                and pre.start_date <= CURRENT_DATE()
+                and pre.start_date <= '$date'
                 and (pre.end_date is null
-                    or pre.end_date > CURRENT_DATE())
+                    or pre.end_date > '$date')
                 and pre.frequency = 'daily'
-                and (pre.skip_intake not like concat('%', mod(WEEKDAY(CURRENT_DATE())+ 1, 7), '%') or pre.skip_intake is null)
+                and (pre.skip_intake not like concat('%', mod(WEEKDAY('$date')+ 1, 7), '%') or pre.skip_intake is null)
                 and (pre.dont_create_logs is null or pre.dont_create_logs <> 1)
             ";
 

--- a/modules/stic_Prescription/stic_Prescription.php
+++ b/modules/stic_Prescription/stic_Prescription.php
@@ -146,7 +146,7 @@ class stic_Prescription extends Basic
 
             // Logs are only generated if the prescription started before creation date
             $currentDate = date('Y-m-d');
-            if ($startDate < $currentDate) {
+            if ($startDate <= $currentDate) {
                 $scheduleList = explode('^,^', trim($this->schedule, '^'));
                 $iterationDate = strtotime($startDate);
                 $stopGeneratingDate = strtotime($stopGeneratingDate);

--- a/modules/stic_Prescription/stic_Prescription.php
+++ b/modules/stic_Prescription/stic_Prescription.php
@@ -152,7 +152,7 @@ class stic_Prescription extends Basic
                 $stopGeneratingDate = strtotime($stopGeneratingDate);
 
                 if ($this->stic_prescription_contactscontacts_ida instanceof Link2) {
-                    $contactBean = SticUtils::getRelatedBeanObject($this, 'stic_prescription_stic_medication');
+                    $contactBean = SticUtils::getRelatedBeanObject($this, 'stic_prescription_contacts');
                     if ($contactBean) {
                         $contactId = $contactBean->id;
                     }


### PR DESCRIPTION
- Closes #1404 

## Description
Corrige que no se generen registros de stic_Medication_Log al crear una prescripción cuya fecha de inicio es el mismo día, junto con tres defectos latentes detectados durante la investigación:
1. Creación registro del día — modules/stic_Prescription/stic_Prescription.php:149
La condición que controla la generación usaba < en lugar de <=: con fecha de inicio = hoy, hoy < hoy era falso y se descartaba todo el bloque. El bucle de generación (línea 172) ya es inclusivo, por lo que con <= se crea el registro del día actual.
// Antes
if ($startDate < $currentDate) {
// Después
if ($startDate <= $currentDate) {
2. Nombre de relación incorrecta al obtener la persona — stic_Prescription.php:157
Se comprobaba el campo de contactos pero se recuperaba la relación del medicamento (stic_prescription_stic_medication) para $contactBean (error de copy-paste). Corregido a stic_prescription_contacts.
3. El SQL de createLogs() ignoraba el parámetro $date — modules/stic_Medication_Log/Utils.php:52,74,83,85,87
Las 5 ocurrencias de curdate()/CURRENT_DATE() (nombre del registro, deduplicación de logs existentes, filtros start_date/end_date y día de la semana para skip_intake) se sustituyen por '$date'. Ahora la consulta es coherente con la fecha solicitada, lo que además unifica la fuente horaria (reloj PHP en lugar de mezclar PHP/MySQL) y permite, sin duplicados, regenerar logs de fechas pasadas.
4. Protección contra first_name vacío — Utils.php:52
ifnull(concat(con.first_name, ' '), '') evita que se genere nombre vacío cuando no hay first_name
5. Docblock corregido — Utils.php:30
Eliminado el parámetro $prescriptionId documentado pero inexistente en la firma.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
### Creación registro del día
1. Ir al módulo stic_Prescription y crear un nuevo registro.
2. Relacionar una Persona y un Medicamento, establecer frecuencia = `diaria` y añadir al menos un horario de toma.
3. Establecer `fecha de inicio` = **hoy** (dejar la fecha de fin vacía o futura; no marcar "no crear registros").
4. Guardar el registro.
5. Comprobar el módulo stic_Medication_Log (o el subpanel de registros de la prescripción): **sí** existe registro del día actual.

### Nombre de relación incorrecta
1. Crear una prescripción desde el subpanel de Personas
2. Comrpobar que los registros de log generados quedan correctamente vinculados a la Persona (ya sucedía porqué en stic_Medication_Log se está cogiendo el Contact de la prescripción y no el que se enviaba vía la función de creación de log).

### Uso del parámetro $date
1.- Crear varias prescripciones
3.- Borrar los registros de log del día
4.- Pasar el SticCron (segurándose que se ejecuta la tarea de generación de registros del log)
5.- Comprobar que se generan correctamente los registros del día
[Bonus] Modificar la tarea createMedicationLogs() para que pase como parámetro una fecha concreta y comprobar que se usa para la creación del registro.

### Protección contra first_name vacío
1. Crear una persona sin nombre (sólo apellidos)
2. Crear una prescripción para dicha persona
3. Comprobar que se crea correctamente el nombre de los registros de medicación (sin la corrección sóloincluye el momento de la toma)

