### PR TITLE
Hotfix - Economía - Los pagos recurrentes de Stripe no se marcan como pagados

### DIFF
--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php
@@ -969,10 +969,14 @@ class PaymentBO extends WebFormDataBO
         $paymentBean = null;
         $pcBean = null;
 
-        if ($invoice->subscription != null) {
+        $subscriptionId = $invoice->subscription
+            ?? ($invoice->parent->subscription_details ?? null)->subscription
+            ?? null;
+
+        if ($subscriptionId != null) {
             // Load the Payment Commitment from subscription, then the Payment
             $pcBean = Beanfactory::getBean('stic_Payment_Commitments');
-            $pcBean = $pcBean->retrieve_by_string_fields(array('stripe_subscr_id' => $invoice->subscription));
+            $pcBean = $pcBean->retrieve_by_string_fields(array('stripe_subscr_id' => $subscriptionId));
             $paymentBean = $this->getBeanPaymentFromStripePaymentCommitment($pcBean, $invoice->created);
         }
 

--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php
@@ -980,6 +980,8 @@ class PaymentBO extends WebFormDataBO
      * @return boolean
      */
     private function loadPaymentBeansFromStripeInvoice($invoice) {
+        require_once 'SticInclude/Utils.php';
+
         $paymentBean = null;
         $pcBean = null;
 
@@ -1002,6 +1004,26 @@ class PaymentBO extends WebFormDataBO
 
             if ($pcBean != null) {
                 $paymentBean = $this->getBeanPaymentFromStripePaymentCommitment($pcBean, $invoice->created);
+            }
+        }
+
+        // Fallback: the invoice event may arrive before the subscription id is persisted in the
+        // Payment Commitment (API >= 2025-03-31.basil creates the subscription after the payment).
+        // In that case the Payment Commitment cannot be found by stripe_subscr_id, so retrieve the
+        // Payment by the transaction_code propagated in the invoice metadata, as done for PayPal.
+        if ($pcBean == null) {
+            $transactionCode = $invoice->parent->subscription_details->metadata->transaction_code ?? null;
+            if (empty($transactionCode)) {
+                $transactionCode = $invoice->lines->data[0]->metadata->transaction_code ?? null;
+            }
+            $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ": Payment Commitment not found by Stripe subscription. Trying with transaction code [{$transactionCode}]...");
+            if (!empty($transactionCode)) {
+                $paymentBean = BeanFactory::getBean('stic_Payments');
+                $paymentBean = $paymentBean->retrieve_by_string_fields(array('transaction_code' => $transactionCode));
+                if ($paymentBean->id != '') {
+                    $pcBean = SticUtils::getRelatedBeanObject($paymentBean, 'stic_payments_stic_payment_commitments');
+                    $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ": Retrieved {$paymentBean->id} payment for transaction code {$transactionCode}.");
+                }
             }
         }
 

--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php
@@ -800,6 +800,7 @@ class PaymentBO extends WebFormDataBO
             case 'checkout.session.expired':
                 return $this->processStripeCheckout($event->data->object, $event->type, $paymentMailer, $transaction_code, $retCode);
 
+            case 'customer.subscription.created':
             case 'customer.subscription.deleted':
                 return $this->processStripeSubscription($event->data->object, $event->type, $paymentMailer, $retCode);
 
@@ -897,10 +898,10 @@ class PaymentBO extends WebFormDataBO
                 $pcBean->save();
             }
             // If the subscription id is not available here (API 2025-03-31.basil can create the
