### PR TITLE
Hotfix - General - Campo multienum pierde selección si la clave es 0

### DIFF
--- a/include/MVC/Controller/SugarController.php
+++ b/include/MVC/Controller/SugarController.php
@@ -650,7 +650,10 @@ class SugarController
             $sf = $sfh::getSugarField(ucfirst($type), true);
             if (isset($_POST[$field])) {
                 if (is_array($_POST[$field]) && !empty($properties['isMultiSelect'])) {
-                    if (empty($_POST[$field][0])) {
+                    // STIC-Custom 20260904 EPS - Value lost when only selected an element whose key is 0
+                    // if (empty($_POST[$field][0])) {
+                    if (empty($_POST[$field][0]) && $_POST[$field][0] !== '0') {
+                    // END STIC-Custom 20260904 EPS
                         unset($_POST[$field][0]);
                     }
                     $_POST[$field] = encodeMultienumValue($_POST[$field]);

--- a/include/MVC/Controller/SugarController.php
+++ b/include/MVC/Controller/SugarController.php
@@ -651,6 +651,7 @@ class SugarController
             if (isset($_POST[$field])) {
                 if (is_array($_POST[$field]) && !empty($properties['isMultiSelect'])) {
                     // STIC-Custom 20260904 EPS - Value lost when only selected an element whose key is 0
+                    // https://github.com/SinergiaTIC/SinergiaCRM/pull/1407
                     // if (empty($_POST[$field][0])) {
                     if (empty($_POST[$field][0]) && $_POST[$field][0] !== '0') {
                     // END STIC-Custom 20260904 EPS


### PR DESCRIPTION
- Closes #1406 

## Description
Se modifica la condición que hay en SugarController para tratar las claves vacías en campos multienum para que no trate el "0" como si no hubiera valor.

## Motivation and Context
como se describe en #1406 se estaban perdiendo valores cuando sólo se seleccionaba el elemento cuya clave era 0 en los campos multi-selección. Esto pasaba por ejemplo con la lista stic_weekdays_list, tanto en Prescripciones como en Inscripciones.

## How To Test This
1. Crear una prescripción médica seleccionando sólo domingo y comprobar que se mantiene el valor
2. Crear una prescripción sin seleccionar valor y comprobar qu eno hay ningún error
3. Crear una prescripción con diversas combinaciones de valores y comprobar que se mantienen correctamente