-            // subscription after the payment completes), it is NOT persisted at this point.
-            // Note: loadPaymentBeansFromStripeInvoice does not persist stripe_subscr_id either,
-            // so in that case the Payment Commitment keeps no subscription id and the renewals
-            // of that subscription cannot be matched (known limitation of the basil flow).
+            // subscription after the payment completes), it is persisted later when the
+            // customer.subscription.created event is processed. For that, the transaction_code
+            // is propagated to the subscription via subscription_data.metadata (see PaymentController)
+            // and persistSubscriptionIdFromSubscription() links it to the Payment Commitment.
         } else {
             if ($session->subscription != null) {
                 // Load the Payment Commitment from subscription, then the Payment
@@ -1025,6 +1026,16 @@ class PaymentBO extends WebFormDataBO
             return false;
         }
 
+        // New subscription created: persist the subscription id in the Payment Commitment.
+        // In API >= 2025-03-31.basil the subscription is created after the payment, so the
+        // checkout.session.completed event may arrive without session.subscription and the id
+        // would not be persisted otherwise. The transaction_code propagated via
+        // subscription_data.metadata (see PaymentController) lets us find the Payment Commitment.
+        if ($eventType == 'customer.subscription.created') {
+            $this->persistSubscriptionIdFromSubscription($subscription);
+            return true;
+        }
+
         // Process only deleted subscriptions
         if ($eventType != 'customer.subscription.deleted') {
             return true;
@@ -1055,6 +1066,37 @@ class PaymentBO extends WebFormDataBO
             $pcBean->save();
         }
         return true;
+    }
+
+    /**
+     * Persist the Stripe subscription id in the Payment Commitment related to a subscription
+     * created event, using the transaction_code propagated via subscription_data.metadata.
+     *
+     * @param Stripe\Subscription $subscription
+     * @return void
+     */
+    private function persistSubscriptionIdFromSubscription($subscription) {
+        require_once 'SticInclude/Utils.php';
+
+        $transactionCode = $subscription->metadata['transaction_code'] ?? null;
+        if (empty($transactionCode)) {
+            // Subscription not created from a web form checkout (no transaction_code): nothing to link
+            $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ": Skipping Stripe subscription {$subscription->id} without transaction_code in metadata.");
+            return;
+        }
+
+        // Load the Payment from transaction_code, then the Payment Commitment
+        $paymentBean = BeanFactory::getBean('stic_Payments');
+        $paymentBean = $paymentBean->retrieve_by_string_fields(array('transaction_code' => $transactionCode));
+        $pcBean = SticUtils::getRelatedBeanObject($paymentBean, 'stic_payments_stic_payment_commitments');
+
+        if (isset($pcBean) && $pcBean->stripe_subscr_id != $subscription->id) {
+            $pcBean->stripe_subscr_id = $subscription->id;
+            $pcBean->save();
+            $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ": Persisted Stripe subscription id {$subscription->id} in Payment Commitment {$pcBean->id}.");
+        } else {
+            $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ": No Payment Commitment found for transaction_code {$transactionCode} or subscription id already persisted.");
+        }
     }
 
     /**

--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php
@@ -891,10 +891,16 @@ class PaymentBO extends WebFormDataBO
             $paymentBean = $paymentBean->retrieve_by_string_fields(array('transaction_code' => $transaction_code));
             $pcBean = SticUtils::getRelatedBeanObject($paymentBean, 'stic_payments_stic_payment_commitments');
             // Update Subscription Id
-            if ($session->subscription != null && isset($pcBean)) {
-                $pcBean->stripe_subscr_id = $session->subscription;
+            $subscriptionId = $session->subscription ?? null;
+            if ($subscriptionId != null && isset($pcBean)) {
+                $pcBean->stripe_subscr_id = $subscriptionId;
                 $pcBean->save();
             }
+            // If the subscription id is not available here (API 2025-03-31.basil can create the
+            // subscription after the payment completes), it is NOT persisted at this point.
+            // Note: loadPaymentBeansFromStripeInvoice does not persist stripe_subscr_id either,
+            // so in that case the Payment Commitment keeps no subscription id and the renewals
+            // of that subscription cannot be matched (known limitation of the basil flow).
         } else {
             if ($session->subscription != null) {
                 // Load the Payment Commitment from subscription, then the Payment
@@ -930,6 +936,12 @@ class PaymentBO extends WebFormDataBO
             return true;
         }
 
+        // Skip invoices with zero amount (e.g. proration credits, credit notes) so they don't modify payments in the CRM
+        if ($invoice->amount_paid == 0) {
+            $GLOBALS['log']->debug('Line ' . __LINE__ . ': ' . __METHOD__ . ": Skipping invoice {$invoice->id} with amount_paid=0 (billing_reason: {$invoice->billing_reason}, subtotal: {$invoice->subtotal})");
+            return true;
+        }
+
         // Load Data with Stripe Invoice
         if (!$this->loadPaymentBeansFromStripeInvoice($invoice)) {
             // Data can not be retrieved from DB: Can not process the event. Stripe will throw it again later
@@ -947,7 +959,8 @@ class PaymentBO extends WebFormDataBO
             return false; 
         }
         $paymentBean = $this->getLastPayment();
-        if ($invoice->paid) {
+        $isPaid = isset($invoice->paid) ? $invoice->paid : ($invoice->status === 'paid');
+        if ($isPaid) {
             $paymentBean->status = 'paid';
             $paymentBean->amount = $invoice->amount_paid/100;
         } else {
@@ -974,10 +987,21 @@ class PaymentBO extends WebFormDataBO
             ?? null;
 
         if ($subscriptionId != null) {
-            // Load the Payment Commitment from subscription, then the Payment
+            // Guard: ensure the Payment Commitment bean can be instantiated
             $pcBean = Beanfactory::getBean('stic_Payment_Commitments');
+            if ($pcBean == null) {
+                $GLOBALS['log']->fatal('Line ' . __LINE__ . ': ' . __METHOD__ . ": Could not instantiate stic_Payment_Commitments for Stripe subscription {$subscriptionId}.");
+                $this->setLastPayment(null);
+                $this->setLastPC(null);
+                return false;
+            }
+
+            // Load the Payment Commitment from subscription, then the Payment
             $pcBean = $pcBean->retrieve_by_string_fields(array('stripe_subscr_id' => $subscriptionId));
-            $paymentBean = $this->getBeanPaymentFromStripePaymentCommitment($pcBean, $invoice->created);
+
+            if ($pcBean != null) {
+                $paymentBean = $this->getBeanPaymentFromStripePaymentCommitment($pcBean, $invoice->created);
+            }
         }
 
         $this->setLastPayment($paymentBean);

--- a/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
+++ b/modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php
@@ -1005,6 +1005,15 @@ class PaymentController extends WebFormDataController {
             'cancel_url' => $koURL,
         ];
 
+        // Propagate the transaction code to the subscription in recurring payments.
+        // In API >= 2025-03-31.basil the subscription is created after the payment, so the
+        // checkout.session.completed event may arrive without session.subscription. This metadata
+        // lets the customer.subscription.created handler link stripe_subscr_id to the Payment
+        // Commitment (session-level metadata is NOT propagated to the subscription).
+        if ($payment_mode == 'subscription') {
+            $stripeSessionValues['subscription_data'] = ['metadata' => ['transaction_code' => $transaction_code]];
+        }
+
         // Add user's email if available
         if (isset($_REQUEST['Contacts___email1']) && !empty($_REQUEST['Contacts___email1'])) {
             $stripeSessionValues['customer_email'] = $_REQUEST['Contacts___email1'];


### PR DESCRIPTION
Closes #1409
Closes #192

## Descripción

Se corrige la identificación de pagos recurrentes de Stripe cuando se recibe el evento `invoice.payment_succeeded` con la versión de API de Stripe `2025-03-31.basil` (o posterior), así como el envío de mensajes de aviso confusos a los administradores cuando el evento llega antes de que el `stripe_subscr_id` quede persistido en el Compromiso de Pago.

El método `PaymentBO::loadPaymentBeansFromStripeInvoice()` (`modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php`) accedía a `$invoice->subscription`, campo que desde esta versión de API ya no llega a nivel raíz del objeto `Stripe\Invoice` (la suscripción solo aparece en `parent.subscription_details.subscription`). Al ser `null`, el matching nunca se ejecutaba: el pago quedaba sin marcar como `paid`, se devolvía `STRIPE_PAYMENT_NOT_FOUND` y se enviaba el correo de aviso a los administradores.

El id de suscripción ahora se resuelve de forma robusta y retrocompatible:

```php
$subscriptionId = $invoice->subscription
    ?? ($invoice->parent->subscription_details ?? null)->subscription
    ?? null;
```

Cada nivel de acceso está protegido con `?? null`, de modo que:
- Cuentas/endpoints fijados en una versión de API anterior (que envían `subscription` a nivel raíz) siguen funcionando.
- La versión `2025-03-31.basil` o posterior (que lo envía en `parent.subscription_details.subscription`) también funciona.

Todos los cambios de este PR (incluida la persistencia del `stripe_subscr_id` vía el evento `customer.subscription.created`) son **retrocompatibles**: no alteran el comportamiento en entidades con una versión de API anterior a basil, donde la suscripción ya está disponible en el checkout, y solo añaden las rutas nuevas que cubren el flujo basil. La metadata propagada en la suscripción se añade sin modificar la metadata existente a nivel de sesión.

## Motivación y contexto

Los pagos recurrentes de Stripe no se marcaban automáticamente como `paid` en el CRM, y los administradores recibían correos de alerta confusos cuando el pago realmente estaba completado. Al recibir `invoice.payment_succeeded`, el sistema enviaba el correo "S'ha rebut un missatge d'Stripe, però no s'ha pogut identificar el pagament" y el pago quedaba sin confirmar hasta corrección manual, aunque el Compromiso de Pago tuviera `stripe_subscr_id` relleno y el Pago del mes existiera con `payment_date` coincidente. Stripe reenviaba el evento poco después y, al reintentarse, el pago se actualizaba correctamente.

Este comportamiento se agravó con la API de Stripe `2025-03-31.basil`, que deprecó y eliminó el campo `subscription` de nivel raíz del objeto Invoice.

## Cambios adicionales detectados durante el desarrollo

Durante el desarrollo y las pruebas end-to-end se detectaron y corrigieron otros problemas relacionados con el procesado de webhooks de Stripe, en `modules/stic_Web_Forms/Catcher/Include/Payment/PaymentBO.php` y `modules/stic_Web_Forms/Catcher/Include/Payment/PaymentController.php`:

1. **Persistencia de `stripe_subscr_id` en el flujo basil** (`PaymentBO::persistSubscriptionIdFromSubscription()` + `PaymentController::stripePrepareFirstStep()`): en basil la suscripción se crea después del pago, por lo que `session->subscription` puede venir vacío en `checkout.session.completed` y el id no quedaba persistido en ningún punto del flujo (el handler de invoice solo lee por `stripe_subscr_id`, y la metadata a nivel de sesión no se propaga a la suscripción). En el formulario web ahora se propaga el `transaction_code` a la suscripción vía `subscription_data.metadata`, y el nuevo handler del evento `customer.subscription.created` localiza el Pago por ese `transaction_code` y persiste el `stripe_subscr_id` en su Compromiso de Pago. Verificado end-to-end con sesiones Checkout reales.
2. **Guards en `loadPaymentBeansFromStripeInvoice()`**: se protege la instanciación del bean (si es `null`, `return false` limpio) y solo se invoca `getBeanPaymentFromStripePaymentCommitment()` cuando el Compromiso de Pago es distinto de `null`. Antes, estos casos producían un FATAL (`L1063: Unable process Stripe Event`).
3. **Detección de pago compatible con basil** (`processStripeInvoice()`): `if ($invoice->paid)` se sustituye por `$isPaid = isset($invoice->paid) ? $invoice->paid : ($invoice->status === 'paid')`, ya que basil eliminó el campo `paid` a nivel raíz del Invoice.
4. **Skip de facturas con `amount_paid == 0`**: las facturas de importe cero (prorrateos, notas de crédito) no deben modificar pagos del CRM.
5. **Fallback por `transaction_code` en `loadPaymentBeansFromStripeInvoice()`** (resuelve #192): si el evento `invoice.payment_succeeded` llega antes de que el `stripe_subscr_id` quede persistido en el Compromiso de Pago (race en el flujo basil, donde la suscripción se crea después del pago), el handler no encontraba el Compromiso y enviaba el correo de aviso a los administradores. Ahora, cuando no se encuentra el Compromiso por `stripe_subscr_id`, se localiza el Pago por `transaction_code` (propagado en `parent.subscription_details.metadata` o en las líneas de la factura, igual que ya hace el flujo PayPal) y desde el Pago se resuelve el Compromiso de Pago asociado. Si tampoco se encuentra, se mantiene el comportamiento anterior (correo de aviso + reintento de Stripe).

## Cómo probarlo

**Entorno:** instancia `https://develop.sinergiacrm.org/bug/1409striperecurringpaymentsnotpaid`  con una cuenta de Stripe en modo TEST cuyas credenciales ya están configuradas correctamente.

**Pasos:**

1. Entrar en la instancia y crear un **Formulario Web** (clásico), habilitando el pago recurrente por Stripe
2. Guardar el formulario y abrir la **URL del formulario** para donar.
3. Rellenar el formulario y elegir **Stripe** y periodicidad **Mensual**. Al llegar al pago, se redirigirá al Checkout de Stripe (modo test).
4. En Stripe, usar una de las **tarjetas de prueba**:

| Tarjeta | Resultado esperado |
|---|---|
| `4242 4242 4242 4242` | Pago aceptado (éxito) |
| `4000 0025 0000 3155` | Pago aceptado; requiere autenticación 3D Secure (se pulsa "Complete authentication") |

   - **Fecha de caducidad:** cualquier fecha futura (ej. `12/28`).
   - **CVC:** cualquier valor de 3 dígitos (ej. `123`).
   - **Código postal:** cualquier valor (ej. `08001`).

5. Tras el pago, verificar en el CRM:
   - El **Compromiso de Pago** creado contiene el **id de suscripción** (`stripe_subscr_id`) relleno.
   - El **Pago** aparece como **`paid`**.
   - El administrador **NO** recibe el correo "S'ha rebut un missatge d'Stripe, però no s'ha pogut identificar el pagament".
6. (Opcional) En el [dashboard de Stripe](https://dashboard.stripe.com/acct_1UE0SNC6DTFSaJeP/test/) (modo test), comprobar que existe la suscripción asociada al pago y que se recibe el evento `customer.subscription.created`. La credenciales de acceso están en el proyecto.
## Tipos de cambios

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)